### PR TITLE
Remove some useless casts

### DIFF
--- a/include/nms_common.h
+++ b/include/nms_common.h
@@ -1209,12 +1209,12 @@ template<typename T> T *MemCopyArray(const T *data, size_t count)
 
 inline char *MemCopyStringA(const char *src)
 {
-   return (src != NULL) ? static_cast<char*>(MemCopyBlock(src, strlen(src) + 1)) : NULL;
+   return (src != NULL) ? MemCopyBlock(src, strlen(src) + 1) : NULL;
 }
 
 inline WCHAR *MemCopyStringW(const WCHAR *src)
 {
-   return (src != NULL) ? static_cast<WCHAR*>(MemCopyBlock(src, (wcslen(src) + 1) * sizeof(WCHAR))) : NULL;
+   return (src != NULL) ? MemCopyBlock(src, (wcslen(src) + 1) * sizeof(WCHAR)) : NULL;
 }
 
 #else

--- a/src/agent/core/session.cpp
+++ b/src/agent/core/session.cpp
@@ -502,7 +502,7 @@ bool CommSession::sendMessage(const NXCPMessage *msg)
  */
 bool CommSession::sendRawMessage(const NXCP_MESSAGE *msg)
 {
-   return sendRawMessage((NXCP_MESSAGE *)nx_memdup(msg, ntohl(msg->size)), m_pCtx);
+   return sendRawMessage(nx_memdup(msg, ntohl(msg->size)), m_pCtx);
 }
 
 /**
@@ -524,7 +524,7 @@ void CommSession::postRawMessage(const NXCP_MESSAGE *msg)
    if (m_disconnected)
       return;
    incRefCount();
-   ThreadPoolExecuteSerialized(g_commThreadPool, m_key, this, &CommSession::sendMessageInBackground, static_cast<NXCP_MESSAGE*>(nx_memdup(msg, ntohl(msg->size))));
+   ThreadPoolExecuteSerialized(g_commThreadPool, m_key, this, &CommSession::sendMessageInBackground, nx_memdup(msg, ntohl(msg->size)));
 }
 
 /**

--- a/src/agent/subagents/dbquery/dbquery.cpp
+++ b/src/agent/subagents/dbquery/dbquery.cpp
@@ -213,11 +213,11 @@ DECLARE_SUBAGENT_ENTRY_POINT(DBQUERY)
    AddParameters(parameters, parametersTable, config);
 
    m_info.numParameters = parameters->size();
-   m_info.parameters = (NETXMS_SUBAGENT_PARAM *)nx_memdup(parameters->getBuffer(),
+   m_info.parameters = nx_memdup(parameters->getBuffer(),
                      parameters->size() * sizeof(NETXMS_SUBAGENT_PARAM));
 
    m_info.numTables = parametersTable->size();
-   m_info.tables = (NETXMS_SUBAGENT_TABLE *)nx_memdup(parametersTable->getBuffer(),
+   m_info.tables = nx_memdup(parametersTable->getBuffer(),
                      parametersTable->size() * sizeof(NETXMS_SUBAGENT_TABLE));
 
    delete parameters;

--- a/src/agent/subagents/devemu/devemu.cpp
+++ b/src/agent/subagents/devemu/devemu.cpp
@@ -179,7 +179,7 @@ static bool LoadConfiguration(bool initial)
       if (initial)
       {
          m_info.numParameters = parameters->size();
-         m_info.parameters = (NETXMS_SUBAGENT_PARAM *)nx_memdup(parameters->getBuffer(),
+         m_info.parameters = nx_memdup(parameters->getBuffer(),
                            parameters->size() * sizeof(NETXMS_SUBAGENT_PARAM));
          delete parameters;
       }
@@ -257,7 +257,7 @@ static bool LoadConfiguration(bool initial)
    if (initial)
    {
       m_info.numParameters = parameters->size();
-      m_info.parameters = (NETXMS_SUBAGENT_PARAM *)nx_memdup(parameters->getBuffer(),
+      m_info.parameters = nx_memdup(parameters->getBuffer(),
                           parameters->size() * sizeof(NETXMS_SUBAGENT_PARAM));
       delete parameters;
    }

--- a/src/agent/subagents/linux/cpu.cpp
+++ b/src/agent/subagents/linux/cpu.cpp
@@ -328,37 +328,37 @@ static void GetUsage(int source, int cpu, int count, TCHAR *value)
 	switch (source)
 	{
 		case CPU_USAGE_OVERAL:
-			table = (float *)m_cpuUsage;
+			table = m_cpuUsage;
 			break;
 		case CPU_USAGE_USER:
-			table = (float *)m_cpuUsageUser;
+			table = m_cpuUsageUser;
 			break;
 		case CPU_USAGE_NICE:
-			table = (float *)m_cpuUsageNice;
+			table = m_cpuUsageNice;
 			break;
 		case CPU_USAGE_SYSTEM:
-			table = (float *)m_cpuUsageSystem;
+			table = m_cpuUsageSystem;
 			break;
 		case CPU_USAGE_IDLE:
-			table = (float *)m_cpuUsageIdle;
+			table = m_cpuUsageIdle;
 			break;
 		case CPU_USAGE_IOWAIT:
-			table = (float *)m_cpuUsageIoWait;
+			table = m_cpuUsageIoWait;
 			break;
 		case CPU_USAGE_IRQ:
-			table = (float *)m_cpuUsageIrq;
+			table = m_cpuUsageIrq;
 			break;
 		case CPU_USAGE_SOFTIRQ:
-			table = (float *)m_cpuUsageSoftIrq;
+			table = m_cpuUsageSoftIrq;
 			break;
 		case CPU_USAGE_STEAL:
-			table = (float *)m_cpuUsageSteal;
+			table = m_cpuUsageSteal;
 			break;
 		case CPU_USAGE_GUEST:
-			table = (float *)m_cpuUsageGuest;
+			table = m_cpuUsageGuest;
 			break;
 		default:
-			table = (float *)m_cpuUsage;
+			table = m_cpuUsage;
 	}
 
    table += cpu * CPU_USAGE_SLOTS;

--- a/src/libnetxms/array.cpp
+++ b/src/libnetxms/array.cpp
@@ -90,7 +90,7 @@ Array::Array(const Array *src)
    m_grow = src->m_grow;
    m_allocated = src->m_allocated;
    m_elementSize = src->m_elementSize;
-   m_data = (src->m_data != NULL) ? (void **)MemCopyBlock(src->m_data, m_elementSize * m_allocated) : NULL;
+   m_data = (src->m_data != NULL) ? MemCopyBlock(src->m_data, m_elementSize * m_allocated) : NULL;
    m_objectOwner = src->m_objectOwner;
    m_objectDestructor = src->m_objectDestructor;
    m_storePointers = src->m_storePointers;

--- a/src/libnxlp/parser.cpp
+++ b/src/libnxlp/parser.cpp
@@ -166,7 +166,7 @@ LogParser::LogParser(const LogParser *src)
 	{
 		int count;
 		for(count = 0; src->m_eventNameList[count].text != NULL; count++);
-		m_eventNameList = (count > 0) ? (CODE_TO_TEXT *)nx_memdup(src->m_eventNameList, sizeof(CODE_TO_TEXT) * (count + 1)) : NULL;
+		m_eventNameList = (count > 0) ? nx_memdup(src->m_eventNameList, sizeof(CODE_TO_TEXT) * (count + 1)) : NULL;
 	}
 	else
 	{


### PR DESCRIPTION
Всё из-за особенности шаблона MemCopyBlock, кроме очевидного исправления с float. 