### PR TITLE
PostgreSQL subagent added

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -873,7 +873,7 @@ AC_ARG_WITH(dist,
 	DB_DRIVERS="mysql mariadb pgsql odbc mssql sqlite oracle db2 informix"
 	MODULES="appagent jansson java-common libexpat libstrophe zlib libnetxms libnxjava install sqlite snmp ethernetip libnxsl libnxmb libnxlp libnxpython libnxcc db server ncdrivers agent client nxscript nxcproxy"
 	TOOLS="nxlptest"
-	SUBAGENT_DIRS="linux ds18x20 freebsd openbsd minix mqtt mysql netbsd sunos aix ipso hpux odbcquery informix oracle lmsensors darwin rpi java jmx bind9 ubntlw netsvc db2 tuxedo mongodb ssh vmgr xen lorawan asterisk python"
+	SUBAGENT_DIRS="linux ds18x20 freebsd openbsd minix mqtt mysql pgsql netbsd sunos aix ipso hpux odbcquery informix oracle lmsensors darwin rpi java jmx bind9 ubntlw netsvc db2 tuxedo mongodb ssh vmgr xen lorawan asterisk python"
 	AGENT_DIRS="libnxtux"
 	NCDRV_DIRS="anysms kannel msteams mymobile nexmo nxagent slack smseagle telegram text2reach websms"
    HDLINK_DIRS="jira redmine"
@@ -1000,6 +1000,12 @@ if test $? = 0; then
 	if test $? = 0; then
 		COMPONENTS="$COMPONENTS mysql"
 		SUBAGENT_LIBS="$SUBAGENT_LIBS ../subagents/mysql/mysql.la"
+	fi
+
+	check_substr "$STATIC_SUBAGENT_LIST" "pgsql"
+	if test $? = 0; then
+		COMPONENTS="$COMPONENTS pgsql"
+		SUBAGENT_LIBS="$SUBAGENT_LIBS ../subagents/pgsql/pgsql.la"
 	fi
 
 	case "$PLATFORM" in
@@ -1167,6 +1173,7 @@ fi
 check_substr "$COMPONENTS" "pgsql"
 if test $? = 0; then
 	DB_DRIVERS="$DB_DRIVERS pgsql"
+	SUBAGENT_DIRS="$SUBAGENT_DIRS pgsql"
 fi
 
 check_substr "$COMPONENTS" "sqlite_drv"
@@ -4561,6 +4568,7 @@ AC_CONFIG_FILES([
 	src/agent/subagents/odbcquery/Makefile
 	src/agent/subagents/openbsd/Makefile
 	src/agent/subagents/oracle/Makefile
+	src/agent/subagents/pgsql/Makefile
 	src/agent/subagents/ping/Makefile
 	src/agent/subagents/portCheck/Makefile
 	src/agent/subagents/python/Makefile

--- a/src/agent/subagents/pgsql/Makefile.am
+++ b/src/agent/subagents/pgsql/Makefile.am
@@ -1,12 +1,12 @@
-SUBAGENT = postgresql
+SUBAGENT = pgsql
 
-pkglib_LTLIBRARIES = postgresql.la
-postgresql_la_SOURCES = main.cpp
-postgresql_la_CPPFLAGS=-I@top_srcdir@/include -I@top_srcdir@/build
-postgresql_la_LDFLAGS = -module -avoid-version -export-symbols ../subagent.sym
-postgresql_la_LIBADD = ../../libnxagent/libnxagent.la ../../../libnetxms/libnetxms.la ../../../db/libnxdb/libnxdb.la
+pkglib_LTLIBRARIES = pgsql.la
+pgsql_la_SOURCES = db.cpp main.cpp
+pgsql_la_CPPFLAGS=-I@top_srcdir@/include -I@top_srcdir@/build
+pgsql_la_LDFLAGS = -module -avoid-version -export-symbols ../subagent.sym
+pgsql_la_LIBADD = ../../libnxagent/libnxagent.la ../../../libnetxms/libnetxms.la ../../../db/libnxdb/libnxdb.la
 
-EXTRA_DIST = postgresql.vcxproj postgresql.vcxproj.filters postgresql_subagent.h
+EXTRA_DIST = pgsql.vcxproj pgsql.vcxproj.filters pgsql_subagent.h
 
 if !STATIC_BUILD
 install-exec-hook:

--- a/src/agent/subagents/pgsql/db.cpp
+++ b/src/agent/subagents/pgsql/db.cpp
@@ -1,0 +1,392 @@
+/*
+ ** NetXMS - Network Management System
+ ** Subagent for PostgreSQL monitoring
+ ** Copyright (C) 2009-2019 Raden Solutions
+ ** Copyright (C) 2020 Petr Votava
+ **
+ ** This program is free software; you can redistribute it and/or modify
+ ** it under the terms of the GNU Lesser General Public License as published
+ ** by the Free Software Foundation; either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU Lesser General Public License
+ ** along with this program; if not, write to the Free Software
+ ** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ **/
+
+#include "pgsql_subagent.h"
+#include <netxms-regex.h>
+
+/**
+ * Create new database instance object
+ */
+DatabaseInstance::DatabaseInstance(DatabaseInfo *info)
+{
+	memcpy(&m_info, info, sizeof(DatabaseInfo));
+	m_pollerThread = INVALID_THREAD_HANDLE;
+	m_session = NULL;
+	m_connected = false;
+	m_data = NULL;
+	m_dataLock = MutexCreate();
+	m_sessionLock = MutexCreate();
+	m_stopCondition = ConditionCreate(TRUE);
+}
+
+/**
+ * Destructor
+ */
+DatabaseInstance::~DatabaseInstance()
+{
+	stop();
+	MutexDestroy(m_dataLock);
+	MutexDestroy(m_sessionLock);
+	ConditionDestroy(m_stopCondition);
+	delete m_data;
+}
+
+/**
+ * Run
+ */
+void DatabaseInstance::run()
+{
+	m_pollerThread = ThreadCreateEx(DatabaseInstance::pollerThreadStarter, 0, this);
+}
+
+/**
+ * Stop
+ */
+void DatabaseInstance::stop()
+{
+	ConditionSet(m_stopCondition);
+	ThreadJoin(m_pollerThread);
+	m_pollerThread = INVALID_THREAD_HANDLE;
+	if (m_session != NULL)
+	{
+		DBDisconnect(m_session);
+		m_session = NULL;
+	}
+}
+
+/**
+ * Detect PosgreSQL version
+ */
+int DatabaseInstance::getPgsqlVersion() 
+{
+	DB_RESULT hResult = DBSelect(m_session, _T("SELECT substring(version() from '(\\\\d+\\.\\\\d+(\\\\.\\\\d+)?)')"));
+	if (hResult == NULL)	
+	{
+		return 0;
+	}
+
+	TCHAR versionString[16];
+	DBGetField(hResult, 0, 0, versionString, 16);
+	int ver1 = 0, ver2 = 0, ver3 = 0;
+	_stscanf(versionString, _T("%d.%d.%d"), &ver1, &ver2, &ver3);
+	DBFreeResult(hResult);
+
+	return MAKE_PGSQL_VERSION(ver1, ver2, ver3);
+}
+
+
+/**
+ * Poller thread starter
+ */
+THREAD_RESULT THREAD_CALL DatabaseInstance::pollerThreadStarter(void *arg)
+{
+	((DatabaseInstance *)arg)->pollerThread();
+	return THREAD_OK;
+}
+
+/**
+ * Poller thread
+ */
+void DatabaseInstance::pollerThread()
+{
+	AgentWriteDebugLog(3, _T("PGSQL: poller thread for database server %s started"), m_info.id);
+	INT64 connectionTTL = (INT64)m_info.connectionTTL * _LL(1000);
+	do
+	{
+reconnect:
+		MutexLock(m_sessionLock);
+
+		TCHAR errorText[DBDRV_MAX_ERROR_TEXT];
+		m_session = DBConnect(g_pgsqlDriver, m_info.server, m_info.name, m_info.login, m_info.password, NULL, errorText);
+		if (m_session == NULL)
+		{
+			MutexUnlock(m_sessionLock);
+			AgentWriteDebugLog(6, _T("PGSQL: cannot connect to database server %s: %s"), m_info.id, errorText);
+			continue;
+		}
+
+		m_connected = true;
+		DBEnableReconnect(m_session, false);
+		m_version = getPgsqlVersion();
+		if ((m_version & 0xFF) == 0)
+			AgentWriteLog(NXLOG_INFO, _T("PGSQL: connection with database server %s restored (version %d.%d, connection TTL %d)"),
+				m_info.id, m_version >> 16, (m_version >> 8) & 0xFF, m_info.connectionTTL);
+		else
+			AgentWriteLog(NXLOG_INFO, _T("PGSQL: connection with database server %s restored (version %d.%d.%d, connection TTL %d)"),
+				m_info.id, m_version >> 16, (m_version >> 8) & 0xFF, m_version & 0xFF, m_info.connectionTTL);
+
+		MutexUnlock(m_sessionLock);
+
+		INT64 pollerLoopStartTime = GetCurrentTimeMs();
+		UINT32 sleepTime;
+		do
+		{
+			INT64 startTime = GetCurrentTimeMs();
+			if (!poll())
+			{
+				AgentWriteLog(NXLOG_WARNING, _T("PGSQL: connection with database server %s lost"), m_info.id);
+				break;
+			}
+			INT64 currTime = GetCurrentTimeMs();
+			if (currTime - pollerLoopStartTime > connectionTTL)
+			{
+				AgentWriteDebugLog(4, _T("PGSQL: planned connection reset"));
+				MutexLock(m_sessionLock);
+				m_connected = false;
+				DBDisconnect(m_session);
+				m_session = NULL;
+				MutexUnlock(m_sessionLock);
+				goto reconnect;
+			}
+			INT64 elapsedTime = currTime - startTime;
+			sleepTime = (UINT32)((elapsedTime >= 60000) ? 60000 : (60000 - elapsedTime));
+		}
+		while(!ConditionWait(m_stopCondition, sleepTime));
+
+		MutexLock(m_sessionLock);
+		m_connected = false;
+		DBDisconnect(m_session);
+		m_session = NULL;
+		MutexUnlock(m_sessionLock);
+	}
+	while(!ConditionWait(m_stopCondition, 60000));	// reconnect every 60 seconds
+	AgentWriteDebugLog(3, _T("PGSQL: poller thread for database server %s stopped"), m_info.id);
+}
+
+/**
+ * Read global stats table into memory
+ */
+static StringMap *ReadGlobalStatsTable(DB_HANDLE hdb, const TCHAR *table)
+{
+	TCHAR query[128];
+	_sntprintf(query, 128, _T("SELECT variable_name,variable_value FROM %s"), table);
+	DB_RESULT hResult = DBSelect(hdb, query);
+	if (hResult == NULL)
+		return NULL;
+
+	StringMap *data = new StringMap();
+	int count = DBGetNumRows(hResult);
+	for(int i = 0; i < count; i++)
+		data->setPreallocated(DBGetField(hResult, i, 0, NULL, 0), DBGetField(hResult, i, 1, NULL, 0));
+	DBFreeResult(hResult);
+	return data;
+}
+
+/**
+ * Do actual database polling. Should return false if connection is broken.
+ */
+bool DatabaseInstance::poll()
+{
+	StringMap *data = new StringMap();
+
+	int count = 0;
+	int failures = 0;
+
+	for(int i = 0; g_queries[i].name != NULL; i++)
+	{
+		if (g_queries[i].minVersion > m_version)
+			continue;	// not supported by this database
+
+		if (g_queries[i].maxVersion != 0 && g_queries[i].maxVersion <= m_version)
+			continue;	// not supported by this database
+
+		count++;
+		DB_RESULT hResult = DBSelect(m_session, g_queries[i].query);
+		if (hResult == NULL)
+		{
+			failures++;
+			continue;
+		}
+
+		int rowCount = DBGetNumRows(hResult);
+		if (rowCount == 0)
+		{
+			continue;
+		}
+
+		TCHAR tag[256];
+		_tcscpy(tag, g_queries[i].name);
+		int tagBaseLen = (int)_tcslen(tag);
+		tag[tagBaseLen++] = _T('/');
+
+		int numColumns = DBGetColumnCount(hResult);
+		if (g_queries[i].instanceColumns > 0)
+		{
+			for(int row = 0; row < rowCount; row++)
+			{
+				int col;
+
+				// Process instance columns
+				TCHAR instance[128];
+				instance[0] = 0;
+				for(col = 0; (col < g_queries[i].instanceColumns) && (col < numColumns); col++)
+				{
+					int len = (int)_tcslen(instance);
+					if (len > 0)
+						instance[len++] = _T('|');
+					DBGetField(hResult, row, col, &instance[len], 128 - len);
+				}
+
+				for(; col < numColumns; col++)
+				{
+					DBGetColumnName(hResult, col, &tag[tagBaseLen], 256 - tagBaseLen);
+					size_t tagLen = _tcslen(tag);
+					tag[tagLen++] = _T('@');
+					nx_strncpy(&tag[tagLen], instance, 256 - tagLen);
+					data->setPreallocated(_tcsdup(tag), DBGetField(hResult, row, col, NULL, 0));
+				}
+			}
+		}
+		else
+		{
+			for(int col = 0; col < numColumns; col++)
+			{
+				DBGetColumnName(hResult, col, &tag[tagBaseLen], 256 - tagBaseLen);
+				data->setPreallocated(_tcsdup(tag), DBGetField(hResult, 0, col, NULL, 0));
+			}
+		}
+
+		DBFreeResult(hResult);
+	}
+
+	// update cached data
+	MutexLock(m_dataLock);
+	delete m_data;
+	m_data = data;
+	MutexUnlock(m_dataLock);
+
+	return failures < count;
+}
+
+/**
+ * Get collected data
+ */
+bool DatabaseInstance::getData(const TCHAR *tag, TCHAR *value)
+{
+	bool success = false;
+	MutexLock(m_dataLock);
+	if (m_data != NULL)
+	{
+		const TCHAR *v = m_data->get(tag);
+		if (v != NULL)
+		{
+			ret_string(value, v);
+			success = true;
+		}
+	}
+	MutexUnlock(m_dataLock);
+	return success;
+}
+
+/**
+ * Tag list callback data
+ */
+struct TagListCallbackData
+{
+	PCRE *preg;
+	StringList *list;
+};
+
+/**
+ * Tag list callback
+ */
+static EnumerationCallbackResult TagListCallback(const TCHAR *key, const TCHAR *value, TagListCallbackData *data)
+{
+	int pmatch[9];
+	if (_pcre_exec_t(data->preg, NULL, reinterpret_cast<const PCRE_TCHAR*>(key), static_cast<int>(_tcslen(key)), 0, 0, pmatch, 9) >= 2) // MATCH
+	{
+		size_t slen = pmatch[3] - pmatch[2];
+		TCHAR *s = MemAllocString(slen + 1);
+		memcpy(s, &key[pmatch[2]], slen * sizeof(TCHAR));
+		s[slen] = 0;
+		data->list->addPreallocated(s);
+	}
+	return _CONTINUE;
+}
+
+/**
+ * Get list of tags matching given pattern from collected data
+ */
+bool DatabaseInstance::getTagList(const TCHAR *pattern, StringList *value)
+{
+	bool success = false;
+	MutexLock(m_dataLock);
+	if (m_data != NULL)
+	{
+		const char *eptr;
+		int eoffset;
+		TagListCallbackData data;
+		data.list = value;
+		data.preg = _pcre_compile_t(reinterpret_cast<const PCRE_TCHAR*>(pattern), PCRE_COMMON_FLAGS | PCRE_CASELESS, &eptr, &eoffset, NULL);
+		if (data.preg != NULL)
+		{
+			m_data->forEach(TagListCallback, &data);
+			_pcre_free_t(data.preg);
+			success = true;
+		}
+	}
+	MutexUnlock(m_dataLock);
+	return success;
+}
+
+/**
+ * Query table
+ */
+bool DatabaseInstance::queryTable(TableDescriptor *td, Table *value)
+{
+	MutexLock(m_sessionLock);
+	
+	if (!m_connected || (m_session == NULL))
+	{
+		MutexUnlock(m_sessionLock);
+		return false;
+	}
+
+	bool success = false;
+
+	DB_RESULT hResult = DBSelect(m_session, td->query);
+	if (hResult != NULL)
+	{
+		int numColumns = DBGetColumnCount(hResult);
+		for(int col = 0; col < numColumns; col++)
+		{
+			TCHAR name[64];
+			DBGetColumnName(hResult, col, name, 64);
+			value->addColumn(name, td->columns[col].dataType, td->columns[col].displayName, col == 0);
+		}
+
+		int numRows = DBGetNumRows(hResult);
+		for(int row = 0; row < numRows; row++)
+		{
+			value->addRow();
+			for(int col = 0; col < numColumns; col++)
+			{
+				value->setPreallocated(col, DBGetField(hResult, row, col, NULL, 0));
+			}
+		}
+
+		DBFreeResult(hResult);
+		success = true;
+	}
+
+	MutexUnlock(m_sessionLock);
+	return success;
+}

--- a/src/agent/subagents/pgsql/main.cpp
+++ b/src/agent/subagents/pgsql/main.cpp
@@ -1,7 +1,8 @@
 /*
  ** NetXMS - Network Management System
  ** Subagent for PostgreSQL monitoring
- ** Copyright (C) 2015 Raden Solutions
+ ** Copyright (C) 2009-2020 Raden Solutions
+ ** Copyright (C) 2020 Petr Votava
  **
  ** This program is free software; you can redistribute it and/or modify
  ** it under the terms of the GNU Lesser General Public License as published
@@ -18,25 +19,541 @@
  ** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  **/
 
+#include "pgsql_subagent.h"
+
+#define DEBUG_TAG _T("pgsql")
+
 /**
  * Driver handle
  */
-DB_DRIVER g_driverHandle = NULL;
+DB_DRIVER g_pgsqlDriver = NULL;
+
+/**
+ * Polling queries
+ */
+DatabaseQuery g_queries[] =
+{
+	{ _T("DB_STAT"), MAKE_PGSQL_VERSION(12, 0, 0), 0, 1,
+		_T("SELECT d.datname, CASE WHEN has_database_privilege(current_user, d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE NULL END AS size, s.numbackends, s.deadlocks, ")
+			_T("round(s.blks_hit::numeric*100/(s.blks_hit+s.blks_read), 2) CacheHitRatio, s.xact_commit, s.xact_rollback, ")
+			_T("s.tup_inserted, s.tup_updated, s.tup_deleted, s.tup_fetched, s.tup_returned, s.blks_read, s.blks_hit, ")
+			_T("s.conflicts, s.temp_files, s.temp_bytes, s.blk_read_time, s.blk_write_time, ")
+			_T("s.checksum_failures ")
+			_T("FROM  pg_catalog.pg_database d LEFT JOIN pg_catalog.pg_stat_database s ON d.oid = s.datid ")
+			_T("WHERE NOT d.datistemplate AND d.datallowconn AND s.blks_read >0")
+	},
+	{ _T("DB_STAT"), 0, MAKE_PGSQL_VERSION(12, 0, 0), 1,
+		_T("SELECT d.datname, CASE WHEN has_database_privilege(current_user, d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE NULL END AS size, s.numbackends, s.deadlocks, ")
+			_T("round(s.blks_hit::numeric*100/(s.blks_hit+s.blks_read), 2) CacheHitRatio, s.xact_commit, s.xact_rollback, ")
+			_T("s.tup_inserted, s.tup_updated, s.tup_deleted, s.tup_fetched, s.tup_returned, s.blks_read, s.blks_hit, ")
+			_T("s.conflicts, s.temp_files, s.temp_bytes, s.blk_read_time, s.blk_write_time ")
+			_T("FROM  pg_catalog.pg_database d LEFT JOIN pg_catalog.pg_stat_database s ON d.oid = s.datid ")
+			_T("WHERE NOT d.datistemplate AND d.datallowconn AND s.blks_read >0")
+	},
+	{ _T("DB_CONNECTIONS"), MAKE_PGSQL_VERSION(9, 6, 0), 0, 1,
+		_T("SELECT datname, count(*) AS total, count(*) FILTER (WHERE state = 'active') AS active, count(*) FILTER (WHERE state = 'active') AS idle, ")
+			_T("count(*) FILTER (WHERE state = 'idle in transaction') AS idle_in_transaction, count(*) FILTER (WHERE state = 'idle in transaction (aborted)') AS idle_in_transaction_aborted, ")
+			_T("count(*) FILTER (WHERE state = 'fastpath function call') AS fastpath_function_call, greatest(max(age(backend_xmin)), max(age(backend_xid))) AS oldestxid, ")
+			_T("count(*) FILTER (WHERE state <> 'idle' AND query like '%autovacuum%') AS autovacuum, ")
+			_T("count(*) FILTER (WHERE wait_event IS NOT NULL ) AS waiting ") // change in v9.6
+			_T("FROM pg_catalog.pg_stat_activity WHERE datid is not NULL GROUP BY datname")
+	},
+	{ _T("DB_CONNECTIONS"), 0, MAKE_PGSQL_VERSION(9, 6, 0), 1,
+		_T("SELECT datname, count(*) AS total, count(*) FILTER (WHERE state = 'active') AS active, count(*) FILTER (WHERE state = 'active') AS idle, ")
+			_T("count(*) FILTER (WHERE state = 'idle in transaction') AS idle_in_transaction, count(*) FILTER (WHERE state = 'idle in transaction (aborted)') AS idle_in_transaction_aborted, ")
+			_T("count(*) FILTER (WHERE state = 'fastpath function call') AS fastpath_function_call, greatest(max(age(backend_xmin)), max(age(backend_xid))) AS oldestxid, ")
+			_T("count(*) FILTER (WHERE state <> 'idle' AND query like '%autovacuum%') AS autovacuum, ")
+			_T("count(*) FILTER (WHERE waiting ) AS waiting ")
+			_T("FROM pg_catalog.pg_stat_activity WHERE datid is not NULL GROUP BY datname")
+	},
+	{ _T("CONNECTIONS"), 0, 0, 0,
+		_T("SELECT count(*) AS total, pg_catalog.current_setting('max_connections')::int AS max, count(*)*100/(SELECT pg_catalog.current_setting('max_connections')::int) AS total_pct, ")
+			_T("pg_catalog.current_setting('autovacuum_max_workers')::int AS autovacuum_max ")
+			_T("FROM pg_catalog.pg_stat_activity WHERE datid is not NULL")
+	},
+	{ _T("DB_TRANSACTIONS"), 0, 0, 1,
+		_T("SELECT database, count(*) AS prepared FROM pg_catalog.pg_prepared_xacts GROUP BY database")
+	},
+	{ _T("DB_LOCKS"), 0, 0, 1,
+		_T("SELECT d.datname, ")
+			_T("count(*) FILTER (WHERE MODE IS NOT NULL) AS total, ")
+			_T("count(*) FILTER (WHERE MODE = 'AccessExclusiveLock') AS accessexclusive, ")
+			_T("count(*) FILTER (WHERE MODE = 'AccessShareLock') AS accessshare, ")
+			_T("count(*) FILTER (WHERE MODE = 'ExclusiveLock') AS exclusive, ")
+			_T("count(*) FILTER (WHERE MODE = 'RowExclusiveLock') AS rowexclusive, ")
+			_T("count(*) FILTER (WHERE MODE = 'RowShareLock') AS rowshare, ")
+			_T("count(*) FILTER (WHERE MODE = 'ShareLock') AS share, ")
+			_T("count(*) FILTER (WHERE MODE = 'ShareRowExclusiveLock') AS sharerowexclusive, ")
+			_T("count(*) FILTER (WHERE MODE = 'ShareUpdateExclusiveLock') AS shareupdateexclusive ")
+			_T("FROM pg_catalog.pg_locks l RIGHT JOIN pg_catalog.pg_database d ON d.oid = l.database WHERE NOT datistemplate AND datallowconn GROUP BY d.datname")
+	},
+	{ _T("BGWRITER"), 0, 0, 0,
+		_T("SELECT checkpoints_timed, checkpoints_req, checkpoint_write_time, checkpoint_sync_time, buffers_checkpoint, buffers_clean, maxwritten_clean, ")
+			_T("buffers_backend, buffers_backend_fsync, buffers_alloc FROM pg_catalog.pg_stat_bgwriter")
+	},
+	{ _T("ARCHIVER"), 0, 0, 0,
+		_T("SELECT archived_count, last_archived_wal, extract(epoch from current_timestamp - last_archived_time)::int as last_archived_age, ")
+			_T("failed_count, last_failed_wal, ")
+			_T("CASE WHEN (last_failed_wal IS NULL OR last_failed_wal <= last_archived_wal) THEN NULL ELSE extract(epoch from current_timestamp - last_failed_time)::int END AS last_failed_age, ")
+			_T("CASE WHEN (pg_catalog.current_setting('archive_mode')::boolean AND ( last_failed_wal IS NULL OR last_failed_wal <= last_archived_wal)) THEN 'YES' ELSE 'NO' END AS is_archiving ")
+			_T("FROM pg_catalog.pg_stat_archiver")
+	},
+	{ _T("REPLICATION"), 0, 0, 0,
+		_T("SELECT CASE WHEN pg_is_in_recovery() THEN 'YES' ELSE 'NO' END AS in_recovery,  CASE WHEN count(*) > 0 THEN 'YES' ELSE 'NO' END AS is_receiver FROM pg_catalog.pg_stat_wal_receiver")
+	},
+	{ _T("REPLICATION"), 0, 0, 0,
+		_T("SELECT count(*) stanby FROM pg_catalog.pg_stat_replication")
+	},
+	{ _T("REPLICATION"), MAKE_PGSQL_VERSION(10, 0, 0), 0, 0,
+		_T("SELECT CASE WHEN pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn() THEN 0 ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_catalog.pg_last_xact_replay_timestamp())::integer, 0) END AS lag")
+	},
+	{ _T("REPLICATION"), MAKE_PGSQL_VERSION(10, 0, 0), 0, 0,
+		_T("SELECT pg_catalog.pg_wal_lsn_diff (received_lsn, pg_catalog.pg_last_wal_replay_lsn()) AS lag_bytes FROM pg_catalog.pg_stat_wal_receiver")
+	},
+	{ _T("REPLICATION"), MAKE_PGSQL_VERSION(10, 0, 0), 0, 0,
+		_T("SELECT pg_catalog.pg_wal_lsn_diff(pg_current_wal_lsn(),'0/00000000') AS xlog_size, count(*) AS xlog_files FROM pg_catalog.pg_ls_waldir()")
+	},
+	{ NULL, 0, 0, 0, NULL }
+};
+
+/**
+ * Table query definitions: Backends activity
+ */
+static TableDescriptor s_tqBackends[] =
+{
+	{
+		MAKE_PGSQL_VERSION(10, 0, 0),
+		_T("SELECT pid, datname, usename, application_name, client_addr, ")
+			_T("to_char(backend_start, 'YYYY-MM-DD HH24:MI:SS TZ') AS backend_start, ")
+			_T("state, ")
+			_T("wait_event_type || ': ' || wait_event AS wait_event, ")
+			_T("array_to_string(pg_blocking_pids(pid), ',') AS blocking_pids, ")
+			_T("backend_type, ")  // new in v10
+			_T("to_char(query_start, 'YYYY-MM-DD HH24:MI:SS TZ') AS query_start, ")
+			_T("to_char(state_change, 'YYYY-MM-DD HH24:MI:SS TZ') AS state_change, ")
+			_T("query ")
+			_T("FROM pg_catalog.pg_stat_activity WHERE pid != pg_catalog.pg_backend_pid() ORDER BY pid"),
+		{
+			{ DCI_DT_INT64, _T("PID") },
+			{ DCI_DT_STRING, _T("Database") },
+			{ DCI_DT_STRING, _T("User") },
+			{ DCI_DT_STRING, _T("Application") },
+			{ DCI_DT_STRING, _T("Client") },
+			{ DCI_DT_STRING, _T("Backend start") },
+			{ DCI_DT_STRING, _T("State") },
+			{ DCI_DT_STRING, _T("Wait event") },
+			{ DCI_DT_STRING, _T("Blocking PIDs") },
+			{ DCI_DT_STRING, _T("Backend type") },
+			{ DCI_DT_STRING, _T("Query start") },
+			{ DCI_DT_STRING, _T("Last state change") },
+			{ DCI_DT_STRING, _T("SQL") }
+		}
+	},
+	{
+		MAKE_PGSQL_VERSION(9, 6, 0),
+		_T("SELECT pid, datname, usename, application_name, client_addr, ")
+			_T("to_char(backend_start, 'YYYY-MM-DD HH24:MI:SS TZ') AS backend_start, ")
+			_T("state, ")
+			_T("wait_event_type || ': ' || wait_event AS wait_event, ") // change in v9.6
+			_T("array_to_string(pg_blocking_pids(pid), ',') AS blocking_pids, ") // new in v9.6
+			_T("to_char(query_start, 'YYYY-MM-DD HH24:MI:SS TZ') AS query_start, ")
+			_T("to_char(state_change, 'YYYY-MM-DD HH24:MI:SS TZ') AS state_change, ")
+			_T("query ")
+			_T("FROM pg_catalog.pg_stat_activity WHERE pid != pg_catalog.pg_backend_pid() ORDER BY pid"),
+		{
+			{ DCI_DT_INT64, _T("PID") },
+			{ DCI_DT_STRING, _T("Database") },
+			{ DCI_DT_STRING, _T("User") },
+			{ DCI_DT_STRING, _T("Application") },
+			{ DCI_DT_STRING, _T("Client") },
+			{ DCI_DT_STRING, _T("Backend start") },
+			{ DCI_DT_STRING, _T("State") },
+			{ DCI_DT_STRING, _T("Wait event") },
+			{ DCI_DT_STRING, _T("Blocking PIDs") },
+			{ DCI_DT_STRING, _T("Query start") },
+			{ DCI_DT_STRING, _T("Last state change") },
+			{ DCI_DT_STRING, _T("SQL") }
+		}
+	},
+	{
+		0,
+		_T("SELECT pid, datname, usename, application_name, client_addr, ")
+			_T("to_char(backend_start, 'YYYY-MM-DD HH24:MI:SS TZ') AS backend_start, ")
+			_T("state, ")
+			_T("CASE WHEN waiting THEN 'YES' ELSE 'NO' END AS waiting, ")
+			_T("to_char(query_start, 'YYYY-MM-DD HH24:MI:SS TZ') AS query_start, ")
+			_T("to_char(state_change, 'YYYY-MM-DD HH24:MI:SS TZ') AS state_change, ")
+			_T("query ")
+			_T("FROM pg_catalog.pg_stat_activity WHERE pid != pg_catalog.pg_backend_pid() ORDER BY pid"),
+		{
+			{ DCI_DT_INT64, _T("PID") },
+			{ DCI_DT_STRING, _T("Database") },
+			{ DCI_DT_STRING, _T("User") },
+			{ DCI_DT_STRING, _T("Application") },
+			{ DCI_DT_STRING, _T("Client") },
+			{ DCI_DT_STRING, _T("Backend start") },
+			{ DCI_DT_STRING, _T("State") },
+			{ DCI_DT_STRING, _T("Waiting?") },
+			{ DCI_DT_STRING, _T("Query start") },
+			{ DCI_DT_STRING, _T("Last state change") },
+			{ DCI_DT_STRING, _T("SQL") }
+		}
+	}
+};
+
+/**
+ * Table query definition: Locks
+ */
+static TableDescriptor s_tqLocks[] =
+{
+	{
+		0,
+		_T("SELECT pid, datname, locktype, relation::regclass, page, tuple, virtualxid, transactionid, ")
+			_T("classid::regclass, objid, virtualtransaction, mode, ")
+			_T("CASE WHEN granted THEN 'YES' ELSE 'NO' END AS granted, ")
+			_T("CASE WHEN fastpath THEN 'YES' ELSE 'NO' END AS fastpath ")
+			_T("FROM pg_catalog.pg_locks l LEFT OUTER JOIN pg_catalog.pg_database d ON (l.database = d.oid) ")
+			_T("WHERE pid != pg_backend_pid() ORDER BY pid, locktype"),
+		{
+			{ DCI_DT_INT64, _T("PID") },
+			{ DCI_DT_STRING, _T("Database") },
+			{ DCI_DT_STRING, _T("Lock type") },
+			{ DCI_DT_STRING, _T("Target relation") },
+			{ DCI_DT_STRING, _T("Page") },
+			{ DCI_DT_STRING, _T("Tuple") },
+			{ DCI_DT_STRING, _T("vXID (target)") },
+			{ DCI_DT_STRING, _T("XID (target)") },
+			{ DCI_DT_STRING, _T("Class") },
+			{ DCI_DT_STRING, _T("Object ID") },
+			{ DCI_DT_STRING, _T("vXID (owner)") },
+			{ DCI_DT_STRING, _T("Mode") },
+			{ DCI_DT_STRING, _T("Granted?") },
+			{ DCI_DT_STRING, _T("Fastpath?") }
+		}
+	}
+};
+
+/**
+ * Table query definition: Prepared Transactions
+ */
+static TableDescriptor s_tqPrepared[] =
+{
+	{
+		0,
+		_T("SELECT gid, database, owner, transaction, ")
+			_T("to_char(prepared, 'YYYY-MM-DD HH24:MI:SS TZ') AS prepared ")
+			_T("FROM pg_catalog.pg_prepared_xacts ORDER BY gid, database, owner"),
+		{
+			{ DCI_DT_INT64, _T("GID") },
+			{ DCI_DT_STRING, _T("Name") },
+			{ DCI_DT_STRING, _T("Owner") },
+			{ DCI_DT_INT64, _T("XID") },
+			{ DCI_DT_STRING, _T("Prepared at") }
+		}
+	}
+};
+
+/**
+ * Database instances
+ */
+static ObjectArray<DatabaseInstance> *s_instances = NULL;
+
+/**
+ * Find instance by ID
+ */
+static DatabaseInstance *FindInstance(const TCHAR *id)
+{
+	for(int i = 0; i < s_instances->size(); i++)
+	{
+		DatabaseInstance *db = s_instances->get(i);
+		if (!_tcsicmp(db->getId(), id))
+			return db;
+	}
+	return NULL;
+}
+
+/**
+ * Handler for parameters without instance
+ */
+static LONG H_GlobalParameter(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session)
+{
+	TCHAR id[MAX_DB_STRING];
+	if (!AgentGetParameterArg(param, 1, id, MAX_DB_STRING))
+		return SYSINFO_RC_UNSUPPORTED;
+
+	DatabaseInstance *db = FindInstance(id);
+	if (db == NULL)
+		return SYSINFO_RC_UNSUPPORTED;
+
+	bool missingAsZero;
+	if (arg[0] == _T('?'))  // count missing data as 0
+	{
+		if (db->getData(&arg[1], value))
+			return SYSINFO_RC_SUCCESS;
+		ret_int(value, 0);
+		return SYSINFO_RC_SUCCESS;
+	}
+	else
+		return db->getData(arg, value) ? SYSINFO_RC_SUCCESS : SYSINFO_RC_ERROR;
+}
+
+/**
+ * Handler for parameters with instance
+ */
+static LONG H_InstanceParameter(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session)
+{
+	TCHAR id[MAX_DB_STRING];
+	if (!AgentGetParameterArg(param, 1, id, MAX_DB_STRING))
+		return SYSINFO_RC_UNSUPPORTED;
+
+	TCHAR *c;
+	TCHAR instance[MAX_DB_STRING];
+	if ((c = _tcschr(id, _T('@'))) != NULL) { // is the first parameter in format database@connection
+		*(c++) = 0;
+		_tcscpy(instance, id);
+		_tcscpy(id, c);
+	}
+
+
+
+	DatabaseInstance *db = FindInstance(id);
+	if (db == NULL)
+		return SYSINFO_RC_UNSUPPORTED;
+
+	if (c == NULL) 
+		if (!AgentGetParameterArg(param, 2, instance, MAX_DB_STRING))
+			_tcscpy(instance, db->getName()); // use connection's maintenance database
+
+	TCHAR tag[MAX_DB_STRING];
+	bool missingAsZero;
+	if (arg[0] == _T('?'))  // count missing instance as 0
+	{
+		_sntprintf(tag, MAX_DB_STRING, _T("%s@%s"), &arg[1], instance);
+		missingAsZero = true;
+	}
+	else
+	{
+		_sntprintf(tag, MAX_DB_STRING, _T("%s@%s"), arg, instance);
+		missingAsZero = false;
+	}
+	if (db->getData(tag, value))
+		return SYSINFO_RC_SUCCESS;
+	if (missingAsZero)
+	{
+		ret_int(value, 0);
+		return SYSINFO_RC_SUCCESS;
+	}
+	return SYSINFO_RC_ERROR;
+}
+
+/**
+ * Handler for PostgreSQL.IsReachable parameter
+ */
+static LONG H_DatabaseServerConnectionStatus(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session)
+{
+	TCHAR id[MAX_DB_STRING];
+	if (!AgentGetParameterArg(param, 1, id, MAX_DB_STRING))
+		return SYSINFO_RC_UNSUPPORTED;
+
+	DatabaseInstance *db = FindInstance(id);
+	if (db == NULL)
+		return SYSINFO_RC_UNSUPPORTED;
+
+	ret_string(value, db->isConnected() ? _T("YES") : _T("NO"));
+	return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Handler for Oracle.DBInfo.Version parameter
+ */
+static LONG H_DatabaseVersion(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session)
+{
+	TCHAR id[MAX_DB_STRING];
+	if (!AgentGetParameterArg(param, 1, id, MAX_DB_STRING))
+		return SYSINFO_RC_UNSUPPORTED;
+
+	DatabaseInstance *db = FindInstance(id);
+	if (db == NULL)
+		return SYSINFO_RC_UNSUPPORTED;
+
+	int version = db->getVersion();
+	if ((version & 0xFF) == 0)
+		_sntprintf(value, MAX_RESULT_LENGTH, _T("%d.%d"), version >> 16, (version >> 8) & 0xFF);
+	else
+		_sntprintf(value, MAX_RESULT_LENGTH, _T("%d.%d.%d"), version >> 16, (version >> 8) & 0xFF, version & 0xFF);
+	return SYSINFO_RC_SUCCESS;
+}
+
+
+/**
+ * Handler for PostgreSQL.DBServersList list
+ */
+static LONG H_DBServersList(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session)
+{
+	for(int i = 0; i < s_instances->size(); i++)
+		value->add(s_instances->get(i)->getId());
+	return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Handler for PostgreSQL.AllDatabases list
+ */
+static LONG H_AllDatabasesList(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session)
+{
+	StringList *list;
+	for(int i = 0; i < s_instances->size(); i++) {
+		DatabaseInstance *db = s_instances->get(i);
+		list = new StringList();
+		if (!db->getTagList(arg, list)) {
+			delete list;
+			return SYSINFO_RC_ERROR;
+		}
+		for(int j = 0; j < list->size(); j++) {
+			TCHAR s[MAX_RESULT_LENGTH];
+			_sntprintf(s, MAX_RESULT_LENGTH, _T("%s@%s"), list->get(j), db->getId());
+			value->add(s);
+		}
+		delete list;
+	}
+	return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Handler for generic list parameter
+ */
+static LONG H_TagList(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session)
+{
+	TCHAR id[MAX_DB_STRING];
+	if (!AgentGetParameterArg(param, 1, id, MAX_DB_STRING))
+		return SYSINFO_RC_UNSUPPORTED;
+
+	DatabaseInstance *db = FindInstance(id);
+	if (db == NULL)
+		return SYSINFO_RC_UNSUPPORTED;
+
+	return db->getTagList(arg, value) ? SYSINFO_RC_SUCCESS : SYSINFO_RC_ERROR;
+}
+
+/**
+ * Handler for generic table queries
+ */
+static LONG H_TableQuery(const TCHAR *param, const TCHAR *arg, Table *value, AbstractCommSession *session)
+{
+	TCHAR id[MAX_DB_STRING];
+	if (!AgentGetParameterArg(param, 1, id, MAX_DB_STRING))
+		return SYSINFO_RC_UNSUPPORTED;
+
+	DatabaseInstance *db = FindInstance(id);
+	if (db == NULL)
+		return SYSINFO_RC_UNSUPPORTED;
+
+	TableDescriptor *td = (TableDescriptor *)arg;
+	while (td->minVersion > db->getVersion())
+		td++;
+
+	return db->queryTable(td, value) ? SYSINFO_RC_SUCCESS : SYSINFO_RC_ERROR;
+}
+
+/**
+ * Config template
+ */
+static DatabaseInfo s_dbInfo;
+static NX_CFG_TEMPLATE s_configTemplate[] =
+{
+	{ _T("ConnectionTTL"),	CT_LONG, 0, 0, 0, 0, &s_dbInfo.connectionTTL },
+	{ _T("Database"),		CT_STRING, 0, 0, MAX_DB_STRING,	0, s_dbInfo.name },
+	{ _T("Id"),				CT_STRING, 0, 0, MAX_DB_STRING,	0, s_dbInfo.id },
+	{ _T("Login"),			CT_STRING, 0, 0, MAX_DB_LOGIN,	 0, s_dbInfo.login },
+	{ _T("Password"),		CT_STRING, 0, 0, MAX_DB_PASSWORD, 0, s_dbInfo.password },
+	{ _T("Server"),			CT_STRING, 0, 0, MAX_DB_STRING,	0, s_dbInfo.server },
+	{ _T(""), CT_END_OF_LIST, 0, 0, 0, 0, NULL }
+};
 
 /*
  * Subagent initialization
  */
 static bool SubAgentInit(Config *config)
 {
-   int i;
+	int i;
 
 	// Init db driver
-	g_driverHandle = DBLoadDriver(_T("pgsql.ddr"), NULL, TRUE, NULL, NULL);
-	if (g_driverHandle == NULL)
+	g_pgsqlDriver = DBLoadDriver(_T("pgsql.ddr"), NULL, TRUE, NULL, NULL);
+	if (g_pgsqlDriver == NULL)
 	{
-		AgentWriteLog(EVENTLOG_ERROR_TYPE, _T("%s: failed to load database driver"), MYNAMESTR);
+		AgentWriteLog(EVENTLOG_ERROR_TYPE, _T("PGSQL: failed to load database driver"));
 		return false;
 	}
+
+	s_instances = new ObjectArray<DatabaseInstance>(8, 8, Ownership::True);
+
+	// Load configuration from "pgsql" section to allow simple configuration
+	// of one connection without XML includes
+	memset(&s_dbInfo, 0, sizeof(s_dbInfo));
+	s_dbInfo.connectionTTL = 3600;
+	_tcscpy(s_dbInfo.id, _T("localdb"));
+	_tcscpy(s_dbInfo.server, _T("127.0.0.1"));
+	_tcscpy(s_dbInfo.name, _T("postgres"));
+	_tcscpy(s_dbInfo.login, _T("netxms"));
+	if(config->getEntry(_T("/pgsql/id")) != NULL || config->getEntry(_T("/pgsql/name")) != NULL ||
+			config->getEntry(_T("pgsql/server")) != NULL || config->getEntry(_T("/pgsql/login")) != NULL  ||
+			config->getEntry(_T("/pgsql/password")) != NULL)
+	{
+		if (config->parseTemplate(_T("PGSQL"), s_configTemplate))
+		{
+			if (s_dbInfo.name[0] != 0)
+			{
+				if (s_dbInfo.id[0] == 0)
+					_tcscpy(s_dbInfo.id, s_dbInfo.name);
+
+				DecryptPassword(s_dbInfo.login, s_dbInfo.password, s_dbInfo.password, MAX_DB_PASSWORD);
+				s_instances->add(new DatabaseInstance(&s_dbInfo));
+			}
+		}
+	}
+
+	// Load full-featured XML configuration
+	ConfigEntry *metricRoot = config->getEntry(_T("/pgsql/servers"));
+	if (metricRoot != NULL)
+	{
+		ObjectArray<ConfigEntry> *metrics = metricRoot->getSubEntries(_T("*"));
+		for(int i = 0; i < metrics->size(); i++)
+		{
+			TCHAR section[MAX_DB_STRING];
+			ConfigEntry *e = metrics->get(i);
+			s_dbInfo.connectionTTL = 3600;
+			_tcscpy(s_dbInfo.id, e->getName());
+			_tcscpy(s_dbInfo.server, _T("127.0.0.1"));
+			_tcscpy(s_dbInfo.name, _T("postgres"));
+			_tcscpy(s_dbInfo.login, _T("netxms"));
+
+			_sntprintf(section, MAX_DB_STRING, _T("pgsql/servers/%s"), e->getName());
+			if (!config->parseTemplate(section, s_configTemplate))
+			{
+				nxlog_debug_tag(DEBUG_TAG, NXLOG_WARNING, _T("PGSQL: error parsing configuration template %s"), e->getName());
+				continue;
+			}
+
+			if (s_dbInfo.id[0] == 0)
+				continue;
+
+			DecryptPassword(s_dbInfo.login, s_dbInfo.password, s_dbInfo.password, MAX_DB_PASSWORD);
+
+			s_instances->add(new DatabaseInstance(&s_dbInfo));
+		}
+		delete metrics;
+	}
+
+	// Exit if no usable configuration found
+	if (s_instances->size() == 0)
+	{
+		nxlog_debug_tag(DEBUG_TAG, NXLOG_WARNING, _T("PGSQL: no databases to monitor, exiting"));
+		delete s_instances;
+		return false;
+	}
+
+	// Run query thread for each configured database
+	for(i = 0; i < s_instances->size(); i++)
+		s_instances->get(i)->run();
 
 	return true;
 }
@@ -46,6 +563,10 @@ static bool SubAgentInit(Config *config)
  */
 static void SubAgentShutdown()
 {
+	nxlog_debug_tag(DEBUG_TAG, 1, _T("PGSQL: stopping pollers"));
+	for(int i = 0; i < s_instances->size(); i++)
+		s_instances->get(i)->stop();
+	delete s_instances;
 	AgentWriteDebugLog(1, _T("PGSQL: stopped"));
 }
 
@@ -54,6 +575,74 @@ static void SubAgentShutdown()
  */
 static NETXMS_SUBAGENT_PARAM s_parameters[] =
 {
+	{ _T("PostgreSQL.IsReachable(*)"), H_DatabaseServerConnectionStatus, NULL, DCI_DT_STRING, _T("PostgreSQL: database server instance reachable") },
+	{ _T("PostgreSQL.Version(*)"), H_DatabaseVersion, NULL, DCI_DT_STRING, _T("PostgreSQL: database server version") },
+	{ _T("PostgreSQL.Archiver.ArchivedCount(*)"), H_GlobalParameter, _T("ARCHIVER/archived_count"), DCI_DT_INT64, _T("PostgreSQL/Archiver: archived") },
+	{ _T("PostgreSQL.Archiver.FailedCount(*)"), H_GlobalParameter, _T("ARCHIVER/failed_count"), DCI_DT_INT64, _T("PostgreSQL/Archiver: failed") },
+	{ _T("PostgreSQL.Archiver.IsArchiving(*)"), H_GlobalParameter, _T("ARCHIVER/is_archiving"), DCI_DT_STRING, _T("PostgreSQL/Archiver: is running") },
+	{ _T("PostgreSQL.Archiver.LastArchivedAge(*)"), H_GlobalParameter, _T("ARCHIVER/last_archived_age"), DCI_DT_INT, _T("PostgreSQL/Archiver: last archived age") },
+	{ _T("PostgreSQL.Archiver.LastArchivedWAL(*)"), H_GlobalParameter, _T("ARCHIVER/last_archived_wal"), DCI_DT_STRING, _T("PostgreSQL/Archiver: last archived") },
+	{ _T("PostgreSQL.Archiver.LastFailedAge(*)"), H_GlobalParameter, _T("ARCHIVER/last_failed_age"), DCI_DT_INT, _T("PostgreSQL/Archiver: last failed age") },
+	{ _T("PostgreSQL.Archiver.LastFailedWAL(*)"), H_GlobalParameter, _T("ARCHIVER/last_failed_wal"), DCI_DT_STRING, _T("PostgreSQL/Archiver: last failed") },
+	{ _T("PostgreSQL.BGWriter.BuffersAlloc(*)"), H_GlobalParameter, _T("BGWRITER/buffers_alloc"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: allocated buffers") },
+	{ _T("PostgreSQL.BGWriter.BuffersBackend(*)"), H_GlobalParameter, _T("BGWRITER/buffers_backend"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: diretly written buffers") },
+	{ _T("PostgreSQL.BGWriter.BuffersBackendFsync(*)"), H_GlobalParameter, _T("BGWRITER/buffers_backend_fsync"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: fsync written buffers") },
+	{ _T("PostgreSQL.BGWriter.BuffersClean(*)"), H_GlobalParameter, _T("BGWRITER/buffers_clean"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: buffers written by backround writer") },
+	{ _T("PostgreSQL.BGWriter.BuffersCheckpoint(*)"), H_GlobalParameter, _T("BGWRITER/buffers_checkpoint"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: buffers written during checkpoins") },
+	{ _T("PostgreSQL.BGWriter.CheckpointsReq(*)"), H_GlobalParameter, _T("BGWRITER/checkpoints_req"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: requested checkpoints") },
+	{ _T("PostgreSQL.BGWriter.CheckpointsTimed(*)"), H_GlobalParameter, _T("BGWRITER/checkpoints_timed"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: scheduled checkpoints") },
+	{ _T("PostgreSQL.BGWriter.CheckpointSyncTime(*)"), H_GlobalParameter, _T("BGWRITER/checkpoint_sync_time"), DCI_DT_FLOAT, _T("PostgreSQL/BGWriter: checkpoint sync time") },
+	{ _T("PostgreSQL.BGWriter.CheckpointWriteTime(*)"), H_GlobalParameter, _T("BGWRITER/checkpoint_write_time"), DCI_DT_FLOAT, _T("PostgreSQL/BGWriter: chechpoint write time") },
+	{ _T("PostgreSQL.BGWriter.MaxWrittenClean(*)"), H_GlobalParameter, _T("BGWRITER/checkpoints_timed"), DCI_DT_INT64, _T("PostgreSQL/BGWriter: background witer stops") },
+	{ _T("PostgreSQL.GlobalConnections.AutovacuumMax(*)"), H_GlobalParameter, _T("CONNECTIONS/autovacuum_max"), DCI_DT_INT, _T("PostgreSQL/GlobalConnections: max autovacuum backends") },
+	{ _T("PostgreSQL.GlobalConnections.Total(*)"), H_GlobalParameter, _T("CONNECTIONS/total"), DCI_DT_INT, _T("PostgreSQL/GlobalConnections: number of all backends") },
+	{ _T("PostgreSQL.GlobalConnections.TotalMax(*)"), H_GlobalParameter, _T("CONNECTIONS/max"), DCI_DT_INT, _T("PostgreSQL/GlobalConnections: max connections") },
+	{ _T("PostgreSQL.GlobalConnections.TotalPct(*)"), H_GlobalParameter, _T("CONNECTIONS/total_pct"), DCI_DT_INT, _T("PostgreSQL/GlobalConnections: used connections (%)") },
+	{ _T("PostgreSQL.Replication.InRecovery(*)"), H_GlobalParameter, _T("REPLICATION/in_recovery"), DCI_DT_STRING, _T("PostgreSQL/Replication: in recovery") },
+	{ _T("PostgreSQL.Replication.IsReceiver(*)"), H_GlobalParameter, _T("REPLICATION/is_receiver"), DCI_DT_STRING, _T("PostgreSQL/Replication: is receicer") },
+	{ _T("PostgreSQL.Replication.Lag(*)"), H_GlobalParameter, _T("REPLICATION/lag"), DCI_DT_INT, _T("PostgreSQL/Replication: lag in seconds") },
+	{ _T("PostgreSQL.Replication.LagBytes(*)"), H_GlobalParameter, _T("?REPLICATION/lag_bytes"), DCI_DT_FLOAT, _T("PostgreSQL/Replication: lag in bytes ") },
+	{ _T("PostgreSQL.Replication.Stanby(*)"), H_GlobalParameter, _T("REPLICATION/stanby"), DCI_DT_INT64, _T("PostgreSQL/Replication: WAL senders") },
+	{ _T("PostgreSQL.Replication.WALFiles(*)"), H_GlobalParameter, _T("REPLICATION/xlog_files"), DCI_DT_INT64, _T("PostgreSQL/Replication: WAL files") },
+	{ _T("PostgreSQL.Replication.WALSize(*)"), H_GlobalParameter, _T("REPLICATION/xlog_size"), DCI_DT_FLOAT, _T("PostgreSQL/Replication: WAL size") },
+	{ _T("PostgreSQL.DBConnections.Active(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/active"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} number of active backends") },
+	{ _T("PostgreSQL.DBConnections.Autovacuum(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/autovacuum"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} autovacuum backends") },
+	{ _T("PostgreSQL.DBConnections.FastpathFunctionCall(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/fastpath_function_call"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} number of fastpath function call backends") },
+	{ _T("PostgreSQL.DBConnections.Idle(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/idle"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} number of idle backends") },
+	{ _T("PostgreSQL.DBConnections.IdleInTransaction(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/idle_in_transaction"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} number of idle in a transaction backends") },
+	{ _T("PostgreSQL.DBConnections.IdleInTransactionAborted(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/idle_in_transaction_aborted"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} number of idle in transaction (aborted) backends") },
+	{ _T("PostgreSQL.DBConnections.OldestXID(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/oldestxid"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} oldest XID age") },
+	{ _T("PostgreSQL.DBConnections.Total(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/total"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} number of all backends") },
+	{ _T("PostgreSQL.DBConnections.Waiting(*)"), H_InstanceParameter, _T("DB_CONNECTIONS/waiting"), DCI_DT_INT, _T("PostgreSQL/DBConnections: {instance-name} waiting backends") },
+	{ _T("PostgreSQL.Locks.AccessExclusive(*)"), H_InstanceParameter, _T("DB_LOCKS/accessexclusive"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} AccessExclusive locks") },
+	{ _T("PostgreSQL.Locks.AccessShare(*)"), H_InstanceParameter, _T("DB_LOCKS/accessshare"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} AccessShare locks") },
+	{ _T("PostgreSQL.Locks.Exclusive(*)"), H_InstanceParameter, _T("DB_LOCKS/exclusive"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} Exclusive locks") },
+	{ _T("PostgreSQL.Locks.RowExclusive(*)"), H_InstanceParameter, _T("DB_LOCKS/rowexclusive"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} RowExclusive locks") },
+	{ _T("PostgreSQL.Locks.RowShare(*)"), H_InstanceParameter, _T("DB_LOCKS/rowshare"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} RowShare locks") },
+	{ _T("PostgreSQL.Locks.Share(*)"), H_InstanceParameter, _T("DB_LOCKS/share"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} Share locks") },
+	{ _T("PostgreSQL.Locks.ShareRowExclusive(*)"), H_InstanceParameter, _T("DB_LOCKS/sharerowexclusive"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} ShareRowExclusive locks") },
+	{ _T("PostgreSQL.Locks.ShareUpdateExclusive(*)"), H_InstanceParameter, _T("DB_LOCKS/total"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} ShareUpdateExclusive locks") },
+	{ _T("PostgreSQL.Locks.Total(*)"), H_InstanceParameter, _T("DB_LOCKS/total"), DCI_DT_INT64, _T("PostgreSQL/Locks: {instance-name} all locks") },
+	{ _T("PostgreSQL.Stats.BlkWriteTime(*)"), H_InstanceParameter, _T("DB_STAT/blk_write_time"), DCI_DT_FLOAT, _T("PostgreSQL/Stats: {instance-name} writing data time") },
+	{ _T("PostgreSQL.Stats.BlockReadTime(*)"), H_InstanceParameter, _T("DB_STAT/blk_read_time"), DCI_DT_FLOAT, _T("PostgreSQL/Stats: {instance-name} reading data time") },
+	{ _T("PostgreSQL.Stats.BlocksRead(*)"), H_InstanceParameter, _T("DB_STAT/blks_read"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} read blocks") },
+	{ _T("PostgreSQL.Stats.BloksHit(*)"), H_InstanceParameter, _T("DB_STAT/blks_hit"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} blocks fond in cache") },
+	{ _T("PostgreSQL.Stats.CacheHitRatio(*)"), H_InstanceParameter, _T("DB_STAT/cachehitratio"), DCI_DT_FLOAT, _T("PostgreSQL/Stats: {instance-name} cache hit ratio (%)") },
+	{ _T("PostgreSQL.Stats.Conflicts(*)"), H_InstanceParameter, _T("DB_STAT/conflicts"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} conflicts") },
+	{ _T("PostgreSQL.Stats.DatabaseSize(*)"), H_InstanceParameter, _T("DB_STAT/size"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} database size") },
+	{ _T("PostgreSQL.Stats.Deadlocks(*)"), H_InstanceParameter, _T("DB_STAT/deadlocks"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} number of deadlocks") },
+	{ _T("PostgreSQL.Stats.ChecksumFailures(*)"), H_InstanceParameter, _T("DB_STAT/checksum_failures"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} page checksum failures") },
+	{ _T("PostgreSQL.Stats.NumBackends(*)"), H_InstanceParameter, _T("DB_STAT/numbackends"), DCI_DT_INT, _T("PostgreSQL/Stats: {instance-name} number of backends") },
+	{ _T("PostgreSQL.Stats.RowsDeleted(*)"), H_InstanceParameter, _T("DB_STAT/tup_deleted"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} deleted rows") },
+	{ _T("PostgreSQL.Stats.RowsFetched(*)"), H_InstanceParameter, _T("DB_STAT/tup_fetched"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} fetched rows") },
+	{ _T("PostgreSQL.Stats.RowsInserted(*)"), H_InstanceParameter, _T("DB_STAT/tup_inserted"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} inserred rows") },
+	{ _T("PostgreSQL.Stats.RowsReturned(*)"), H_InstanceParameter, _T("DB_STAT/tup_returned"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} returned rows") },
+	{ _T("PostgreSQL.Stats.RowsUpdated(*)"), H_InstanceParameter, _T("DB_STAT/tup_updated"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} updated rows") },
+	{ _T("PostgreSQL.Stats.TempBytes(*)"), H_InstanceParameter, _T("DB_STAT/temp_bytes"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} temporary data size") },
+	{ _T("PostgreSQL.Stats.TempFiles(*)"), H_InstanceParameter, _T("DB_STAT/temp_files"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} temporary files") },
+	{ _T("PostgreSQL.Stats.TransactionCommits(*)"), H_InstanceParameter, _T("DB_STAT/xact_commit"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} commited tranactions") },
+	{ _T("PostgreSQL.Stats.TransactionRollbacks(*)"), H_InstanceParameter, _T("DB_STAT/xact_rollback"), DCI_DT_INT64, _T("PostgreSQL/Stats: {instance-name} rolled back transactions") },
+	{ _T("PostgreSQL.Transactions.Prepared(*)"), H_InstanceParameter, _T("?DB_TRANSACTIONS/prepared"), DCI_DT_INT64, _T("PostgreSQL/Transactions: {instance-name} prepared transactions") }
 };
 
 /**
@@ -61,6 +650,11 @@ static NETXMS_SUBAGENT_PARAM s_parameters[] =
  */
 static NETXMS_SUBAGENT_LIST s_lists[] =
 {
+	{ _T("PostgreSQL.DBServers"), H_DBServersList, NULL, _T("PostgreSQL: database servers being monitored") },
+	{ _T("PostgreSQL.Databases(*)"), H_TagList, _T("^DB_STAT/size@(.*)$"), _T("PostgreSQL: databases on the specific server") },
+	{ _T("PostgreSQL.AllDatabases"), H_AllDatabasesList, _T("^DB_STAT/size@(.*)$"), _T("PostgreSQL: all databases on all monitored servers") },
+	{ _T("PostgreSQL.DataTags(*)"), H_TagList, _T("^(.*)$") }
+
 };
 
 /**
@@ -68,6 +662,9 @@ static NETXMS_SUBAGENT_LIST s_lists[] =
  */
 static NETXMS_SUBAGENT_TABLE s_tables[] =
 {
+	{ _T("PostgreSQL.Backends(*)"), H_TableQuery, (const TCHAR *)&s_tqBackends, _T("PID"), _T("PostgreSQL: backend activity") },
+	{ _T("PostgreSQL.Locks(*)"), H_TableQuery, (const TCHAR *)&s_tqLocks, _T("PID"), _T("PostgreSQL: locks") },
+	{ _T("PostgreSQL.PrepparedTransactions(*)"), H_TableQuery, (const TCHAR *)&s_tqPrepared, _T("GID"), _T("PostgreSQL: prepared transactions") }
 };
 
 /**
@@ -81,8 +678,8 @@ static NETXMS_SUBAGENT_INFO s_info =
 	sizeof(s_parameters) / sizeof(NETXMS_SUBAGENT_PARAM), s_parameters,
 	sizeof(s_lists) / sizeof(NETXMS_SUBAGENT_LIST), s_lists,
 	sizeof(s_tables) / sizeof(NETXMS_SUBAGENT_TABLE), s_tables,
-	0,	NULL,    // actions
-	0,	NULL     // push parameters
+	0,	NULL,	 // actions
+	0,	NULL	  // push parameters
 };
 
 /**

--- a/src/agent/subagents/pgsql/pgsql_subagent.h
+++ b/src/agent/subagents/pgsql/pgsql_subagent.h
@@ -1,0 +1,119 @@
+/*
+ ** NetXMS - Network Management System
+ ** Subagent for PostgreSQL monitoring
+ ** Copyright (C) 2009-2014 Raden Solutions
+ ** Copyright (C) 2020 Petr Votava
+ **
+ ** This program is free software; you can redistribute it and/or modify
+ ** it under the terms of the GNU Lesser General Public License as published
+ ** by the Free Software Foundation; either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU Lesser General Public License
+ ** along with this program; if not, write to the Free Software
+ ** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ **/
+
+#ifndef _pgsql_subagent_h_
+#define _pgsql_subagent_h_
+
+#include <nms_common.h>
+#include <nms_util.h>
+#include <nms_agent.h>
+#include <nxdbapi.h>
+
+/**
+ * Database connection information
+ */
+struct DatabaseInfo
+{
+	TCHAR id[MAX_DB_STRING];				// instance ID (connection name)
+	TCHAR name[MAX_DB_STRING];				// maintenance DB name
+	TCHAR server[MAX_DB_STRING];
+	TCHAR login[MAX_DB_LOGIN];
+	TCHAR password[MAX_DB_PASSWORD];
+	UINT32 connectionTTL;
+};
+
+/**
+ * Table query descriptor
+ */
+struct TableDescriptor
+{
+	int minVersion;
+	const TCHAR *query;
+	struct
+	{
+		int dataType;
+		const TCHAR *displayName;
+	} columns[32];
+};
+
+/**
+ * Database instance
+ */
+class DatabaseInstance
+{
+private:
+	DatabaseInfo m_info;
+	THREAD m_pollerThread;
+	DB_HANDLE m_session;
+	bool m_connected;
+	int m_version;
+	StringMap *m_data;
+	MUTEX m_dataLock;
+	MUTEX m_sessionLock;
+	CONDITION m_stopCondition;
+
+	static THREAD_RESULT THREAD_CALL pollerThreadStarter(void *arg);
+
+	void pollerThread();
+	bool poll();
+	int getPgsqlVersion();
+
+public:
+	DatabaseInstance(DatabaseInfo *info);
+	~DatabaseInstance();
+
+	void run();
+	void stop();
+
+	const TCHAR *getId() { return m_info.id; }
+	const TCHAR *getName() { return m_info.name; }
+	bool isConnected() { return m_connected; }
+	int getVersion() { return m_version; }
+
+	bool getData(const TCHAR *tag, TCHAR *value);
+	bool getTagList(const TCHAR *pattern, StringList *value);
+	bool queryTable(TableDescriptor *td, Table *value);
+};
+
+/**
+ * Query for polling
+ */
+struct DatabaseQuery
+{
+	const TCHAR *name;
+	int minVersion; // >= 
+	int maxVersion; // <
+	int instanceColumns;
+	const TCHAR *query;
+};
+
+/**
+ * Global variables
+ */
+extern DB_DRIVER g_pgsqlDriver;
+extern DatabaseQuery g_queries[];
+
+/**
+ * Make version number
+ */
+#define MAKE_PGSQL_VERSION(ver1, ver2, ver3) ((((ver1) << 16) | (ver2) << 8) | (ver3))
+
+#endif	/* _pgsql_subagent_h_ */


### PR DESCRIPTION
PostgreSQL is supported database but there was no subagent for PostgreSQL monitoring therefore I crated one.

The skeleton of the PostgreSQL subagent is similar to the Oracle subagent with some small changes.

I do not have Windows development environment and I didn't find any description what is needed therefore I've tested it on Debian only but I don't use any non-Windows specific features therefore I thing after adding of pgsql.vcxproj and pgsql.vcxproj.filters files it will be possible to compile the subagent on Windows and it will work.

Please add the agent and its documentation to the original repositories.
