### PR TITLE
Enable SSL certificate verification for AI provider connections

### DIFF
--- a/src/server/core/ai_core.cpp
+++ b/src/server/core/ai_core.cpp
@@ -2154,6 +2154,7 @@ void ShowAIProviders(ServerConsole *console)
       ConsolePrintf(console, L"Type            : %s\n", typeName);
       ConsolePrintf(console, L"Model           : %hs\n", p->getModelName());
       ConsolePrintf(console, L"URL             : %hs\n", p->getUrl());
+      ConsolePrintf(console, L"Verify SSL      : %s\n", p->isSSLVerificationEnabled() ? L"yes" : L"no");
 
       StringList *slots = providerSlots[p];
       StringBuffer slotList;
@@ -2319,6 +2320,7 @@ bool InitAIAssistant()
          config.topP = entry->getSubEntryValueAsInt(_T("TopP"), 0, -1);
          config.contextSize = entry->getSubEntryValueAsInt(_T("ContextSize"), 0, 32768);
          config.timeout = entry->getSubEntryValueAsInt(_T("Timeout"), 0, 180);
+         config.verifySSL = entry->getSubEntryValueAsBoolean(_T("VerifySSL"), true);
 
          // Create provider
          shared_ptr<LLMProvider> provider = CreateLLMProvider(config);
@@ -2351,8 +2353,8 @@ bool InitAIAssistant()
             case LLMProviderType::ANTHROPIC: typeName = _T("Anthropic"); break;
             default: typeName = _T("Ollama"); break;
          }
-         nxlog_debug_tag(DEBUG_TAG, 3, _T("Configured AI provider \"%s\" (type=%s, model=%hs, slots=%s)"),
-            config.name.cstr(), typeName, config.model, slotsStr);
+         nxlog_debug_tag(DEBUG_TAG, 3, _T("Configured AI provider \"%s\" (type=%s, model=%hs, slots=%s, verifySSL=%s)"),
+            config.name.cstr(), typeName, config.model, slotsStr, config.verifySSL ? _T("yes") : _T("no"));
       }
    }
 

--- a/src/server/core/ai_provider.cpp
+++ b/src/server/core/ai_provider.cpp
@@ -128,8 +128,8 @@ json_t *LLMProvider::doHttpRequest(json_t *requestData)
    curl_easy_setopt(curl, CURLOPT_HEADER, (long)0);
    curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_config.timeout);
    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ByteStream::curlWriteFunction);
-   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, (long)0);
-   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (long)0);
+   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_config.verifySSL ? (long)2 : (long)0);
+   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_config.verifySSL ? (long)1 : (long)0);
    curl_easy_setopt(curl, CURLOPT_USERAGENT, "NetXMS Server/" NETXMS_VERSION_STRING_A);
 
    char *postData = (requestData != nullptr) ? json_dumps(requestData, 0) : MemCopyStringA("{}");

--- a/src/server/include/ai_provider.h
+++ b/src/server/include/ai_provider.h
@@ -50,6 +50,7 @@ struct NXCORE_EXPORTABLE LLMProviderConfig
    double topP;           // -1 = not set
    int contextSize;
    int timeout;           // seconds
+   bool verifySSL;        // verify peer certificate for HTTPS connections
 
    LLMProviderConfig()
    {
@@ -61,6 +62,7 @@ struct NXCORE_EXPORTABLE LLMProviderConfig
       topP = -1.0;
       contextSize = 32768;
       timeout = 180;
+      verifySSL = true;
    }
 };
 
@@ -111,6 +113,7 @@ public:
    double getTemperature() const { return m_config.temperature; }
    double getTopP() const { return m_config.topP; }
    LLMProviderType getType() const { return m_config.type; }
+   bool isSSLVerificationEnabled() const { return m_config.verifySSL; }
    int64_t getTotalRequests() const { return m_totalRequests; }
    int64_t getTotalInputTokens() const { return m_totalInputTokens; }
    int64_t getTotalOutputTokens() const { return m_totalOutputTokens; }


### PR DESCRIPTION
## Summary
- Added per-provider `VerifySSL` configuration option (default: `true`) that controls TLS certificate validation for HTTPS connections to LLM providers
- Previously SSL verification was unconditionally disabled (`CURLOPT_SSL_VERIFYPEER=0`, `CURLOPT_SSL_VERIFYHOST=0`)
- Added `isSSLVerificationEnabled()` accessor and display in `show ai-providers` console command

## Configuration
```
[AI/Provider/MyProvider]
Type = openai
URL = https://api.openai.com/v1/chat/completions
Model = gpt-4
Token = sk-...
VerifySSL = yes   # default, can be set to "no" for self-signed certs
```

## Test plan
- [ ] Verify cloud providers (OpenAI, Anthropic) work with default `VerifySSL=true`
- [ ] Verify Ollama over HTTP (localhost) is unaffected
- [ ] Verify `VerifySSL=no` allows self-signed certificate endpoints
- [ ] Verify `show ai-providers` console command displays SSL verification status

https://claude.ai/code/session_01BTtL4BF62wd9nH42CjLyoy