### PR TITLE
implement secret filtering in logging system

### DIFF
--- a/include/nms_util.h
+++ b/include/nms_util.h
@@ -5772,6 +5772,8 @@ void LIBNETXMS_EXPORTABLE nxlog_debug_tag(const TCHAR *tag, int level, const TCH
 void LIBNETXMS_EXPORTABLE nxlog_debug_tag2(const TCHAR *tag, int level, const TCHAR *format, va_list args);
 void LIBNETXMS_EXPORTABLE nxlog_debug_tag_object(const TCHAR *tag, UINT32 objectId, int level, const TCHAR *format, ...);
 void LIBNETXMS_EXPORTABLE nxlog_debug_tag_object2(const TCHAR *tag, UINT32 objectId, int level, const TCHAR *format, va_list args);
+void LIBNETXMS_EXPORTABLE nxlog_add_secret(const TCHAR *value, time_t ttl = 0);
+void LIBNETXMS_EXPORTABLE nxlog_remove_secret(const TCHAR *value);
 bool LIBNETXMS_EXPORTABLE nxlog_set_rotation_policy(int rotationMode, UINT64 maxLogSize, int historySize, const TCHAR *dailySuffix);
 bool LIBNETXMS_EXPORTABLE nxlog_rotate();
 void LIBNETXMS_EXPORTABLE nxlog_set_debug_level(int level);

--- a/src/libnetxms/log.cpp
+++ b/src/libnetxms/log.cpp
@@ -33,6 +33,26 @@
 
 #define LOCAL_MSG_BUFFER_SIZE    1024
 
+struct Secret
+{
+   TCHAR *value;
+   time_t validTo;
+
+   Secret(const TCHAR *value, time_t ttl)
+   {
+      this->value = _tcsdup(value);
+      if (ttl > 0)
+         this->validTo = time(nullptr) + ttl;
+      else
+         this->validTo = 0;
+   }
+
+   ~Secret()
+   {
+      MemFree(value);
+   }
+};
+
 typedef Buffer<TCHAR, LOCAL_MSG_BUFFER_SIZE> msg_buffer_t;
 
 /**
@@ -82,6 +102,8 @@ static NxLogDebugWriter s_debugWriter = nullptr;
 static volatile DebugTagManager s_tagTree;
 static Mutex s_mutexDebugTagTreeWrite(MutexType::FAST);
 static NxLogRotationHook s_rotationHook = nullptr;
+static ObjectArray<Secret> s_secrets;
+static Mutex s_mutexSecrets(MutexType::FAST);
 
 /**
  * Swaps tag tree pointers and waits till reader count drops to 0
@@ -114,6 +136,35 @@ static inline void FormatString(msg_buffer_t& buffer, const TCHAR *format, va_li
    _vsntprintf(buffer, bufferSize, format, args2);
    buffer[bufferSize - 1] = 0;
    va_end(args2);
+}
+
+/**
+ * Filter secrets
+ */
+static void FilterSecrets(msg_buffer_t& buffer)
+{
+   s_mutexSecrets.lock();
+   time_t now = time(nullptr);
+   for(int i = s_secrets.size() - 1; i >= 0; i--)
+   {
+      Secret *s = s_secrets.get(i);
+      if ((s->validTo > 0) && (s->validTo < now))
+      {
+         s_secrets.remove(i);
+         continue;
+      }
+
+      TCHAR *p = buffer;
+      while((p = _tcsstr(p, s->value)) != nullptr)
+      {
+         size_t len = _tcslen(s->value);
+         for (int i = 0; i < len; i++) {
+            *(p + i) = _T('*');
+         }
+         p += len;
+      }
+   }
+   s_mutexSecrets.unlock();
 }
 
 /**
@@ -158,6 +209,39 @@ void LIBNETXMS_EXPORTABLE nxlog_set_debug_level(int level)
    s_tagTree.secondary->setRootDebugLevel(level); // Update the previously active tree
    InterlockedDecrement(&s_tagTree.secondary->m_writers);
    s_mutexDebugTagTreeWrite.unlock();
+}
+
+/**
+ * Add secret token
+ */
+void LIBNETXMS_EXPORTABLE nxlog_add_secret(const TCHAR *value, time_t ttl)
+{
+   if (_tcslen(value) > 0)
+   {
+      s_mutexSecrets.lock();
+      s_secrets.add(new Secret(value, ttl));
+      s_mutexSecrets.unlock();
+   }
+}
+
+/**
+ * Remove secret token
+ */
+void LIBNETXMS_EXPORTABLE nxlog_remove_secret(const TCHAR *value)
+{
+   if (_tcslen(value) > 0)
+   {
+      s_mutexSecrets.lock();
+      for(int i = s_secrets.size() - 1; i >= 0; i--)
+      {
+         Secret *s = s_secrets.get(i);
+         if (!_tcscmp(s->value, value)) {
+            s_secrets.remove(i);
+            break;
+         }
+      }
+      s_mutexSecrets.unlock();
+   }
 }
 
 /**
@@ -1209,6 +1293,7 @@ static void WriteLog(int16_t severity, const TCHAR *tag, const TCHAR *format, va
    {
       msg_buffer_t message(LOCAL_MSG_BUFFER_SIZE);
       FormatString(message, format, args);
+      FilterSecrets(message);
 
 #ifdef _WIN32
       const TCHAR *strings = message.buffer();
@@ -1288,12 +1373,16 @@ static void WriteLog(int16_t severity, const TCHAR *tag, const TCHAR *format, va
       }
 
       TCHAR tagf[20];
+      msg_buffer_t message(LOCAL_MSG_BUFFER_SIZE);
+      FormatString(message, format, args);
+      FilterSecrets(message);
+
       s_mutexLogAccess.lock();
       if (tag != NULL)
          _ftprintf(stderr, _T("<%d>[%s] "), level, FormatTag(tag, tagf));
       else
          _ftprintf(stderr, _T("<%d> "), level);
-      _vftprintf(stderr, format, args);
+      _fputts(message, stderr);
       _fputtc(_T('\n'), stderr);
       fflush(stderr);
       s_mutexLogAccess.unlock();
@@ -1302,6 +1391,7 @@ static void WriteLog(int16_t severity, const TCHAR *tag, const TCHAR *format, va
    {
       msg_buffer_t message(LOCAL_MSG_BUFFER_SIZE);
       FormatString(message, format, args);
+      FilterSecrets(message);
       WriteLogToFile(severity, tag, message);
    }
 }

--- a/src/libnetxms/log.cpp
+++ b/src/libnetxms/log.cpp
@@ -40,7 +40,7 @@ struct Secret
 
    Secret(const TCHAR *value, time_t ttl)
    {
-      this->value = _tcsdup(value);
+      this->value = MemCopyString(value);
       if (ttl > 0)
          this->validTo = time(nullptr) + ttl;
       else
@@ -103,7 +103,6 @@ static volatile DebugTagManager s_tagTree;
 static Mutex s_mutexDebugTagTreeWrite(MutexType::FAST);
 static NxLogRotationHook s_rotationHook = nullptr;
 static ObjectArray<Secret> s_secrets;
-static Mutex s_mutexSecrets(MutexType::FAST);
 
 /**
  * Swaps tag tree pointers and waits till reader count drops to 0
@@ -143,7 +142,6 @@ static inline void FormatString(msg_buffer_t& buffer, const TCHAR *format, va_li
  */
 static void FilterSecrets(msg_buffer_t& buffer)
 {
-   s_mutexSecrets.lock();
    time_t now = time(nullptr);
    for(int i = s_secrets.size() - 1; i >= 0; i--)
    {
@@ -164,7 +162,6 @@ static void FilterSecrets(msg_buffer_t& buffer)
          p += len;
       }
    }
-   s_mutexSecrets.unlock();
 }
 
 /**
@@ -218,9 +215,9 @@ void LIBNETXMS_EXPORTABLE nxlog_add_secret(const TCHAR *value, time_t ttl)
 {
    if (_tcslen(value) > 0)
    {
-      s_mutexSecrets.lock();
+      s_mutexLogAccess.lock();
       s_secrets.add(new Secret(value, ttl));
-      s_mutexSecrets.unlock();
+      s_mutexLogAccess.unlock();
    }
 }
 
@@ -231,7 +228,7 @@ void LIBNETXMS_EXPORTABLE nxlog_remove_secret(const TCHAR *value)
 {
    if (_tcslen(value) > 0)
    {
-      s_mutexSecrets.lock();
+      s_mutexLogAccess.lock();
       for(int i = s_secrets.size() - 1; i >= 0; i--)
       {
          Secret *s = s_secrets.get(i);
@@ -240,7 +237,7 @@ void LIBNETXMS_EXPORTABLE nxlog_remove_secret(const TCHAR *value)
             break;
          }
       }
-      s_mutexSecrets.unlock();
+      s_mutexLogAccess.unlock();
    }
 }
 

--- a/src/server/core/webapi_auth.cpp
+++ b/src/server/core/webapi_auth.cpp
@@ -80,6 +80,7 @@ static inline void CompleteLogin(json_t *response, const LoginRequest& loginRequ
    UserAuthenticationToken token = IssueAuthenticationToken(loginRequest.userId, AUTH_TOKEN_VALIDITY_TIME, AuthenticationTokenType::EPHEMERAL, _T("Web access token"))->token;
    char encodedToken[64];
    json_object_set_new(response, "token", json_string(token.toStringA(encodedToken)));
+   nxlog_add_secret(token.toString(), AUTH_TOKEN_VALIDITY_TIME);
    json_object_set_new(response, "userId", json_integer(loginRequest.userId));
    json_object_set_new(response, "systemAccessRights", json_integer(loginRequest.systemAccessRights));
    json_object_set_new(response, "changePassword", json_boolean(loginRequest.changePassword));
@@ -168,6 +169,8 @@ int H_Login(Context *context)
       MemFree(username);
       return 400;
    }
+
+   nxlog_add_secret(password);
 
 #if WITH_PRIVATE_EXTENSIONS
    if (!IsComponentRegistered(_T("EMCL")) && !IsComponentRegistered(_T("WEBAPI")))


### PR DESCRIPTION
Add secret management functions to prevent sensitive data from appearing in logs:
- nxlog_add_secret(): register secret values with optional TTL
- nxlog_remove_secret(): remove previously registered secrets
- automatic filtering replaces secret values with asterisks in log output
- integrated with web API authentication to filter passwords and tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for registering sensitive values that should be masked in log messages.
  * Secret values can optionally expire automatically after a specified time.
  * Added the ability to remove registered secrets from log masking.
  * Applied masking consistently across supported logging outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->