### PR TITLE
Fix Wdelete-non-virtual-dtor

### DIFF
--- a/include/gauge_helpers.h
+++ b/include/gauge_helpers.h
@@ -114,6 +114,8 @@ public:
       m_period = period;
    }
 
+   virtual ~Gauge() {};
+
    const TCHAR *getName() const { return m_name; }
    T getCurrent() const { return m_data.getCurrent(); }
    T getMin() const { return m_data.getMin(); }
@@ -228,6 +230,7 @@ protected:
 
 public:
    ManualGauge64(const TCHAR *name, int interval, int period) : Gauge64(name, interval, period) { }
+   virtual ~ManualGauge64() override {};
 };
 
 #endif


### PR DESCRIPTION
Ноги оттуда растут https://github.com/netxms/netxms/blob/master/src/server/include/nms_objects.h#L1730 Получаем deleting object of polymorphic class type «ManualGauge64» which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
Возможно что-то упустил, просьба проверить.