### PR TITLE
NX-2533: set $INPUT in scripts called from object tool

### DIFF
--- a/src/server/core/session.cpp
+++ b/src/server/core/session.cpp
@@ -11536,6 +11536,7 @@ void ClientSession::executeLibraryScript(const NXCPMessage& request)
                      m_scriptExecutorsLock.unlock();
 
                      SetupServerScriptVM(vm, object, shared_ptr<DCObjectInfo>());
+                     vm->setGlobalVariable("$INPUT", vm->createValue(new NXSL_HashMap(vm, &inputFields)));
                      WriteAuditLog(AUDIT_OBJECTS, true, m_userId, m_workstation, m_id, object->getId(), _T("Library script '%s' successfully executed"), maskedScript.cstr());
                      response.setField(VID_RCC, RCC_SUCCESS);
                      response.setField(VID_PROCESS_ID, executorId);

--- a/tests/integration/src/test/java/org/netxms/tests/ObjectToolsTest.java
+++ b/tests/integration/src/test/java/org/netxms/tests/ObjectToolsTest.java
@@ -35,62 +35,62 @@ import org.netxms.client.objecttools.ObjectToolDetails;
 public class ObjectToolsTest extends AbstractSessionTest
 {
    @Test
-	public void testGet() throws Exception
-	{
-		final NXCSession session = connectAndLogin();
-		
-		List<ObjectTool> tools = session.getObjectTools();
-		for(ObjectTool tool : tools)
-		{
-			System.out.println(" >>Tool>> " + tool.getId() + " " + tool.getName());
-		}
-		
-		session.disconnect();
-	}
+   public void testGet() throws Exception
+   {
+      final NXCSession session = connectAndLogin();
 
-   @Test
-	public void testGetDetails() throws Exception
-	{
-		final NXCSession session = connectAndLogin();
-		List <ObjectTool> allObjectTools = session.getObjectTools();
-		ObjectTool testObjectTool = null;
-      if (!allObjectTools.isEmpty()) {
-      testObjectTool = allObjectTools.get(0);
+      List<ObjectTool> tools = session.getObjectTools();
+      for(ObjectTool tool : tools)
+      {
+         System.out.println(" >>Tool>> " + tool.getId() + " " + tool.getName());
       }
-		ObjectToolDetails td = session.getObjectToolDetails(testObjectTool.getId());
-		System.out.println("Object tool details:");
-		System.out.println("   id = " + td.getId());
-		System.out.println("   name = " + td.getName());
-		System.out.println("   type = " + td.getToolType());
-		System.out.println("   OID = " + td.getSnmpOid());
-		System.out.println("   confirmation = " + td.getConfirmationText());
-		System.out.println("   columnCount = " + td.getColumns().size());
-		
-		session.disconnect();
-	}
-	
-   @Test
-	public void testGenerateId() throws Exception
-	{
-		final NXCSession session = connectAndLogin();
 
-		long id = session.generateObjectToolId();
-		assertFalse(id == 0);
-		
-		System.out.println("Object tool ID generated: " + id);
-		
-		session.disconnect();
-	}
-	
+      session.disconnect();
+   }
+
    @Test
-	public void testCreateAndDelete() throws Exception
-	{
+   public void testGetDetails() throws Exception
+   {
+      final NXCSession session = connectAndLogin();
+      List <ObjectTool> allObjectTools = session.getObjectTools();
+      ObjectTool testObjectTool = null;
+      if (!allObjectTools.isEmpty()) {
+         testObjectTool = allObjectTools.get(0);
+      }
+      ObjectToolDetails td = session.getObjectToolDetails(testObjectTool.getId());
+      System.out.println("Object tool details:");
+      System.out.println("   id = " + td.getId());
+      System.out.println("   name = " + td.getName());
+      System.out.println("   type = " + td.getToolType());
+      System.out.println("   OID = " + td.getSnmpOid());
+      System.out.println("   confirmation = " + td.getConfirmationText());
+      System.out.println("   columnCount = " + td.getColumns().size());
+
+      session.disconnect();
+   }
+
+   @Test
+   public void testGenerateId() throws Exception
+   {
+      final NXCSession session = connectAndLogin();
+
+      long id = session.generateObjectToolId();
+      assertFalse(id == 0);
+
+      System.out.println("Object tool ID generated: " + id);
+
+      session.disconnect();
+   }
+
+   @Test
+   public void testCreateAndDelete() throws Exception
+   {
       final NXCSession session = connectAndLogin();
 
       long id = session.generateObjectToolId();
       assertFalse(id == 0);
       System.out.println("Object tool ID generated: " + id);
-      
+
       ObjectToolDetails td = new ObjectToolDetails(id, ObjectTool.TYPE_LOCAL_COMMAND, "UnitTest");
       td.setData("ping %{10%(not a field)} -t %(address) -s %(size)");
       td.addInputField(new InputField("size", InputFieldType.NUMBER, "Size (bytes)", 0));
@@ -104,5 +104,5 @@ public class ObjectToolsTest extends AbstractSessionTest
       session.deleteObjectTool(id);
 
       session.disconnect();
-	}
+   }
 }


### PR DESCRIPTION
No test yet, hence draft status.

BTW, I am concerned about the very next line after the insertion.
Seems like it reports script successful execution too early.
```
WriteAuditLog(AUDIT_OBJECTS, true, m_userId, m_workstation, m_id, object->getId(), _T("Library script '%s' successfully executed"), maskedScript.cstr());
```
But we've just set a global variable for the VM (interpreter instance), it takes effect (seen in manual testing) and we haven't done implicitly anything which looks like execution or completion of the script.
I am not sure where to move that log statement.