### PR TITLE
Add ability to probe TLS behind SMTP STARTTLS (NX-2455)

### DIFF
--- a/tests/test-netsvc-tls
+++ b/tests/test-netsvc-tls
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+: "${AGNT:=127.0.0.1}"
+
+# FIXME all-encompassing health metric is lacking
+
+# STARTTLS: SMTP
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(smtp.gmail.com,587,,smtp)')
+then [[ "$O" == "C=US,O=Google Trust Services LLC,CN=GTS CA 1C3" ]]; else false; fi
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(smtp.gmail.com,25,,smtp)')
+then [[ "$O" == "C=US,O=Google Trust Services LLC,CN=GTS CA 1C3" ]]; else false; fi
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(mail.netxms.org,587,,smtp)')
+then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(mail.netxms.org,25,,smtp)')
+then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi
+
+# HTTPS
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(badssl.com,443)')
+then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi
+
+# what '0' stands for? why 0 for both actual and expired cert?
+if O=$(nxget "$AGNT" 'NetworkService.TLSStatus(badssl.com,443)')
+then [[ "$O" == "0" ]]; else false; fi
+
+# what '0' stands for? why 0 for both actual and expired cert?
+if O=$(nxget "$AGNT" 'NetworkService.TLSStatus(expired.badssl.com,443)')
+then [[ "$O" == "0" ]]; else false; fi
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(expired.badssl.com,443)')
+then [[ "$O" == "C=GB,ST=Greater Manchester,L=Salford,O=COMODO CA Limited,CN=COMODO RSA Domain Validation Secure Server CA" ]]; else false; fi
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.ExpirationDate(expired.badssl.com,443)')
+then [[ "$O" =~ 2015-* ]]; else false; fi
+
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(self-signed.badssl.com,443)')
+then [[ "$O" == "C=US,ST=California,L=San Francisco,O=BadSSL,CN=*.badssl.com" ]]; else false; fi
+
+# Empty output, that's right
+if O=$(nxget "$AGNT" 'TLS.Certificate.Subject(no-subject.badssl.com,443)')
+then [[ "$O" == "" ]]; else false; fi
+
+# FIXME? Outputs "500: Internal error" with exit code 1
+# 2024.03.22 15:16:34.720 *D* [netsvc             ] SetupTLSSession(null.badssl.com, 443): TLS handshake failed (error:00000001:lib(0)::reason(1))
+# 2024.03.22 15:16:34.728 *D* [netsvc             ] SetupTLSSession(null.badssl.com, 443): caused by: error:0A000410:SSL routines::sslv3 alert handshake failure
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(null.badssl.com,443)')
+then echo "Failure expected"; else echo "BAD EXITCODE: $?"; echo "OUTPUT: $O"; fi
+
+# FIXME? Outputs "500: Internal error" with exit code 1
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(http.badssl.com,80)')
+then echo "Failure expected"; else echo "BAD EXITCODE: $?"; echo "OUTPUT: $O"; fi


### PR DESCRIPTION
This implements probing TLS behind SMTP STARTTLS, as described in https://track.radensolutions.com/issue/NX-2455 .

A trivial testing script is added.

Potential future work:

- support of protocols other than SMTP;

- automated local setup of https://github.com/chromium/badssl.com for
  testing;

- expand badssl.com test suite with SMTP/STARTTLS services;

- add an overall "health" TLS.Certificate metric:
  for many badssl.com cases there's no clear way to demonstrate that
  they are bad with existing TLS.Certificate.*.
  NetworkService.TLSStatus() also doesn't give expected results.