### PR TITLE
Implement Windows file permissions conversion using ACL

### DIFF
--- a/src/agent/subagents/filemgr/filemgr.cpp
+++ b/src/agent/subagents/filemgr/filemgr.cpp
@@ -1050,11 +1050,79 @@ static void CH_GetFileDetails(NXCPMessage *request, NXCPMessage *response, Abstr
 /**
  * Convert file permissions into internal format
  */
+#ifdef _WIN32
+static uint16_t ConvertFilePermissions(const TCHAR *path)
+{
+   uint16_t accessRights = 0;
+
+   PSID ownerSid = nullptr;
+   PSID groupSid = nullptr;
+   PACL dacl = nullptr;
+   PSECURITY_DESCRIPTOR sd = nullptr;
+   if (GetNamedSecurityInfo(path, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+         &ownerSid, &groupSid, &dacl, nullptr, &sd) != ERROR_SUCCESS)
+      return 0;
+
+   if (dacl != nullptr)
+   {
+      TRUSTEE trustee;
+      ACCESS_MASK effectiveRights;
+
+      // Owner permissions
+      if (ownerSid != nullptr)
+      {
+         BuildTrusteeWithSid(&trustee, ownerSid);
+         if (GetEffectiveRightsFromAcl(dacl, &trustee, &effectiveRights) == ERROR_SUCCESS)
+         {
+            if (effectiveRights & FILE_GENERIC_READ)
+               accessRights |= (1 << 0);
+            if (effectiveRights & FILE_GENERIC_WRITE)
+               accessRights |= (1 << 1);
+            if (effectiveRights & FILE_GENERIC_EXECUTE)
+               accessRights |= (1 << 2);
+         }
+      }
+
+      // Group permissions
+      if (groupSid != nullptr)
+      {
+         BuildTrusteeWithSid(&trustee, groupSid);
+         if (GetEffectiveRightsFromAcl(dacl, &trustee, &effectiveRights) == ERROR_SUCCESS)
+         {
+            if (effectiveRights & FILE_GENERIC_READ)
+               accessRights |= (1 << 3);
+            if (effectiveRights & FILE_GENERIC_WRITE)
+               accessRights |= (1 << 4);
+            if (effectiveRights & FILE_GENERIC_EXECUTE)
+               accessRights |= (1 << 5);
+         }
+      }
+
+      // Everyone permissions
+      SID_IDENTIFIER_AUTHORITY worldAuthority = SECURITY_WORLD_SID_AUTHORITY;
+      PSID everyoneSid = nullptr;
+      if (AllocateAndInitializeSid(&worldAuthority, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, &everyoneSid))
+      {
+         BuildTrusteeWithSid(&trustee, everyoneSid);
+         if (GetEffectiveRightsFromAcl(dacl, &trustee, &effectiveRights) == ERROR_SUCCESS)
+         {
+            if (effectiveRights & FILE_GENERIC_READ)
+               accessRights |= (1 << 6);
+            if (effectiveRights & FILE_GENERIC_WRITE)
+               accessRights |= (1 << 7);
+            if (effectiveRights & FILE_GENERIC_EXECUTE)
+               accessRights |= (1 << 8);
+         }
+         FreeSid(everyoneSid);
+      }
+   }
+
+   LocalFree(sd);
+   return accessRights;
+}
+#else
 static uint16_t ConvertFilePermissions(mode_t mode)
 {
-#ifdef _WIN32
-   return 0;   // FIXME: how to return correct permissions?
-#else
    uint16_t accessRights = 0;
    if (S_IRUSR & mode)
       accessRights |= (1 << 0);
@@ -1075,8 +1143,8 @@ static uint16_t ConvertFilePermissions(mode_t mode)
    if (S_IXOTH & mode)
       accessRights |= (1 << 8);
    return accessRights;
-#endif
 }
+#endif
 
 /**
  * Handler for "get file set details" command
@@ -1106,7 +1174,11 @@ static void CH_GetFileSetDetails(const NXCPMessage& request, NXCPMessage *respon
             if (!CalculateFileMD5Hash(fullPath, hash))
                memset(hash, 0, MD5_DIGEST_SIZE);
             response->setField(fieldId++, hash, MD5_DIGEST_SIZE);
+#ifdef _WIN32
+            response->setField(fieldId++, ConvertFilePermissions(fullPath));
+#else
             response->setField(fieldId++, ConvertFilePermissions(fs.st_mode));
+#endif
 #ifdef _WIN32
             TCHAR owner[1024];
             response->setField(fieldId++, GetFileOwner(fileName, owner, 1024));


### PR DESCRIPTION
## Summary
Replaced the stub Windows implementation of `ConvertFilePermissions()` with a proper ACL-based implementation that extracts file permissions from Windows security descriptors and maps them to a Unix-like permission format.

## Key Changes
- **Windows implementation**: Added full ACL parsing to extract effective rights for owner, group, and everyone
  - Retrieves security descriptor using `GetNamedSecurityInfo()`
  - Calculates effective rights for each trustee (owner, group, everyone) using `GetEffectiveRightsFromAcl()`
  - Maps Windows generic rights (READ, WRITE, EXECUTE) to 9-bit permission format (bits 0-8)
  - Properly allocates and frees the "Everyone" SID for world permissions
  
- **Function signature**: Changed Windows version to accept file path (`const TCHAR *path`) instead of `mode_t mode` to enable security descriptor retrieval

- **Code organization**: Restructured preprocessor conditionals to clearly separate Windows and Unix implementations

- **Call site updates**: Added platform-specific conditional compilation at the call site in `CH_GetFileSetDetails()` to pass the appropriate parameter type

## Implementation Details
The permission bits are mapped as follows:
- Bits 0-2: Owner read, write, execute
- Bits 3-5: Group read, write, execute  
- Bits 6-8: Everyone read, write, execute

This provides a consistent interface across platforms while properly handling Windows ACL-based security model.

https://claude.ai/code/session_01R2LUM1FGVLXMeCUgfNM8jb