### PR TITLE
NX-2455: implement StartTLS for IMAP, POP3

### DIFF
--- a/src/agent/subagents/netsvc/tls.cpp
+++ b/src/agent/subagents/netsvc/tls.cpp
@@ -23,6 +23,65 @@
 #include "netsvc.h"
 #include <openssl/ssl.h>
 
+static const TCHAR *startTlsTag = _T("netsvc.starttls");
+
+/**
+ * Send data once, await response within timeout and checks for "completion" with a supplied regex
+ *
+ * @param hSocket TCP socket connected to the surveyed application server
+ * @param timeout Timeout in milliseconds
+ * @param ourLine Data we send to initiate StartTLS
+ * @param expectRegex Pattern which a complete response must match
+ * @param descrTag description of the connection for log messages
+ * @return True if successful, false otherwise
+ */
+static bool GenericStartTls(SOCKET hSocket, uint32_t timeout, const char *ourLine, const char *expectRegex, const TCHAR *descrTag)
+{
+   if (!NetWrite(hSocket, ourLine, strlen(ourLine)))
+   {
+      nxlog_debug_tag(startTlsTag, 9, _T("%s: Failed to send our line"), descrTag);
+      return false;
+   }
+
+   int64_t startTime = GetCurrentTimeMs();
+   int64_t deadlineTime = startTime + timeout;
+   char buf[1024] = {0};
+   char *ptr = buf;
+   size_t bufAvail = sizeof(buf);
+
+   while (true)
+   {
+      if (SocketCanRead(hSocket, timeout))
+      {
+         ssize_t bytesRead = NetRead(hSocket, ptr, bufAvail - 1);
+         if (bytesRead <= 0)
+         {
+            nxlog_debug_tag(startTlsTag, 9, _T("%s: NetRead returned non-positive value %zd"), descrTag, bytesRead);
+            return false;
+         }
+         assert(bytesRead > 0 && bytesRead <= bufAvail - 1);
+         ptr += bytesRead;
+         bufAvail -= bytesRead;
+      }
+
+      // check if the response is complete;
+      if (RegexpMatchA(buf, expectRegex, false))
+      {
+         nxlog_debug_tag(startTlsTag, 7, _T("%s: Response complete, ready to start TLS"), descrTag);
+         return true;
+      }
+
+      int64_t now = GetCurrentTimeMs();
+      if (now >= deadlineTime)
+      {
+         nxlog_debug_tag(startTlsTag, 7, _T("%s: Timeout"), descrTag);
+         return false;
+      }
+      timeout = static_cast<uint32_t>(deadlineTime - now);
+   }
+   return false;
+}
+
 /**
  * Perform protocol-specific STARTTLS sequence on a connected socket
  *
@@ -30,88 +89,34 @@
  * @param timeout Timeout in milliseconds
  * @param host    Surveyed application server hostname
  * @param proto   Application protocol string. Supported values: "smtp"
+ * @param descrTag description of the connection for log messages
  * @return True if successful, false otherwise
  */
-static bool SetupStartTLSSession(SOCKET hSocket, uint32_t timeout, const char *host, const char *proto)
+static bool SetupStartTLSSession(SOCKET hSocket, uint32_t timeout, const char *host, const char *proto, const TCHAR *descrTag)
 {
+// Newline regex: \r (which might be omitted), then \n
+#define NL_RE "\\r?\\n"
    if (!strcmp(proto, "smtp"))
    {
-      // We send two commands and expect three batches of response lines,
-      // each batch ending with a line matching "^(220|250) .*\r\n"
       const char ourLine[] = "EHLO mail.example.com.\r\nSTARTTLS\r\n";
-      if (!NetWrite(hSocket, ourLine, strlen(ourLine)))
-      {
-         nxlog_debug_tag(DEBUG_TAG, 9, _T("SetupStartTLSSession(%hs): SMTP: failed to send our line"), host);
-         return false;
-      }
-
-      int64_t startTime = GetCurrentTimeMs();
-      int64_t deadlineTime = startTime + timeout;
-      char buf[1024] = {0};
-      char *ptr = buf;
-      size_t bufAvail = sizeof(buf);
-      char *line = buf;
-      uint32_t finalLinesRead = 0;
-
-      while (true)
-      {
-         if (SocketCanRead(hSocket, timeout))
-         {
-            ssize_t bytesRead = NetRead(hSocket, ptr, bufAvail - 1);
-            nxlog_debug_tag(DEBUG_TAG, 9, _T("SetupStartTLSSession(%hs): NetRead() returned %zd"), host, bytesRead);
-            if (bytesRead <= 0)
-            {
-               nxlog_debug_tag(DEBUG_TAG, 9, _T("SetupStartTLSSession(%hs): NetRead returned non-positive value %zd"), host, bytesRead);
-               return false;
-            }
-            assert(bytesRead > 0 && bytesRead <= bufAvail - 1);
-            ptr += bytesRead;
-            bufAvail -= bytesRead;
-         }
-
-         // check if the response is complete;
-         // expected response structure:
-         // 220 some string in response to connection establishment\r\n
-         // 250-any number of such strings\r\n
-         // 250 some string in response to EHLO\r\n
-         // 220 string in response to STARTTLS\r\n
-         const int minLineLen = 6; // Lines shouldn't be shorter than "250-\r\n"
-         while (ptr - line >= minLineLen)
-         {
-            char *lineEnd = strstr(line, "\r\n");
-            bool lineIsFinal = false;
-            if (lineEnd != nullptr)
-            {
-               *lineEnd = '\0';
-               if ((line[3] == ' ') &&
-                    (!strncmp(line, "220 ", 4)
-                     || !strncmp(line, "250 ", 4)))
-               {
-                  lineIsFinal = true;
-                  finalLinesRead++;
-               }
-               nxlog_debug_tag(DEBUG_TAG, 7, _T("SetupStartTLSSession(%hs): SMTP: %hs response line '%hs'"), host, (lineIsFinal ? "final" : "non-final"), line);
-               if (finalLinesRead == 3)
-               {
-                  nxlog_debug_tag(DEBUG_TAG, 7, _T("SetupStartTLSSession(%hs): SMTP: response complete, ready to start TLS"), host);
-                  return true;
-               }
-               line = lineEnd + 2;
-            }
-         }
-
-         int64_t now = GetCurrentTimeMs();
-         if (now >= deadlineTime)
-         {
-            nxlog_debug_tag(DEBUG_TAG, 7, _T("SetupStartTLSSession(%hs): timeout, had %") INT64_FMT _T(" ms"), host, deadlineTime - startTime);
-            return false;
-         }
-         timeout = static_cast<uint32_t>(deadlineTime - now);
-         nxlog_debug_tag(DEBUG_TAG, 7, _T("SetupStartTLSSession(%hs): timeout reduced to %u ms"), host, timeout);
-      }
-      return false;
+      const char expectRegex[] = NL_RE "220 .*" NL_RE;
+      return GenericStartTls(hSocket, timeout, ourLine, expectRegex, descrTag);
    }
+   else if (!strcmp(proto, "imap"))
+   {
+      const char ourLine[] = "cmd1 CAPABILITY\r\ncmd2 STARTTLS\r\n";
+      const char expectRegex[] = NL_RE "cmd2 .*" NL_RE;
+      return GenericStartTls(hSocket, timeout, ourLine, expectRegex, descrTag);
+   }
+   else if (!strcmp(proto, "pop3"))
+   {
+      const char ourLine[] = "STLS\r\n";
+      const char expectRegex[] = "\\+OK .*" NL_RE "\\+OK .*" NL_RE;
+      return GenericStartTls(hSocket, timeout, ourLine, expectRegex, descrTag);
+   }
+   nxlog_write_tag(NXLOG_ERROR, startTlsTag, _T("%s: unknown protocol %hs"), descrTag, proto);
    return false;
+#undef NL_RE
 }
 
 /**
@@ -328,9 +333,13 @@ LONG H_TLSCertificateInfo(const TCHAR *parameters, const TCHAR *arg, TCHAR *valu
    }
 
    if (startTlsInProto[0] != '\0') {
-      bool startTlsSuccess = SetupStartTLSSession(hSocket, timeout, (sniServerName[0] != 0) ? sniServerName : host, startTlsInProto);
+      const char *serverName = (sniServerName[0] != 0) ? sniServerName : host;
+      TCHAR descrTag[256];
+      _sntprintf(descrTag, sizeof(descrTag), _T("%hs StartTLS %hs:%u"), startTlsInProto, serverName, port);
+
+      bool startTlsSuccess = SetupStartTLSSession(hSocket, timeout, serverName, startTlsInProto, descrTag);
       if (!startTlsSuccess) {
-         nxlog_debug_tag(DEBUG_TAG, 7, _T("H_TLSCertificateInfo(%hs, %d): STARTTLS error"), host, port);
+         nxlog_debug_tag(startTlsTag, 7, _T("%s: StartTLS error"), descrTag);
          return SYSINFO_RC_ERROR;
       }
    }

--- a/tests/test-netsvc-tls
+++ b/tests/test-netsvc-tls
@@ -19,6 +19,17 @@ then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi
 if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(mail.netxms.org,25,,smtp)')
 then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi
 
+# STARTTLS: IMAP
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(imap.mailbox.org,143,,imap)')
+then [[ "$O" == "C=US,O=DigiCert Inc,OU=www.digicert.com,CN=Thawte TLS RSA CA G1" ]]; else false; fi
+
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(mail.netxms.org,143,,imap)')
+then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi
+
+# STARTTLS: POP3
+if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(pop3.mailbox.org,110,,pop3)')
+then [[ "$O" == "C=US,O=DigiCert Inc,OU=www.digicert.com,CN=Thawte TLS RSA CA G1" ]]; else false; fi
+
 # HTTPS
 if O=$(nxget "$AGNT" 'TLS.Certificate.Issuer(badssl.com,443)')
 then [[ "$O" == "C=US,O=Let's Encrypt,CN=R3" ]]; else false; fi


### PR DESCRIPTION
Completeness of protocol response is now checked by regex matching, in order to reuse the most of connection handling code and keep it simple.

Custom debug tag is used to make log statements neater.

Added tests for the new protocols.

---8<---

P. S. So I have done this custom debug tag, but I see that it's not meant to be long enough:

```
2024.04.19 17:20:41.971 *D* [comm.cs.6          ] Requesting metric "TLS.Certificate.Issuer(mail.netxms.org,143,,imap)"
2024.04.19 17:20:42.065 *D* [imap StartTLS mail.] Response complete, ready to start TLS
2024.04.19 17:20:42.106 *D* [netsvc             ] SetupTLSSession(mail.netxms.org, 143): TLS handshake: read wait completed
2024.04.19 17:20:42.111 *D* [comm.cs.6          ] GetMetricValue("TLS.Certificate.Issuer(mail.netxms.org,143,,imap)"): 0 (SUCCESS) value = "C=US,O=Let's Encrypt,CN=R3"

```

I guess I should do something else. I'd love your feedback on this.