### PR TITLE
Remove invalid template-id from constructor/destructor declarations

### DIFF
--- a/src/server/include/nms_objects.h
+++ b/src/server/include/nms_objects.h
@@ -439,12 +439,12 @@ private:
    }
 
 public:
-   SharedPointerIndex<T>() : AbstractIndexBase(Ownership::True)
+   SharedPointerIndex() : AbstractIndexBase(Ownership::True)
    {
       this->m_objectDestructor = destructor;
    }
    SharedPointerIndex(const SharedPointerIndex& src) = delete;
-   ~SharedPointerIndex<T>()
+   ~SharedPointerIndex()
    {
       clear(); // Delete all entries before memory pool is destroyed
    }
@@ -540,7 +540,7 @@ public:
 template<typename T> class AbstractIndex : public AbstractIndexBase
 {
 public:
-   AbstractIndex<T>(Ownership owner) : AbstractIndexBase(owner) { }
+   AbstractIndex(Ownership owner) : AbstractIndexBase(owner) { }
    AbstractIndex(const AbstractIndex& src) = delete;
 
    bool put(uint64_t key, T *object)
@@ -623,7 +623,7 @@ private:
    }
 
 public:
-   AbstractIndexWithDestructor<T>(Ownership owner) : AbstractIndex<T>(owner)
+   AbstractIndexWithDestructor(Ownership owner) : AbstractIndex<T>(owner)
    {
       this->m_objectDestructor = destructor;
    }


### PR DESCRIPTION
## Summary

Removes erroneous `<T>` template-id suffixes from four constructor/destructor declarations in class templates in `src/server/include/nms_objects.h`. These forms are ill-formed per the C++ standard (CWG 2237) — constructors and destructors of a class template must be declared using the injected-class-name, not a simple-template-id. Compilers previously accepted the construct as an extension but it is explicitly rejected in C++20 mode (e.g. Clang's `-Wtemplate-id-cdtor`, GCC 14+'s `-Wtemplate-id-cdtor`).

Fixes applied:

- `SharedPointerIndex<T>()` → `SharedPointerIndex()`
- `~SharedPointerIndex<T>()` → `~SharedPointerIndex()`
- `AbstractIndex<T>(Ownership owner)` → `AbstractIndex(Ownership owner)`
- `AbstractIndexWithDestructor<T>(Ownership owner)` → `AbstractIndexWithDestructor(Ownership owner)`

The change is backward-compatible with all supported C++ standard versions (C++11 and later). A sweep of the rest of the codebase (notably `include/nms_util.h` and all other template-bearing headers) confirmed no further occurrences.

## Test plan

- [ ] Build server with existing toolchain (GCC / MSVC) — no behavior change expected
- [ ] Build with Clang or GCC 14+ in C++20 mode to confirm `-Wtemplate-id-cdtor` no longer fires on these declarations

https://claude.ai/code/session_01MM6XPENsrwZrMoCqzrnpu4