### PR TITLE
[Feat] Set browser document title for RWT shells (Web Client)

### DIFF
--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginDialog.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginDialog.java
@@ -25,6 +25,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.rap.rwt.RWT;
+import org.eclipse.rap.rwt.client.service.JavaScriptExecutor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
@@ -99,9 +100,13 @@ public class LoginDialog extends Dialog
    protected void configureShell(Shell shell)
    {
       super.configureShell(shell);
-      shell.setText(String.format(i18n.tr("%s - Connect to Server"), BrandingManager.getProductName()));
+      String title = BrandingManager.getProductName() + " - " + i18n.tr("Connect to Server");
+      shell.setText(title);
       shell.setMaximized(true);
       shell.setFullScreen(true);
+      JavaScriptExecutor js = RWT.getClient().getService(JavaScriptExecutor.class);
+      if (js != null)
+         js.execute("document.title='" + title.replace("'", "\\'") + "';");
    }
 
    /**

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginProgressDialog.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginProgressDialog.java
@@ -27,6 +27,7 @@ import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.operation.ModalContext;
 import org.eclipse.rap.rwt.RWT;
+import org.eclipse.rap.rwt.client.service.JavaScriptExecutor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -71,9 +72,13 @@ public class LoginProgressDialog extends Dialog implements IRunnableContext
    protected void configureShell(Shell shell)
    {
       super.configureShell(shell);
-      shell.setText(String.format(i18n.tr("%s - Connecting"), BrandingManager.getProductName()));
+      String title = BrandingManager.getProductName() + " - " + i18n.tr("Connecting");
+      shell.setText(title);
       shell.setMaximized(true);
       shell.setFullScreen(true);
+      JavaScriptExecutor js = RWT.getClient().getService(JavaScriptExecutor.class);
+      if (js != null)
+         js.execute("document.title='" + title.replace("'", "\\'") + "';");
    }
 
    /**

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/windows/MainWindow.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/windows/MainWindow.java
@@ -28,6 +28,7 @@ import org.eclipse.jface.preference.PreferenceManager;
 import org.eclipse.jface.preference.PreferenceNode;
 import org.eclipse.jface.window.Window;
 import org.eclipse.rap.rwt.RWT;
+import org.eclipse.rap.rwt.client.service.JavaScriptExecutor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.SashForm;
@@ -176,7 +177,11 @@ public class MainWindow extends Window implements MessageAreaHolder
       super.configureShell(shell);
 
       final NXCSession session = Registry.getSession();
-      shell.setText(String.format(i18n.tr("%s - %s"), BrandingManager.getClientProductName(), session.getUserName() + "@" + session.getServerAddress()));
+      String title = String.format(i18n.tr("%s - %s"), BrandingManager.getClientProductName(), session.getUserName() + "@" + session.getServerAddress());
+      shell.setText(title);
+      JavaScriptExecutor js = RWT.getClient().getService(JavaScriptExecutor.class);
+      if (js != null)
+         js.execute("document.title='" + title.replace("'", "\\'") + "';");
 
       final SessionListener sessionListener = (n) -> processSessionNotification(n);
       session.addListener(sessionListener);


### PR DESCRIPTION
Extract title construction into a variable and use RWT JavaScriptExecutor to update the browser page title (document.title) in LoginDialog, LoginProgressDialog and MainWindow. Added JavaScriptExecutor imports and null checks before executing JS, and escape single quotes in the title string.

Before:

<img width="243" height="44" alt="image" src="https://github.com/user-attachments/assets/1461336a-19bc-433c-8ef1-b45d596e9263" />

After:

<img width="270" height="174" alt="image" src="https://github.com/user-attachments/assets/33fde7ca-6765-42cc-a5b4-d5f3e68a46c3" />