### PR TITLE
Correct typo in referencing pgsql.ddr database driver

### DIFF
--- a/contrib/netxmsd.conf-dist
+++ b/contrib/netxmsd.conf-dist
@@ -11,7 +11,7 @@
 # DBDriver = mssql.ddr
 # DBDriver = mysql.ddr
 # DBDriver = oracle.ddr
-# DBDriver = pgdql.ddr
+# DBDriver = pgsql.ddr
 # DBDriver = sqlite.ddr
 
 #


### PR DESCRIPTION
contrib/netxmsd.conf-dist seems to have a typo in  reference to pgsql.ddr
