### PR TITLE
Add .clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Microsoft
+IndentWidth: 3
+AlignConsecutiveMacros: true


### PR DESCRIPTION
Base style chosen on the basis of having tried all the existing base styles and resulting in the least amount of changes proposed by
- clang-format -i $(find include src tests -name '*.cpp' -or -name '*.h' -or -name '*.hpp'  | grep -v zlib)
- clang-format-diff total amount on all Victor's commits in range release-5.0.0..d4346d7a5b23393b36e68c25ba63af0aeb6ddc6b

So far `git diff | wc -l` after the first command above returns 472975, so there's still a lot to tweak.