### PR TITLE
Add missing field initializers

### DIFF
--- a/src/agent/subagents/ping/ping.cpp
+++ b/src/agent/subagents/ping/ping.cpp
@@ -533,16 +533,16 @@ UINT32 s_poolMaxSize = 1024;
 UINT32 s_poolMinSize = 1;
 static NX_CFG_TEMPLATE m_cfgTemplate[] =
 {
-   { _T("AutoConfigureTargets"), CT_BOOLEAN, 0, 0, PING_OPT_ALLOW_AUTOCONFIGURE, 0, &s_options },
-	{ _T("DefaultPacketSize"), CT_LONG, 0, 0, 0, 0, &s_defaultPacketSize },
-   { _T("DefaultDoNotFragmentFlag"), CT_BOOLEAN, 0, 0, PING_OPT_DONT_FRAGMENT, 0, &s_options },
-   { _T("MaxTargetInactivityTime"), CT_LONG, 0, 0, 0, 0, &s_maxTargetInactivityTime },
-	{ _T("PacketRate"), CT_LONG, 0, 0, 0, 0, &s_pollsPerMinute },
-	{ _T("Target"), CT_STRING_LIST, _T('\n'), 0, 0, 0, &m_pszTargetList },
-   { _T("ThreadPoolMaxSize"), CT_LONG, 0, 0, 0, 0, &s_poolMaxSize },
-   { _T("ThreadPoolMinSize"), CT_LONG, 0, 0, 0, 0, &s_poolMinSize },
-	{ _T("Timeout"), CT_LONG, 0, 0, 0, 0, &s_timeout },
-	{ _T(""), CT_END_OF_LIST, 0, 0, 0, 0, NULL }
+   { _T("AutoConfigureTargets"), CT_BOOLEAN, 0, 0, PING_OPT_ALLOW_AUTOCONFIGURE, 0, &s_options, NULL },
+	{ _T("DefaultPacketSize"), CT_LONG, 0, 0, 0, 0, &s_defaultPacketSize, NULL },
+   { _T("DefaultDoNotFragmentFlag"), CT_BOOLEAN, 0, 0, PING_OPT_DONT_FRAGMENT, 0, &s_options, NULL },
+   { _T("MaxTargetInactivityTime"), CT_LONG, 0, 0, 0, 0, &s_maxTargetInactivityTime, NULL },
+	{ _T("PacketRate"), CT_LONG, 0, 0, 0, 0, &s_pollsPerMinute, NULL },
+	{ _T("Target"), CT_STRING_LIST, _T('\n'), 0, 0, 0, &m_pszTargetList, NULL },
+   { _T("ThreadPoolMaxSize"), CT_LONG, 0, 0, 0, 0, &s_poolMaxSize, NULL },
+   { _T("ThreadPoolMinSize"), CT_LONG, 0, 0, 0, 0, &s_poolMinSize, NULL },
+	{ _T("Timeout"), CT_LONG, 0, 0, 0, 0, &s_timeout, NULL },
+	{ _T(""), CT_END_OF_LIST, 0, 0, 0, 0, NULL, NULL }
 };
 
 /**


### PR DESCRIPTION
Based on NX_CFG_TEMPLATE definition.
PS
Это по большому счёту не коммит а вопрос - а в чём заключается нелюбовь к nullptr? Код же по сути уже к с++11 гвоздями приколочен?