### PR TITLE
NX-2488: enable use of web service cache in requests from NXSL

### DIFF
--- a/src/agent/core/websvc.cpp
+++ b/src/agent/core/websvc.cpp
@@ -84,6 +84,7 @@ private:
    time_t m_lastRequestTime;
    Mutex m_mutex;
    DocumentType m_type;
+   uint32_t m_responseCode;
    union
    {
       pugi::xml_document *xml;
@@ -124,6 +125,8 @@ public:
 
    uint32_t getParams(StringList *params, NXCPMessage *response);
    uint32_t getList(const TCHAR *path, NXCPMessage *response);
+   const TCHAR *getText();
+   uint32_t getResponseCode();
    bool isDataExpired(uint32_t retentionTime) { return (time(nullptr) - m_lastRequestTime) >= retentionTime; }
    uint32_t query(const TCHAR *url, uint16_t requestMethod, const char *requestData, const char *userName, const char *password,
          WebServiceAuthType authType, struct curl_slist *headers, bool verifyPeer, bool verifyHost, bool followLocation, bool forcePlainTextParser, uint32_t requestTimeout);
@@ -145,6 +148,7 @@ ServiceEntry::ServiceEntry()
 {
    m_lastRequestTime = 0;
    m_type = DocumentType::NONE;
+   m_responseCode = 0;
 }
 
 /**
@@ -615,6 +619,22 @@ uint32_t ServiceEntry::getList(const TCHAR *path, NXCPMessage *response)
 }
 
 /**
+ * Get Text cached data
+ */
+const TCHAR *ServiceEntry::getText()
+{
+   return m_content.text;
+}
+
+/**
+ * Get HTTP response code
+ */
+uint32_t ServiceEntry::getResponseCode()
+{
+   return m_responseCode;
+}
+
+/**
  * Callback for processing data received from cURL
  */
 static size_t OnCurlDataReceived(char *ptr, size_t size, size_t nmemb, void *context)
@@ -725,7 +745,8 @@ retry:
             deleteContent();
             long responseCode;
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-            if (data.size() > 0 && (responseCode >= 200 && responseCode <= 299))
+            m_responseCode = static_cast<uint32_t>(responseCode);
+            if (data.size() > 0 && (m_responseCode >= 200 && m_responseCode <= 299))
             {
                data.write('\0');
 
@@ -793,7 +814,7 @@ retry:
                   MemFree(responseText);
                }
             }
-            else if ((responseCode >= 300) && (responseCode <= 399))
+            else if ((m_responseCode >= 300) && (m_responseCode <= 399))
             {
                char *redirectURL = nullptr;
                curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirectURL);
@@ -818,14 +839,14 @@ retry:
                }
                else
                {
-                  nxlog_debug_tag(DEBUG_TAG, 1, _T("ServiceEntry::query(%s): HTTP response %03d but redirect URL not set"), url, static_cast<uint32_t>(responseCode));
+                  nxlog_debug_tag(DEBUG_TAG, 1, _T("ServiceEntry::query(%s): HTTP response %03d but redirect URL not set"), url, m_responseCode);
                }
                rcc = ERR_MALFORMED_RESPONSE;
             }
             else
             {
-               if (responseCode < 200 || responseCode > 299)
-                  nxlog_debug_tag(DEBUG_TAG, 1, _T("ServiceEntry::query(%s): HTTP response %03d"), url, static_cast<uint32_t>(responseCode));
+               if (m_responseCode < 200 || m_responseCode > 299)
+                  nxlog_debug_tag(DEBUG_TAG, 1, _T("ServiceEntry::query(%s): HTTP response %03d"), url, m_responseCode);
                else if (data.size() == 0)
                   nxlog_debug_tag(DEBUG_TAG, 1, _T("ServiceEntry::query(%s): empty response"), url);
                m_type = DocumentType::NONE;
@@ -919,6 +940,10 @@ void QueryWebService(NXCPMessage* request, shared_ptr<AbstractCommSession> sessi
       MemFree(requestData);
       nxlog_debug_tag(DEBUG_TAG, 5, _T("QueryWebService(): Cache for URL \"%s\" updated"), url);
    }
+   else
+   {
+      nxlog_debug_tag(DEBUG_TAG, 5, _T("QueryWebService(): using cached result for \"%s\""), url);
+   }
    MemFree(url);
 
    NXCPMessage response(CMD_REQUEST_COMPLETED, request->getId());
@@ -965,186 +990,70 @@ void WebServiceCustomRequest(NXCPMessage* request, shared_ptr<AbstractCommSessio
    }
 
    TCHAR *url = request->getFieldAsString(VID_URL);
-   char *login = request->getFieldAsUtf8String(VID_LOGIN_NAME);
-   char *password = request->getFieldAsUtf8String(VID_PASSWORD);
-   char *requestData = request->getFieldAsUtf8String(VID_REQUEST_DATA);
-   bool hostVerify = request->getFieldAsBoolean(VID_VERIFY_HOST);
-   bool peerVerify = request->getFieldAsBoolean(VID_VERIFY_CERT);
-   bool followLocation = request->getFieldAsBoolean(VID_FOLLOW_LOCATION);
-   WebServiceAuthType authType = WebServiceAuthTypeFromInt(request->getFieldAsInt16(VID_AUTH_TYPE));
-   uint32_t requestTimeout = request->getFieldAsUInt32(VID_TIMEOUT);
-   const char *requestMethod = s_httpRequestMethods[requestMethodCode];
 
-   struct curl_slist *headers = nullptr;
-   uint32_t headerCount = request->getFieldAsUInt32(VID_NUM_HEADERS);
-   uint32_t fieldId = VID_HEADERS_BASE;
-   char header[2048];
-   for(uint32_t i = 0; i < headerCount; i++)
+   s_serviceCacheLock.lock();
+   shared_ptr<ServiceEntry> cachedEntry = s_serviceCache.getShared(url);
+   if (cachedEntry == nullptr)
    {
-      request->getFieldAsUtf8String(fieldId++, header, sizeof(header) - 4);   // header name
-      size_t len = strlen(header);
-      header[len++] = ':';
-      header[len++] = ' ';
-      request->getFieldAsUtf8String(fieldId++, &header[len], sizeof(header) - len); // value
-      headers = curl_slist_append(headers, header);
-      nxlog_debug_tag(DEBUG_TAG, 7, _T("WebServiceCustomRequest(): request header: %hs"), header);
+      cachedEntry = make_shared<ServiceEntry>();
+      s_serviceCache.set(url, cachedEntry);
+      nxlog_debug_tag(DEBUG_TAG, 5, _T("WebServiceCustomRequest(): Create new cache entry for URL %s"), url);
    }
+   s_serviceCacheLock.unlock();
 
-   NXCPMessage response(CMD_REQUEST_COMPLETED, request->getId());
-   uint32_t rcc = ERR_SUCCESS;
-   const TCHAR *errorText = _T("Curl request failure");
-   CURL *curl = curl_easy_init();
-   nxlog_debug_tag(DEBUG_TAG, 4, _T("WebServiceCustomRequest(): %hs %s"), requestMethod, url);
-   if (curl != nullptr)
+   cachedEntry->lock();
+   uint32_t retentionTime = request->getFieldAsUInt32(VID_RETENTION_TIME);
+   uint32_t result = ERR_SUCCESS;
+   if (cachedEntry->isDataExpired(retentionTime))
    {
-      char errbuf[CURL_ERROR_SIZE];
-      curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
-      curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-      curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-      curl_easy_setopt(curl, CURLOPT_HEADER, static_cast<long>(0));
-      curl_easy_setopt(curl, CURLOPT_TIMEOUT, static_cast<long>((requestTimeout != 0) ? requestTimeout : 10));
-      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &OnCurlDataReceived);
-      curl_easy_setopt(curl, CURLOPT_USERAGENT, "NetXMS Agent/" NETXMS_VERSION_STRING_A);
-      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, peerVerify ? 1 : 0);
-      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, hostVerify ? 2 : 0);
-      curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, requestMethod);
-      if (requestData != nullptr)
-      {
-         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, strlen(requestData));
-         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, requestData);
-      }
-      else if (requestMethodCode == static_cast<uint16_t>(HttpRequestMethod::_POST))
-      {
-         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);
-         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
-      }
-      EnableLibCURLUnexpectedEOFWorkaround(curl);
+      char *login = request->getFieldAsUtf8String(VID_LOGIN_NAME);
+      char *password = request->getFieldAsUtf8String(VID_PASSWORD);
+      char *requestData = request->getFieldAsUtf8String(VID_REQUEST_DATA);
+      WebServiceAuthType authType = WebServiceAuthTypeFromInt(request->getFieldAsInt16(VID_AUTH_TYPE));
 
-      if (authType == WebServiceAuthType::NONE)
+      struct curl_slist *headers = nullptr;
+      uint32_t headerCount = request->getFieldAsUInt32(VID_NUM_HEADERS);
+      uint32_t fieldId = VID_HEADERS_BASE;
+      char header[2048];
+      for(uint32_t i = 0; i < headerCount; i++)
       {
-         curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_NONE);
-      }
-      else if (authType == WebServiceAuthType::BEARER)
-      {
-#if HAVE_DECL_CURLOPT_XOAUTH2_BEARER
-         curl_easy_setopt(curl, CURLOPT_USERNAME, login);
-         curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, password);
-#else
-         rcc = ERR_NOT_IMPLEMENTED;
-         errorText = _T("OAuth 2.0 Bearer Access Token not implemented");
-#endif
-      }
-      else
-      {
-         curl_easy_setopt(curl, CURLOPT_USERNAME, login);
-         curl_easy_setopt(curl, CURLOPT_PASSWORD, password);
-         curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CurlAuthType(authType));
+         request->getFieldAsUtf8String(fieldId++, header, sizeof(header) - 4);   // header name
+         size_t len = strlen(header);
+         header[len++] = ':';
+         header[len++] = ' ';
+         request->getFieldAsUtf8String(fieldId++, &header[len], sizeof(header) - len); // value
+         headers = curl_slist_append(headers, header);
+         nxlog_debug_tag(DEBUG_TAG, 7, _T("WebServiceCustomRequest(): request header: %hs"), header);
       }
 
-     if (rcc == ERR_SUCCESS)
-     {
-        // Receiving buffer
-        ByteStream data(32768);
-        data.setAllocationStep(32768);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
+      result = cachedEntry->query(url, requestMethodCode, requestData, login, password, authType, headers,
+               request->getFieldAsBoolean(VID_VERIFY_CERT),
+               request->getFieldAsBoolean(VID_VERIFY_HOST),
+               request->getFieldAsBoolean(VID_FOLLOW_LOCATION),
+               request->getFieldAsBoolean(VID_FORCE_PLAIN_TEXT_PARSER),
+               request->getFieldAsUInt32(VID_TIMEOUT));
 
-#ifdef UNICODE
-        char *urlUtf8 = UTF8StringFromWideString(url);
-#else
-        char *urlUtf8 = UTF8StringFromMBString(url);
-#endif
-
-        int redirectLimit = 10;
-
-retry:
-        if (curl_easy_setopt(curl, CURLOPT_URL, urlUtf8) == CURLE_OK)
-        {
-           nxlog_debug_tag(DEBUG_TAG, 7, _T("WebServiceCustomRequest(): requesting URL %hs"), urlUtf8);
-           if (requestData != nullptr)
-              nxlog_debug_tag(DEBUG_TAG, 7, _T("WebServiceCustomRequest(): request data: %hs"), requestData);
-
-           CURLcode rc = curl_easy_perform(curl);
-           if (rc == CURLE_OK)
-           {
-              long responseCode;
-              curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-
-              if ((responseCode >= 300) && (responseCode <= 399))
-              {
-                 char *redirectURL = nullptr;
-                 curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirectURL);
-                 if (redirectURL != nullptr)
-                 {
-                    if (followLocation)
-                    {
-                       if (redirectLimit-- > 0)
-                       {
-                          nxlog_debug_tag(DEBUG_TAG, 6, _T("WebServiceCustomRequest(): follow redirect to %hs"), redirectURL);
-                          MemFree(urlUtf8);
-                          urlUtf8 = MemCopyStringA(redirectURL);
-                          data.clear();
-                          goto retry;
-                       }
-                       nxlog_debug_tag(DEBUG_TAG, 6, _T("H_CheckService(%hs): HTTP redirect to %hs, do not follow (redirect limit reached)"), url, redirectURL);
-                    }
-                    else
-                    {
-                       nxlog_debug_tag(DEBUG_TAG, 6, _T("H_CheckService(%hs): HTTP redirect to %hs, do not follow (forbidden)"), url, redirectURL);
-                    }
-                 }
-              }
-
-              response.setField(VID_WEBSVC_RESPONSE_CODE, static_cast<uint32_t>(responseCode));
-
-              data.write('\0');
-              const char *text = reinterpret_cast<const char*>(data.buffer());
-              response.setFieldFromUtf8String(VID_WEBSVC_RESPONSE, text);
-              errorText = _T("");
-
-              if (nxlog_get_debug_level_tag(DEBUG_TAG) >= 8)
-              {
-#ifdef UNICODE
-                 WCHAR *responseText = WideStringFromUTF8String(text);
-#else
-                 char *responseText = MBStringFromUTF8String(text);
-#endif
-                 for (TCHAR *s = responseText; *s != 0; s++)
-                    if (*s < ' ')
-                       *s = ' ';
-                 nxlog_debug_tag(DEBUG_TAG, 6, _T("WebServiceCustomRequest(): response data: %s"), responseText);
-                 MemFree(responseText);
-              }
-           }
-           else
-           {
-              nxlog_debug_tag(DEBUG_TAG, 1, _T("WebServiceCustomRequest(): call to curl_easy_perform failed (%d: %hs)"), rc, errbuf);
-              rcc = ERR_MALFORMED_RESPONSE;
-           }
-        }
-        else
-        {
-           nxlog_debug_tag(DEBUG_TAG, 1, _T("WebServiceCustomRequest(): curl_easy_setopt failed for CURLOPT_URL"));
-           rcc = ERR_UNSUPPORTED_METRIC;
-        }
-        MemFree(urlUtf8);
-     }
-      curl_easy_cleanup(curl);
+      curl_slist_free_all(headers);
+      MemFree(login);
+      MemFree(password);
+      MemFree(requestData);
+      nxlog_debug_tag(DEBUG_TAG, 5, _T("WebServiceCustomRequest(): Cache for URL \"%s\" updated (was expired, retention time %u)"), url, retentionTime);
    }
    else
    {
-      nxlog_debug_tag(DEBUG_TAG, 1, _T("WebServiceCustomRequest(): Get data from service: curl_init failed"));
-      rcc = ERR_INTERNAL_ERROR;
+      nxlog_debug_tag(DEBUG_TAG, 5, _T("WebServiceCustomRequest(): Cache for URL \"%s\" was used (retention time %u)"), url, retentionTime);
    }
 
-   response.setField(VID_WEBSVC_ERROR_TEXT, errorText);
-   response.setField(VID_RCC, rcc);
+   NXCPMessage response(CMD_REQUEST_COMPLETED, request->getId());
+   response.setField(VID_WEBSVC_RESPONSE, cachedEntry->getText());
+   response.setField(VID_WEBSVC_RESPONSE_CODE, cachedEntry->getResponseCode());
+   cachedEntry->unlock();
 
-   curl_slist_free_all(headers);
-   MemFree(login);
-   MemFree(password);
-   MemFree(requestData);
+   response.setField(VID_RCC, result);
+
    MemFree(url);
    session->sendMessage(&response);
+
    delete request;
 }
 

--- a/src/server/core/agent.cpp
+++ b/src/server/core/agent.cpp
@@ -609,7 +609,7 @@ uint32_t AgentConnectionEx::uninstallPolicy(uuid guid, const TCHAR *type, bool n
  * Make web service custom request
  */
 WebServiceCallResult *AgentConnectionEx::webServiceCustomRequest(HttpRequestMethod requestMethod, const TCHAR *url, uint32_t requestTimeout, const TCHAR *login, const TCHAR *password,
-         const WebServiceAuthType authType, const StringMap& headers, bool verifyCert, bool verifyHost, bool followLocation, const TCHAR *data)
+         const WebServiceAuthType authType, const StringMap& headers, bool verifyCert, bool verifyHost, bool followLocation, uint32_t cacheRetentionTime, const TCHAR *data)
 {
    WebServiceCallResult *result = new WebServiceCallResult();
    NXCPMessage msg(getProtocolVersion());
@@ -625,6 +625,7 @@ WebServiceCallResult *AgentConnectionEx::webServiceCustomRequest(HttpRequestMeth
    msg.setField(VID_VERIFY_CERT, verifyCert);
    msg.setField(VID_VERIFY_HOST, verifyHost);
    msg.setField(VID_FOLLOW_LOCATION, followLocation);
+   msg.setField(VID_RETENTION_TIME, cacheRetentionTime);
    headers.fillMessage(&msg, VID_HEADERS_BASE, VID_NUM_HEADERS);
    msg.setField(VID_REQUEST_DATA, data);
 

--- a/src/server/core/agent.cpp
+++ b/src/server/core/agent.cpp
@@ -611,6 +611,11 @@ uint32_t AgentConnectionEx::uninstallPolicy(uuid guid, const TCHAR *type, bool n
 WebServiceCallResult *AgentConnectionEx::webServiceCustomRequest(HttpRequestMethod requestMethod, const TCHAR *url, uint32_t requestTimeout, const TCHAR *login, const TCHAR *password,
          const WebServiceAuthType authType, const StringMap& headers, bool verifyCert, bool verifyHost, bool followLocation, uint32_t cacheRetentionTime, const TCHAR *data)
 {
+   // Cache only requests using cacheable methods per 4.2.1 of RFC 7231.
+   // Of those, netxms knows only GET.
+   if (cacheRetentionTime > 0) {
+      assert(requestMethod == HttpRequestMethod::_GET);
+   }
    WebServiceCallResult *result = new WebServiceCallResult();
    NXCPMessage msg(getProtocolVersion());
    uint32_t requestId = generateRequestId();

--- a/src/server/core/nxsl_classes.cpp
+++ b/src/server/core/nxsl_classes.cpp
@@ -1378,6 +1378,11 @@ static int BaseWebServiceRequestWithData(WebServiceHandle *websvc, int argc, NXS
          parameters.add(argv[i]->getValueAsCString());
    }
 
+   // GET, HEAD, OPTIONS, TRACE are cacheable per 4.2.1 of RFC 7231.
+   // Of those, netxms knows only GET.
+   if (requestMethod != HttpRequestMethod::_GET) {
+      acceptCached = false;
+   }
    WebServiceCallResult *response = websvc->first->makeCustomRequest(websvc->second, requestMethod, parameters, data, contentType, acceptCached);
    *result = vm->createValue(vm->createObject(&g_nxslWebServiceResponseClass, response));
    MemFree(data);

--- a/src/server/core/nxsl_classes.cpp
+++ b/src/server/core/nxsl_classes.cpp
@@ -1341,11 +1341,22 @@ static int BaseWebServiceRequestWithData(WebServiceHandle *websvc, int argc, NXS
       return NXSL_ERR_NOT_STRING;
    }
 
+   argc -= 2;
+   argv += 2;
+
+   bool acceptCached = false;
+   if (argc > 0 && !strcmp(argv[0]->getName(), "acceptCached"))
+   {
+      acceptCached = argv[0]->getValueAsBoolean();
+      argc -= 1;
+      argv += 1;
+   }
+
    StringList parameters;
-   for (int i = 2; i < argc; i++)
+   for (int i = 0; i < argc; i++)
       parameters.add(argv[i]->getValueAsCString());
 
-   WebServiceCallResult *response = websvc->first->makeCustomRequest(websvc->second, requestMethod, parameters, data, contentType);
+   WebServiceCallResult *response = websvc->first->makeCustomRequest(websvc->second, requestMethod, parameters, data, contentType, acceptCached);
    *result = vm->createValue(vm->createObject(&g_nxslWebServiceResponseClass, response));
    MemFree(data);
 
@@ -1358,11 +1369,19 @@ static int BaseWebServiceRequestWithData(WebServiceHandle *websvc, int argc, NXS
 static int BaseWebServiceRequestWithoutData(WebServiceHandle *websvc, int argc, NXSL_Value **argv,
       NXSL_Value **result, NXSL_VM *vm, const HttpRequestMethod requestMethod)
 {
+   bool acceptCached = false;
+   if (argc > 0 && argv[0]->getName() && !strcmp(argv[0]->getName(), "acceptCached"))
+   {
+      acceptCached = argv[0]->getValueAsBoolean();
+      argc -= 1;
+      argv += 1;
+   }
+
    StringList parameters;
    for (int i = 0 ; i < argc; i++)
       parameters.add(argv[i]->getValueAsCString());
 
-   WebServiceCallResult *response = websvc->first->makeCustomRequest(websvc->second, requestMethod, parameters, nullptr, nullptr);
+   WebServiceCallResult *response = websvc->first->makeCustomRequest(websvc->second, requestMethod, parameters, nullptr, nullptr, acceptCached);
    *result = vm->createValue(vm->createObject(&g_nxslWebServiceResponseClass, response));
 
    return 0;

--- a/src/server/core/websvc.cpp
+++ b/src/server/core/websvc.cpp
@@ -220,7 +220,7 @@ WebServiceCallResult *WebServiceDefinition::makeCustomRequest(shared_ptr<Node> n
    if (contentType != nullptr)
       headers.set(_T("Content-Type"), contentType);
 
-   return conn->webServiceCustomRequest(requestType, url, m_requestTimeout, m_login, m_password, m_authType, headers, isVerifyCertificate(), isVerifyHost(), isFollowLocation(), data);
+   return conn->webServiceCustomRequest(requestType, url, m_requestTimeout, m_login, m_password, m_authType, headers, isVerifyCertificate(), isVerifyHost(), isFollowLocation(), getCacheRetentionTime(), data);
 }
 
 /**

--- a/src/server/core/websvc.cpp
+++ b/src/server/core/websvc.cpp
@@ -199,7 +199,7 @@ uint32_t WebServiceDefinition::query(DataCollectionTarget *object, WebServiceReq
  * Make custom web service request using this definition. Returns agent WebServiceCallResult object.
  */
 WebServiceCallResult *WebServiceDefinition::makeCustomRequest(shared_ptr<Node> node, const HttpRequestMethod requestType,
-      const StringList& args, const TCHAR *data, const TCHAR *contentType) const
+      const StringList& args, const TCHAR *data, const TCHAR *contentType, bool acceptCached) const
 {
    shared_ptr<AgentConnectionEx> conn = node->getAgentConnection();
    if (conn == nullptr)
@@ -219,8 +219,7 @@ WebServiceCallResult *WebServiceDefinition::makeCustomRequest(shared_ptr<Node> n
    m_headers.forEach(ExpandHeaders, &context);
    if (contentType != nullptr)
       headers.set(_T("Content-Type"), contentType);
-
-   return conn->webServiceCustomRequest(requestType, url, m_requestTimeout, m_login, m_password, m_authType, headers, isVerifyCertificate(), isVerifyHost(), isFollowLocation(), getCacheRetentionTime(), data);
+   return conn->webServiceCustomRequest(requestType, url, m_requestTimeout, m_login, m_password, m_authType, headers, isVerifyCertificate(), isVerifyHost(), isFollowLocation(), acceptCached ? getCacheRetentionTime() : 0, data);
 }
 
 /**

--- a/src/server/include/nms_objects.h
+++ b/src/server/include/nms_objects.h
@@ -201,7 +201,7 @@ public:
    uint32_t uninstallPolicy(uuid guid, const TCHAR *type, bool newTypeFormatSupported);
 
    WebServiceCallResult *webServiceCustomRequest(HttpRequestMethod requestMEthod, const TCHAR *url, uint32_t requestTimeout, const TCHAR *login, const TCHAR *password,
-         const WebServiceAuthType authType, const StringMap& headers, bool verifyCert, bool verifyHost, bool followLocation, const TCHAR *data);
+         const WebServiceAuthType authType, const StringMap& headers, bool verifyCert, bool verifyHost, bool followLocation, uint32_t cacheRetentionTime, const TCHAR *data);
 
    void setTunnel(const shared_ptr<AgentTunnel>& tunnel) { m_tunnel = tunnel; }
 

--- a/src/server/include/nxcore_websvc.h
+++ b/src/server/include/nxcore_websvc.h
@@ -63,7 +63,7 @@ public:
    uint32_t query(DataCollectionTarget *object, WebServiceRequestType requestType, const TCHAR *path,
             const StringList& args, AgentConnection *conn, void *result) const;
    WebServiceCallResult *makeCustomRequest(shared_ptr<Node> node, const HttpRequestMethod requestMethod,
-         const StringList& args, const TCHAR *data, const TCHAR *contentType) const;
+         const StringList& args, const TCHAR *data, const TCHAR *contentType, bool acceptCached) const;
    void fillMessage(NXCPMessage *msg) const;
    void createExportRecord(StringBuffer &xml) const;
    json_t *toJson() const;

--- a/tests/nx-2488/db_patch.sql
+++ b/tests/nx-2488/db_patch.sql
@@ -1,0 +1,14 @@
+-- sqlite> .mode insert
+
+-- sqlite> .schema websvc_definitions
+-- CREATE TABLE websvc_definitions (    id integer not null,    guid varchar(36) not null,    name varchar(63) not null,    description varchar(2000) null,    url varchar(4000) null,    http_request_method integer not null,    request_data varchar(4000) null,    flags integer not null,    auth_type integer not null,    login varchar(255) null,    password varchar(255) null,    cache_retention_time integer not null,    request_timeout integer not null,    PRIMARY KEY(id) );
+-- sqlite> select * from websvc_definitions ;
+INSERT INTO "websvc_definitions" VALUES(1,'fd69a06e-082a-41e2-b4d8-e1132e23998c','nx2488webservice','','http://127.0.0.1:1500',0,'',7,0,'','',0,0);
+
+-- sqlite> .schema script_library
+-- CREATE TABLE script_library (   guid varchar(36) not null,   script_id integer not null,   script_name varchar(255) not null,   script_code varchar null,   PRIMARY KEY(script_id) );
+-- sqlite> select * from script_library where script_name = 'nx2488script';
+INSERT INTO "script_library" VALUES('c8336b1d-7a62-4b22-b400-2d27530bf21d',10003,'nx2488script',replace('node = FindObject("netxms"); // FIXME HARDCODE\nres1 = node.callWebService("nx2488webservice", "GET", "/");\nres2 = node.callWebService("nx2488webservice", "GET", "/");\nassert(res1.success);\nassert(res2.success);\nprintln(res1.document .. " vs " .. res2.document);\nassert(res1.document != res2.document);','\n',char(10)));
+
+-- Drop the "must change password" flag. Let the script use the default password with nxadm.
+UPDATE users SET flags = 0 WHERE name = 'admin';

--- a/tests/nx-2488/nx2488script.invalidating.a.nxsl
+++ b/tests/nx-2488/nx2488script.invalidating.a.nxsl
@@ -1,0 +1,17 @@
+// 1. Set the cache to either full or empty:
+// 1.a. populate the cache by GET request
+// 1.b. do nothing
+// 2. Invalidate cache by POST request
+// 3. Check if cache was invalidated, by GET request, its output should not match output of 1 and 2.
+
+node = FindObject("netxms"); // FIXME HARDCODE
+res1 = node.callWebService("nx2488webservice", "GET",  acceptCached: true, "/");
+res2 = node.callWebService("nx2488webservice", "POST", acceptCached: true, "/");
+res3 = node.callWebService("nx2488webservice", "GET",  acceptCached: true, "/");
+assert(res1.success);
+assert(res2.success);
+assert(res3.success);
+println(res1.document .. " vs " .. res2.document .. " vs " .. res3.document);
+assert(res1.document != res2.document);
+assert(res1.document != res3.document);
+assert(res2.document != res3.document);

--- a/tests/nx-2488/nx2488script.invalidating.a.nxsl
+++ b/tests/nx-2488/nx2488script.invalidating.a.nxsl
@@ -8,6 +8,9 @@ node = FindObject("netxms"); // FIXME HARDCODE
 res1 = node.callWebService("nx2488webservice", "GET",  acceptCached: true, "/");
 res2 = node.callWebService("nx2488webservice", "POST", acceptCached: true, "/");
 res3 = node.callWebService("nx2488webservice", "GET",  acceptCached: true, "/");
+println(res1.errorMessage);
+println(res2.errorMessage);
+println(res3.errorMessage);
 assert(res1.success);
 assert(res2.success);
 assert(res3.success);

--- a/tests/nx-2488/nx2488script.invalidating.b.nxsl
+++ b/tests/nx-2488/nx2488script.invalidating.b.nxsl
@@ -1,0 +1,13 @@
+// 1. Set the cache to either full or empty:
+// 1.a. populate the cache by GET request
+// 1.b. do nothing
+// 2. Invalidate cache by POST request
+// 3. Check if cache was invalidated, by GET request, its output should not match output of 1 and 2.
+
+node = FindObject("netxms"); // FIXME HARDCODE
+res2 = node.callWebService("nx2488webservice", "POST", acceptCached: true, "/");
+res3 = node.callWebService("nx2488webservice", "GET",  acceptCached: true, "/");
+assert(res2.success);
+assert(res3.success);
+println(res2.document .. " vs " .. res3.document);
+assert(res2.document != res3.document);

--- a/tests/nx-2488/nx2488script.invalidating.b.nxsl
+++ b/tests/nx-2488/nx2488script.invalidating.b.nxsl
@@ -7,6 +7,8 @@
 node = FindObject("netxms"); // FIXME HARDCODE
 res2 = node.callWebService("nx2488webservice", "POST", acceptCached: true, "/");
 res3 = node.callWebService("nx2488webservice", "GET",  acceptCached: true, "/");
+println(res2.errorMessage);
+println(res3.errorMessage);
 assert(res2.success);
 assert(res3.success);
 println(res2.document .. " vs " .. res3.document);

--- a/tests/nx-2488/nx2488script.nxsl
+++ b/tests/nx-2488/nx2488script.nxsl
@@ -1,0 +1,7 @@
+node = FindObject("netxms"); // FIXME HARDCODE
+res1 = node.callWebService("nx2488webservice", "GET", "/");
+res2 = node.callWebService("nx2488webservice", "GET", "/");
+assert(res1.success);
+assert(res2.success);
+println(res1.document .. " vs " .. res2.document);
+assert(res1.document != res2.document);

--- a/tests/nx-2488/nx2488script.nxsl
+++ b/tests/nx-2488/nx2488script.nxsl
@@ -1,6 +1,8 @@
 node = FindObject("netxms"); // FIXME HARDCODE
 res1 = node.callWebService("nx2488webservice", "GET", "/");
 res2 = node.callWebService("nx2488webservice", "GET", "/");
+println(res1.errorMessage);
+println(res2.errorMessage);
 assert(res1.success);
 assert(res2.success);
 println(res1.document .. " vs " .. res2.document);

--- a/tests/nx-2488/test-websvc-caching
+++ b/tests/nx-2488/test-websvc-caching
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+MYDIR=$(dirname "$(readlink -f "$0")")
+
+# Setup:
+# Server has script in the library.
+# Web service is registered. "Process response as plain text" option is set.
+# Trivial web server returning unix timestamp with fractional part is running.
+killall nc || true
+killall netxmsd || true
+killall nxagentd || true
+
+mv /usr/local/var/lib/netxms/*.db /tmp
+nxdbmgr init
+
+sqlite3 /usr/local/var/lib/netxms/netxms.db < "$MYDIR"/db_patch.sql
+nohup "$MYDIR"/trivial-web-server &
+nxagentd -d -D7
+netxmsd -d -D7
+sleep 5 # Wait for netxmsd to initialize
+
+# Test 1: with caching disabled
+# Runs web service request twice and succeeds only if results are different
+# Should succeed.
+nxadm -uadmin -pnetxms -s nx2488script
+
+# Test 2: with caching enabled
+# Patch DB to enable caching.
+killall netxmsd
+sleep 15 # Wait for netxmsd to stop and unlock the database
+echo "UPDATE websvc_definitions SET cache_retention_time = 1 WHERE name = 'nx2488webservice';" \
+| sqlite3 /usr/local/var/lib/netxms/netxms.db
+netxmsd -d -D7
+sleep 5 # Wait for netxmsd to initialize
+
+# The script should fail this time.
+! nxadm -uadmin -pnetxms -s nx2488script
+killall netxmsd
+killall nxagentd
+killall nc

--- a/tests/nx-2488/test-websvc-caching
+++ b/tests/nx-2488/test-websvc-caching
@@ -47,17 +47,36 @@ function setAcceptCached() {
    | sqlite3 /usr/local/var/lib/netxms/netxms.db
 }
 
+function loadAgent() {
+   > /usr/local/var/lib/netxms/netxmsd.log
+   > /usr/local/var/lib/netxms/nxagentd.log
+   netxmsd -d -D7 # or: nohup rr record netxmsd -S -D7 &>/tmp/rr-netxmsd.out &
+   # Wait for netxmsd to initialize
+   echo -n 'Waiting for netxmsd to connect to agent: '
+   while ! grep -q "Session registered (control=true, master=true)" /usr/local/var/lib/netxms/nxagentd.log; do
+      sleep 1
+      echo -n .
+   done
+   echo
+   sleep 1 # extra - no idea how to replace it with a check
+}
+
 function runTest() {
    expectRetCode=${1:-0}
-   netxmsd -d -D7 # or: nohup rr record netxmsd -S -D7 &>/tmp/rr-netxmsd.out & sleep 60
-   sleep 5 # Wait for netxmsd to initialize
+   loadAgent
    set +e
    OUTPUT=$(nxadm -uadmin -pnetxms -s nx2488script | tee)
    RET=$?
    set -e
    echo "RC $RET, output: $OUTPUT"
    killall netxmsd rr &>/dev/null || true
-   sleep 15 # Wait for netxmsd to stop and unlock the database
+   # Wait for netxmsd to stop and unlock the database
+   echo -n 'Waiting for netxmsd to stop and unlock the database: '
+   while pgrep netxmsd >/dev/null; do
+      sleep 1
+      echo -n .
+   done
+   echo
    [[ "$RET" == "$expectRetCode" ]]
    [[ "$OUTPUT" != '' ]]
 }
@@ -82,15 +101,18 @@ function runInvalidationTest() {
 
 
       expectRetCode=0
-      netxmsd -d -D7 # or: nohup rr record netxmsd -S -D7 &>/tmp/rr-netxmsd.out & sleep 60
-      sleep 5 # Wait for netxmsd to initialize
+      loadAgent
+
       set +e
       OUTPUT=$(nxadm -uadmin -pnetxms -s nx2488script | tee)
       RET=$?
       set -e
       echo "RC $RET, output: $OUTPUT"
       killall netxmsd rr &>/dev/null || true
-      sleep 15 # Wait for netxmsd to stop and unlock the database
+      # Wait for netxmsd to stop and unlock the database
+      while pgrep netxmsd >/dev/null; do
+         sleep 1
+      done
       [[ "$RET" == "$expectRetCode" ]]
       [[ "$OUTPUT" != '' ]]
    done
@@ -109,7 +131,14 @@ nxdbmgr init
 
 sqlite3 /usr/local/var/lib/netxms/netxms.db < "$MYDIR"/db_patch.sql
 nohup "$MYDIR"/trivial-web-server &>/dev/null &
+> /usr/local/var/lib/netxms/nxagentd.log
 nxagentd -d -D7
+echo -n 'Waiting for agent to start: '
+while ! grep -q 'NetXMS Agent started' /usr/local/var/lib/netxms/nxagentd.log; do
+   sleep 1
+   echo -n .
+done
+echo
 
 # Caching can be enabled and disabled with a named boolean parameter 'acceptCached' of callWebService().
 # Cache retention duration is set in web service definition.

--- a/tests/nx-2488/test-websvc-caching
+++ b/tests/nx-2488/test-websvc-caching
@@ -2,11 +2,45 @@
 set -euo pipefail
 MYDIR=$(dirname "$(readlink -f "$0")")
 
+function setRetentionTime() {
+   retentionTime="$1"
+   echo "UPDATE websvc_definitions SET cache_retention_time = $retentionTime WHERE name = 'nx2488webservice';" \
+   | sqlite3 /usr/local/var/lib/netxms/netxms.db
+}
+
+function setAcceptCached() {
+   acceptCached="$1"
+   (
+   echo -n "UPDATE script_library SET script_code = replace('"
+   cat "$MYDIR"/nx2488script.nxsl \
+   | sed 's/$/\\n/g' | tr -d '\n' \
+   | sed -e 's|"GET",|& acceptCached: '"$acceptCached"',|g' \
+   ;
+   echo "','\\n',char(10))"
+   ) \
+   | sqlite3 /usr/local/var/lib/netxms/netxms.db
+}
+
+function runTest() {
+   expectRetCode=${1:-0}
+   netxmsd -d -D7
+   sleep 5 # Wait for netxmsd to initialize
+   set +e
+   OUTPUT=$(nxadm -uadmin -pnetxms -s nx2488script | tee)
+   RET=$?
+   set -e
+   echo "RC $RET, output: $OUTPUT"
+   killall netxmsd
+   sleep 15 # Wait for netxmsd to stop and unlock the database
+   [[ "$RET" == "$expectRetCode" ]]
+   [[ "$OUTPUT" != '' ]]
+}
+
 # Setup:
 # Server has script in the library.
 # Web service is registered. "Process response as plain text" option is set.
 # Trivial web server returning unix timestamp with fractional part is running.
-killall nc || true
+killall trivial-web-server nc || true
 killall netxmsd || true
 killall nxagentd || true
 
@@ -14,27 +48,58 @@ mv /usr/local/var/lib/netxms/*.db /tmp
 nxdbmgr init
 
 sqlite3 /usr/local/var/lib/netxms/netxms.db < "$MYDIR"/db_patch.sql
-nohup "$MYDIR"/trivial-web-server &
+nohup "$MYDIR"/trivial-web-server &>/dev/null &
 nxagentd -d -D7
-netxmsd -d -D7
-sleep 5 # Wait for netxmsd to initialize
 
-# Test 1: with caching disabled
-# Runs web service request twice and succeeds only if results are different
-# Should succeed.
-nxadm -uadmin -pnetxms -s nx2488script
+# Caching can be enabled and disabled with a named boolean parameter 'acceptCached' of callWebService().
+# Cache retention duration is set in web service definition.
+# nx2488script runs web service request twice and succeeds only if results are different
 
-# Test 2: with caching enabled
-# Patch DB to enable caching.
-killall netxmsd
-sleep 15 # Wait for netxmsd to stop and unlock the database
-echo "UPDATE websvc_definitions SET cache_retention_time = 1 WHERE name = 'nx2488webservice';" \
-| sqlite3 /usr/local/var/lib/netxms/netxms.db
-netxmsd -d -D7
-sleep 5 # Wait for netxmsd to initialize
+# Case 1
+# acceptCached: not specified (implied: false)
+# Cache retention duration: 0 (seconds)
+# Expected results: no caching; two requests return different results and the script succeeds.
+setRetentionTime 0
+runTest
 
-# The script should fail this time.
-! nxadm -uadmin -pnetxms -s nx2488script
-killall netxmsd
+# Case 2
+# acceptCached: not specified (implied: false)
+# Cache retention duration: 1 (seconds)
+# Expected results: no caching; two requests return different results and the script succeeds.
+setRetentionTime 1
+runTest
+
+# Case 3
+# acceptCached: false
+# Cache retention duration: 0 (seconds)
+# Expected results: no caching; two requests return different results and the script succeeds.
+setAcceptCached false
+setRetentionTime 0
+runTest
+
+# Case 4
+# acceptCached: false
+# Cache retention duration: 1 (seconds)
+# Expected results: no caching; two requests return different results and the script succeeds.
+setAcceptCached false
+setRetentionTime 1
+runTest
+
+# Case 5
+# acceptCached: true
+# Cache retention duration: 0 (seconds)
+# Expected results: no caching; two requests return different results and the script succeeds.
+setAcceptCached true
+setRetentionTime 0
+runTest
+
+# Case 6
+# acceptCached: true
+# Cache retention duration: 1 (seconds)
+# Expected results: caching; two requests return same results and the script fails.
+setAcceptCached true
+setRetentionTime 1
+runTest 118
+
 killall nxagentd
 killall nc

--- a/tests/nx-2488/test-websvc-caching
+++ b/tests/nx-2488/test-websvc-caching
@@ -62,6 +62,40 @@ function runTest() {
    [[ "$OUTPUT" != '' ]]
 }
 
+function runInvalidationTest() {
+   # 1. Set the cache to either full or empty:
+   # 1.a. populate the cache by GET request
+   # 1.b. do nothing
+   # 2. Invalidate cache by POST request
+   # 3. Check if cache was invalidated, by GET request, its output should not match output of 1 and 2.
+   setRetentionTime 1
+
+   for subcase in a b; do
+      (
+      echo -n "UPDATE script_library SET script_code = replace('"
+      cat "$MYDIR"/nx2488script.invalidating."$subcase".nxsl \
+      | sed 's/$/\\n/g' | tr -d '\n' \
+      ;
+      echo "','\\n',char(10))"
+      ) \
+      | sqlite3 /usr/local/var/lib/netxms/netxms.db
+
+
+      expectRetCode=0
+      netxmsd -d -D7 # or: nohup rr record netxmsd -S -D7 &>/tmp/rr-netxmsd.out & sleep 60
+      sleep 5 # Wait for netxmsd to initialize
+      set +e
+      OUTPUT=$(nxadm -uadmin -pnetxms -s nx2488script | tee)
+      RET=$?
+      set -e
+      echo "RC $RET, output: $OUTPUT"
+      killall netxmsd rr &>/dev/null || true
+      sleep 15 # Wait for netxmsd to stop and unlock the database
+      [[ "$RET" == "$expectRetCode" ]]
+      [[ "$OUTPUT" != '' ]]
+   done
+}
+
 # Setup:
 # Server has script in the library.
 # Web service is registered. "Process response as plain text" option is set.
@@ -141,6 +175,10 @@ for argPosition in post2 post3; do
    setRetentionTime 1
    runTest
 done
+
+# Case 7
+# Test cache invalidation by POST
+runInvalidationTest
 
 killall nxagentd
 killall nc

--- a/tests/nx-2488/test-websvc-caching
+++ b/tests/nx-2488/test-websvc-caching
@@ -128,11 +128,18 @@ done
 # Case 6
 # acceptCached: true
 # Cache retention duration: 1 (seconds)
-# Expected results: caching; two requests return same results and the script fails.
-for argPosition in "${argPositionFilterArray[@]}"; do
+
+# Expected results: caching since GET is cached; two requests return same results and the script fails.
+argPosition=get2
+setAcceptCached true "$argPosition"
+setRetentionTime 1
+runTest 118
+
+# Expected results: no caching since POST is not cached; two requests return same results and the script fails.
+for argPosition in post2 post3; do
    setAcceptCached true "$argPosition"
    setRetentionTime 1
-   runTest 118
+   runTest
 done
 
 killall nxagentd

--- a/tests/nx-2488/test-websvc-caching
+++ b/tests/nx-2488/test-websvc-caching
@@ -8,13 +8,39 @@ function setRetentionTime() {
    | sqlite3 /usr/local/var/lib/netxms/netxms.db
 }
 
+# The following helper functions turn this
+#     node.callWebService("nx2488webservice", "GET", "/")
+# into...
+function get1() {
+   # node.callWebService("nx2488webservice",  acceptCached: false,"GET", "/")
+   sed -e 's|"GET",|acceptCached: '"$acceptCached"', &|g'
+}
+function get2() {
+   # node.callWebService("nx2488webservice", "GET", acceptCached: false, "/")
+   sed -e 's|"GET",|& acceptCached: '"$acceptCached"', |g'
+}
+function post1() {
+   sed -e 's|"GET",|acceptCached: '"$acceptCached"', "POST", "application/octet-stream", |g'
+}
+function post2() {
+   sed -e 's|"GET",|"POST", acceptCached: '"$acceptCached"', "application/octet-stream", |g'
+}
+function post3() {
+   sed -e 's|"GET",|"POST", "application/octet-stream", acceptCached: '"$acceptCached"', |g'
+}
+
+#argPositionFilterArray=( get{1,2} post{1,2,3} )
+argPositionFilterArray=( get2 post{2,3} ) # get1, post1 are broken for now
+
 function setAcceptCached() {
    acceptCached="$1"
+   argPositionFilter="$2"
+   echo "acceptCached: $acceptCached, argPositionFilter: $argPositionFilter"
    (
    echo -n "UPDATE script_library SET script_code = replace('"
    cat "$MYDIR"/nx2488script.nxsl \
    | sed 's/$/\\n/g' | tr -d '\n' \
-   | sed -e 's|"GET",|& acceptCached: '"$acceptCached"',|g' \
+   | "$argPositionFilter" \
    ;
    echo "','\\n',char(10))"
    ) \
@@ -23,14 +49,14 @@ function setAcceptCached() {
 
 function runTest() {
    expectRetCode=${1:-0}
-   netxmsd -d -D7
+   netxmsd -d -D7 # or: nohup rr record netxmsd -S -D7 &>/tmp/rr-netxmsd.out & sleep 60
    sleep 5 # Wait for netxmsd to initialize
    set +e
    OUTPUT=$(nxadm -uadmin -pnetxms -s nx2488script | tee)
    RET=$?
    set -e
    echo "RC $RET, output: $OUTPUT"
-   killall netxmsd
+   killall netxmsd rr &>/dev/null || true
    sleep 15 # Wait for netxmsd to stop and unlock the database
    [[ "$RET" == "$expectRetCode" ]]
    [[ "$OUTPUT" != '' ]]
@@ -40,9 +66,9 @@ function runTest() {
 # Server has script in the library.
 # Web service is registered. "Process response as plain text" option is set.
 # Trivial web server returning unix timestamp with fractional part is running.
-killall trivial-web-server nc || true
-killall netxmsd || true
-killall nxagentd || true
+killall nc &>/dev/null || true
+killall netxmsd &>/dev/null || true
+killall nxagentd &>/dev/null || true
 
 mv /usr/local/var/lib/netxms/*.db /tmp
 nxdbmgr init
@@ -73,33 +99,41 @@ runTest
 # acceptCached: false
 # Cache retention duration: 0 (seconds)
 # Expected results: no caching; two requests return different results and the script succeeds.
-setAcceptCached false
-setRetentionTime 0
-runTest
+for argPosition in "${argPositionFilterArray[@]}"; do
+   setAcceptCached false "$argPosition"
+   setRetentionTime 0
+   runTest
+done
 
 # Case 4
 # acceptCached: false
 # Cache retention duration: 1 (seconds)
 # Expected results: no caching; two requests return different results and the script succeeds.
-setAcceptCached false
-setRetentionTime 1
-runTest
+for argPosition in "${argPositionFilterArray[@]}"; do
+   setAcceptCached false "$argPosition"
+   setRetentionTime 1
+   runTest
+done
 
 # Case 5
 # acceptCached: true
 # Cache retention duration: 0 (seconds)
 # Expected results: no caching; two requests return different results and the script succeeds.
-setAcceptCached true
-setRetentionTime 0
-runTest
+for argPosition in "${argPositionFilterArray[@]}"; do
+   setAcceptCached true "$argPosition"
+   setRetentionTime 0
+   runTest
+done
 
 # Case 6
 # acceptCached: true
 # Cache retention duration: 1 (seconds)
 # Expected results: caching; two requests return same results and the script fails.
-setAcceptCached true
-setRetentionTime 1
-runTest 118
+for argPosition in "${argPositionFilterArray[@]}"; do
+   setAcceptCached true "$argPosition"
+   setRetentionTime 1
+   runTest 118
+done
 
 killall nxagentd
 killall nc

--- a/tests/nx-2488/trivial-web-server
+++ b/tests/nx-2488/trivial-web-server
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# This works only with ncat (aka nmap-ncat).
+nc -l -p 1500 -k -c 'echo "HTTP/1.1 200 OK"; echo "Content-Type: text/plain"; echo; date +%s.%N; echo -n . >'"$(tty)"
+
+# Fallback option for other netcat implementations.
+# Downside: between the laps, incoming connections fail.
+#while true ; do nc -l -p 1500 -c 'echo "HTTP/1.1 200 OK"; echo "Content-Type: text/plain"; echo; date +%s.%N'; echo -n .; done

--- a/tests/nx-2488/trivial-web-server
+++ b/tests/nx-2488/trivial-web-server
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # This works only with ncat (aka nmap-ncat).
-nc -l -p 1500 -k -c 'echo "HTTP/1.1 200 OK"; echo "Content-Type: text/plain"; echo; date +%s.%N; echo -n . >'"$(tty)"
+exec nc -l -p 1500 -k -c 'echo "HTTP/1.1 200 OK"; echo "Content-Type: text/plain"; echo; date +%s.%N; echo -n . >'"$(tty)"
 
 # Fallback option for other netcat implementations.
 # Downside: between the laps, incoming connections fail.


### PR DESCRIPTION
The code for using cached results was copied from QueryWebService().
This led to a lot of curl API using code to be dropped, for which I am a
bit worried that I might have overlooked some feature buried in it.

This suggests that QueryWebService() and WebServiceCustomRequest() could
benefit from a lot of code reuse.

An automated test was added: run tests/nx-2488/test-websvc-caching on a
fresh disposable install configured to use SQLite.