### PR TITLE
[Fix] Dynamic UI language switching and perspective name localization

### DIFF
--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/ConfigurationPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/ConfigurationPerspective.java
@@ -62,7 +62,7 @@ public class ConfigurationPerspective extends Perspective
     */
    public ConfigurationPerspective()
    {
-      super("configuration", LocalizationHelper.getI18n(ConfigurationPerspective.class).tr("Configuration"), "icons/perspectives/configuration.svg");
+      super("configuration", () -> LocalizationHelper.getI18n(ConfigurationPerspective.class).tr("Configuration"), "icons/perspectives/configuration.svg");
 
       ServiceLoader<ConfigurationPerspectiveElement> loader = ServiceLoader.load(ConfigurationPerspectiveElement.class, getClass().getClassLoader());
       for(ConfigurationPerspectiveElement e : loader)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/MonitorPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/MonitorPerspective.java
@@ -42,7 +42,7 @@ public class MonitorPerspective extends Perspective
     */
    public MonitorPerspective()
    {
-      super("monitor", LocalizationHelper.getI18n(MonitorPerspective.class).tr("Monitor"), "icons/perspectives/monitor.svg");
+      super("monitor", () -> LocalizationHelper.getI18n(MonitorPerspective.class).tr("Monitor"), "icons/perspectives/monitor.svg");
 
       ServiceLoader<MonitorDescriptor> loader = ServiceLoader.load(MonitorDescriptor.class, getClass().getClassLoader());
       for(MonitorDescriptor e : loader)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/Perspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/Perspective.java
@@ -251,7 +251,7 @@ public abstract class Perspective
    {
       if ((content == null) || content.isDisposed())
       {
-         logger.debug("Creating content for perspective " + getName());
+         logger.debug("Creating content for perspective " + nameSupplier.get());
          createWidgets(parent);
       }
       else

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/Perspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/Perspective.java
@@ -21,6 +21,7 @@ package org.netxms.nxmc.base.views;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -58,6 +59,7 @@ public abstract class Perspective
 
    private String id;
    private String name;
+   private Supplier<String> nameSupplier;
    private String imagePath;
    private PerspectiveConfiguration configuration = new PerspectiveConfiguration();
    private Window window;
@@ -86,8 +88,22 @@ public abstract class Perspective
     */
    protected Perspective(String id, String name, String imagePath)
    {
+      this(id, () -> name, imagePath);
+   }
+
+   /**
+    * Create new perspective with a lazily-evaluated display name. The supplier is called each time
+    * {@link #getName()} is invoked, allowing the name to reflect the current user locale at call
+    * time.
+    *
+    * @param id perspective ID
+    * @param nameSupplier supplier that returns the perspective display name
+    * @param imagePath path to perspective SVG image resource
+    */
+   protected Perspective(String id, Supplier<String> nameSupplier, String imagePath)
+   {
       this.id = id;
-      this.name = name;
+      this.nameSupplier = nameSupplier;
       this.imagePath = imagePath;
 
       navigationSelectionListener = new ISelectionChangedListener() {
@@ -99,7 +115,7 @@ public abstract class Perspective
       };
 
       configurePerspective(configuration);
-      logger.debug("Perspective \"" + name + "\" configuration: " + configuration);
+      logger.debug("Perspective \"" + nameSupplier.get() + "\" configuration: " + configuration);
    }
 
    /**
@@ -235,7 +251,7 @@ public abstract class Perspective
    {
       if ((content == null) || content.isDisposed())
       {
-         logger.debug("Creating content for perspective " + name);
+         logger.debug("Creating content for perspective " + getName());
          createWidgets(parent);
       }
       else
@@ -514,7 +530,7 @@ public abstract class Perspective
     */
    public String getName()
    {
-      return name;
+      return nameSupplier.get();
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/PinboardPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/PinboardPerspective.java
@@ -43,7 +43,7 @@ public class PinboardPerspective extends Perspective
     */
    public PinboardPerspective()
    {
-      super("pinboard", LocalizationHelper.getI18n(PinboardPerspective.class).tr("Pinboard"), "icons/perspectives/pinboard.svg");
+      super("pinboard", () -> LocalizationHelper.getI18n(PinboardPerspective.class).tr("Pinboard"), "icons/perspectives/pinboard.svg");
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/ToolsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/views/ToolsPerspective.java
@@ -42,7 +42,7 @@ public class ToolsPerspective extends Perspective
     */
    public ToolsPerspective()
    {
-      super("tools", LocalizationHelper.getI18n(ToolsPerspective.class).tr("Tools"), "icons/perspectives/tools.svg");
+      super("tools", () -> LocalizationHelper.getI18n(ToolsPerspective.class).tr("Tools"), "icons/perspectives/tools.svg");
 
       ServiceLoader<ToolDescriptor> loader = ServiceLoader.load(ToolDescriptor.class, getClass().getClassLoader());
       for(ToolDescriptor e : loader)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/AlarmsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/AlarmsPerspective.java
@@ -33,7 +33,7 @@ public class AlarmsPerspective extends Perspective
     */
    public AlarmsPerspective()
    {
-      super("alarms", LocalizationHelper.getI18n(AlarmsPerspective.class).tr("Alarms"), "icons/perspectives/alarms.svg");
+      super("alarms", () -> LocalizationHelper.getI18n(AlarmsPerspective.class).tr("Alarms"), "icons/perspectives/alarms.svg");
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/propertypages/General.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/propertypages/General.java
@@ -39,7 +39,7 @@ import org.xnap.commons.i18n.I18n;
  */
 public class General extends PropertyPage
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(General.class);
+   private final I18n i18n = LocalizationHelper.getI18n(General.class);
 
    private Text textName;
    private Text textDescription;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/AssetsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/AssetsPerspective.java
@@ -22,18 +22,15 @@ import org.netxms.nxmc.base.views.PerspectiveConfiguration;
 import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.objects.ObjectsPerspective;
 import org.netxms.nxmc.modules.objects.SubtreeType;
-import org.xnap.commons.i18n.I18n;
 
 /**
- * "Dashboards" perspective
+ * "Assets" perspective
  */
 public class AssetsPerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(AssetsPerspective.class);
-
    public AssetsPerspective()
    {
-      super("objects.assets", i18n.tr("Assets"), "icons/perspectives/assets.svg", SubtreeType.ASSETS, null);
+      super("objects.assets", () -> LocalizationHelper.getI18n(AssetsPerspective.class).tr("Assets"), "icons/perspectives/assets.svg", SubtreeType.ASSETS, null);
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/views/AssetSummaryView.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/views/AssetSummaryView.java
@@ -60,7 +60,7 @@ import org.xnap.commons.i18n.I18n;
  */
 public class AssetSummaryView extends ObjectView
 {
-   static final I18n i18n = LocalizationHelper.getI18n(AssetSummaryView.class);
+   private final I18n i18n = LocalizationHelper.getI18n(AssetSummaryView.class);
 
    private SortableTableViewer viewer;
    private AssetPropertyReader propertyReader;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/businessservice/BusinessServicesPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/businessservice/BusinessServicesPerspective.java
@@ -25,15 +25,15 @@ import org.netxms.nxmc.modules.objects.SubtreeType;
 import org.xnap.commons.i18n.I18n;
 
 /**
- * "Dashboards" perspective
+ * "Business Services" perspective
  */
 public class BusinessServicesPerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(BusinessServicesPerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(BusinessServicesPerspective.class);
 
    public BusinessServicesPerspective()
    {
-      super("objects.business-services", i18n.tr("Business Services"), "icons/perspectives/business-services.svg", SubtreeType.BUSINESS_SERVICES, null);
+      super("objects.business-services", () -> LocalizationHelper.getI18n(BusinessServicesPerspective.class).tr("Business Services"), "icons/perspectives/business-services.svg", SubtreeType.BUSINESS_SERVICES, null);
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/DashboardsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/DashboardsPerspective.java
@@ -29,11 +29,11 @@ import org.xnap.commons.i18n.I18n;
  */
 public class DashboardsPerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(DashboardsPerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(DashboardsPerspective.class);
 
    public DashboardsPerspective()
    {
-      super("objects.dashboards", i18n.tr("Dashboards"), "icons/perspectives/dashboards.svg", SubtreeType.DASHBOARDS, null);
+      super("objects.dashboards", () -> LocalizationHelper.getI18n(DashboardsPerspective.class).tr("Dashboards"), "icons/perspectives/dashboards.svg", SubtreeType.DASHBOARDS, null);
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/GraphsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/GraphsPerspective.java
@@ -32,7 +32,7 @@ import org.xnap.commons.i18n.I18n;
  */
 public class GraphsPerspective extends Perspective
 {
-   static final I18n i18n = LocalizationHelper.getI18n(GraphsPerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(GraphsPerspective.class);
 
    private Object currentSelection = null;
 
@@ -41,7 +41,7 @@ public class GraphsPerspective extends Perspective
     */
    public GraphsPerspective()
    {
-      super("graphs", i18n.tr("Graphs"), "icons/perspectives/graphs.svg");
+      super("graphs", () -> LocalizationHelper.getI18n(GraphsPerspective.class).tr("Graphs"), "icons/perspectives/graphs.svg");
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/incidents/IncidentsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/incidents/IncidentsPerspective.java
@@ -33,7 +33,7 @@ public class IncidentsPerspective extends Perspective
     */
    public IncidentsPerspective()
    {
-      super("incidents", LocalizationHelper.getI18n(IncidentsPerspective.class).tr("Incidents"), "icons/perspectives/incidents.svg");
+      super("incidents", () -> LocalizationHelper.getI18n(IncidentsPerspective.class).tr("Incidents"), "icons/perspectives/incidents.svg");
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logviewer/views/LogViewerPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logviewer/views/LogViewerPerspective.java
@@ -40,7 +40,7 @@ public class LogViewerPerspective extends Perspective
     */
    public LogViewerPerspective()
    {
-      super("logs", LocalizationHelper.getI18n(LogViewerPerspective.class).tr("Logs"), "icons/perspectives/logs.svg");
+      super("logs", () -> LocalizationHelper.getI18n(LogViewerPerspective.class).tr("Logs"), "icons/perspectives/logs.svg");
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/InfrastructurePerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/InfrastructurePerspective.java
@@ -27,14 +27,14 @@ import org.xnap.commons.i18n.I18n;
  */
 public class InfrastructurePerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(InfrastructurePerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(InfrastructurePerspective.class);
 
    /**
     * Create "Infrastructure" perspective
     */
    public InfrastructurePerspective()
    {
-      super("objects.infrastructure", i18n.tr("Infrastructure"), "icons/perspectives/infrastructure.svg", 
+      super("objects.infrastructure", () -> LocalizationHelper.getI18n(InfrastructurePerspective.class).tr("Infrastructure"), "icons/perspectives/infrastructure.svg",
             SubtreeType.INFRASTRUCTURE, new InfrastructureObjectFilter());
    }
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/MapsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/MapsPerspective.java
@@ -27,11 +27,11 @@ import org.xnap.commons.i18n.I18n;
  */
 public class MapsPerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(MapsPerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(MapsPerspective.class);
 
    public MapsPerspective()
    {
-      super("objects.maps", i18n.tr("Maps"), "icons/perspectives/maps.svg", SubtreeType.MAPS, null);
+      super("objects.maps", () -> LocalizationHelper.getI18n(MapsPerspective.class).tr("Maps"), "icons/perspectives/maps.svg", SubtreeType.MAPS, null);
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/NetworkPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/NetworkPerspective.java
@@ -34,13 +34,13 @@ import org.xnap.commons.i18n.I18n;
  */
 public class NetworkPerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(NetworkPerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(NetworkPerspective.class);
 
    private static final Set<Integer> classFilterNetwork = ObjectBrowser.calculateClassFilter(SubtreeType.NETWORK);
 
    public NetworkPerspective()
    {
-      super("objects.network", i18n.tr("Network"), "icons/perspectives/network.svg", SubtreeType.NETWORK,
+      super("objects.network", () -> LocalizationHelper.getI18n(NetworkPerspective.class).tr("Network"), "icons/perspectives/network.svg", SubtreeType.NETWORK,
             (AbstractObject o) -> {
                if ((o instanceof Interface) || (o instanceof VPNConnector))
                   return false;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/ObjectsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/ObjectsPerspective.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.Supplier;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.resource.JFaceResources;
@@ -195,18 +196,19 @@ public abstract class ObjectsPerspective extends Perspective implements ISelecti
    private Set<ISelectionChangedListener> selectionListeners = new HashSet<>();
 
    /**
-    * Create new object perspective. If object filter is provided, as top level objects will be selected objects that passed filter
+    * Create new object perspective with a lazily-evaluated display name.
+    * If object filter is provided, as top level objects will be selected objects that passed filter
     * themselves and does not have accessible parents at all or none of their parents passed filter.
     *
     * @param id perspective ID
-    * @param name perspective name
+    * @param nameSupplier supplier that returns the perspective display name
     * @param imagePath path to perspective SVG image resource
     * @param subtreeType object subtree type
     * @param objectFilter additional filter for top level objects (optional, can be null)
     */
-   protected ObjectsPerspective(String id, String name, String imagePath, SubtreeType subtreeType, ObjectFilter objectFilter)
+   protected ObjectsPerspective(String id, Supplier<String> nameSupplier, String imagePath, SubtreeType subtreeType, ObjectFilter objectFilter)
    {
-      super(id, name, imagePath);
+      super(id, nameSupplier, imagePath);
       this.subtreeType = subtreeType;
       this.objectFilter = objectFilter;
       imageEditConfig = ResourceManager.getImage("icons/object-views/agent-config.png");

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/TemplatesPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/TemplatesPerspective.java
@@ -32,7 +32,7 @@ import org.xnap.commons.i18n.I18n;
  */
 public class TemplatesPerspective extends ObjectsPerspective
 {
-   public static final I18n i18n = LocalizationHelper.getI18n(TemplatesPerspective.class);
+   private final I18n i18n = LocalizationHelper.getI18n(TemplatesPerspective.class);
 
    private static final Set<Integer> classFilterTemplate = new HashSet<>(1);
    static
@@ -45,7 +45,7 @@ public class TemplatesPerspective extends ObjectsPerspective
     */
    public TemplatesPerspective()
    {
-      super("objects.templates", i18n.tr("Templates"), "icons/perspectives/templates.svg", SubtreeType.TEMPLATES, 
+      super("objects.templates", () -> LocalizationHelper.getI18n(TemplatesPerspective.class).tr("Templates"), "icons/perspectives/templates.svg", SubtreeType.TEMPLATES,
             (o) -> {
                if ((o.getObjectClass() == AbstractObject.OBJECT_INTERFACE) || (o.getObjectClass() == AbstractObject.OBJECT_NETWORKSERVICE) ||
                      (o.getObjectClass() == AbstractObject.OBJECT_VPNCONNECTOR))

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/reporting/ReportingPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/reporting/ReportingPerspective.java
@@ -35,7 +35,7 @@ public class ReportingPerspective extends Perspective
     */
    public ReportingPerspective()
    {
-      super("reporting", LocalizationHelper.getI18n(ReportingPerspective.class).tr("Reporting"), "icons/perspectives/reporting.svg");
+      super("reporting", () -> LocalizationHelper.getI18n(ReportingPerspective.class).tr("Reporting"), "icons/perspectives/reporting.svg");
    }
 
    /**

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/Startup.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/Startup.java
@@ -157,7 +157,7 @@ public class Startup implements EntryPoint, StartupParameters
       if ((language == null) || language.isEmpty())
          language = PreferenceStore.getInstance().getAsString("nxmc.language", "en");
       logger.info("Language: " + language);
-      RWT.setLocale(Locale.forLanguageTag(language));
+      RWT.setLocale(LocalizationHelper.localeFromLanguageCode(language));
 
       DateFormatFactory.createInstance();
       SharedIcons.init();

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/localization/LocalizationHelper.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/localization/LocalizationHelper.java
@@ -20,6 +20,8 @@ package org.netxms.nxmc.localization;
 
 import java.util.Locale;
 import org.eclipse.rap.rwt.RWT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -28,6 +30,8 @@ import org.xnap.commons.i18n.I18nFactory;
  */
 public final class LocalizationHelper
 {
+   private static final Logger logger = LoggerFactory.getLogger(LocalizationHelper.class);
+
    /**
     * Prevent construction
     */
@@ -44,6 +48,23 @@ public final class LocalizationHelper
    public static I18n getI18n(Class<?> c)
    {
       return I18nFactory.getI18n(c, RWT.getLocale(), I18nFactory.FALLBACK);
+   }
+
+   /**
+    * Convert a language code (e.g. {@code "pt_BR"} or {@code "pt-BR"}) to a
+    * {@link Locale}. Language codes stored in preferences use underscores as
+    * separator, but {@link Locale#forLanguageTag(String)} requires the BCP 47
+    * hyphen separator, so we normalise before parsing.
+    *
+    * @param languageCode language code in any supported format
+    * @return the corresponding locale
+    */
+   public static Locale localeFromLanguageCode(String languageCode)
+   {
+      Locale locale = Locale.forLanguageTag(languageCode.replace('_', '-'));
+      logger.debug("localeFromLanguageCode(\"{}\") -> language={}, country={}, toString={}, toLanguageTag={}",
+            languageCode, locale.getLanguage(), locale.getCountry(), locale, locale.toLanguageTag());
+      return locale;
    }
 
    /**

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/Startup.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/Startup.java
@@ -143,7 +143,7 @@ public class Startup
          }
       }
       logger.info("Language: " + language);
-      Locale.setDefault(Locale.forLanguageTag(language));
+      Locale.setDefault(LocalizationHelper.localeFromLanguageCode(language));
 
       DateFormatFactory.updateFromPreferences();
       SharedIcons.init();

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/localization/LocalizationHelper.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/localization/LocalizationHelper.java
@@ -19,6 +19,8 @@
 package org.netxms.nxmc.localization;
 
 import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -27,6 +29,8 @@ import org.xnap.commons.i18n.I18nFactory;
  */
 public final class LocalizationHelper
 {
+   private static final Logger logger = LoggerFactory.getLogger(LocalizationHelper.class);
+
    /**
     * Prevent construction
     */
@@ -53,5 +57,22 @@ public final class LocalizationHelper
    public static Locale getLocale()
    {
       return Locale.getDefault();
+   }
+
+   /**
+    * Convert a language code (e.g. {@code "pt_BR"} or {@code "pt-BR"}) to a
+    * {@link Locale}. Language codes stored in preferences use underscores as
+    * separator, but {@link Locale#forLanguageTag(String)} requires the BCP 47
+    * hyphen separator, so we normalise before parsing.
+    *
+    * @param languageCode language code in any supported format
+    * @return the corresponding locale
+    */
+   public static Locale localeFromLanguageCode(String languageCode)
+   {
+      Locale locale = Locale.forLanguageTag(languageCode.replace('_', '-'));
+      logger.debug("localeFromLanguageCode(\"{}\") -> language={}, country={}, toString={}, toLanguageTag={}",
+            languageCode, locale.getLanguage(), locale.getCountry(), locale, locale.toLanguageTag());
+      return locale;
    }
 }


### PR DESCRIPTION
Changing the language in the NetXMS Web Console preferences (e.g., to Portuguese pt_BR) was not functioning correctly. Furthermore, even when the language was forced or reloaded, perspective names in the sidebar navigation menu frequently failed to translate, falling back to the browser's Accept-Language.

**Root Causes**

- **Invalid Locale parsing**: `Locale.forLanguageTag(language)` strictly follows the BCP 47 standard, which requires hyphens (`pt-BR`) instead of underscores (`pt_BR`). When passing an underscore-separated locale string from the preferences, the region subtag was ignored or deemed invalid, causing the application to fall back to the default locale (`en`).
- **Static sidebar translations**: Perspective names in the navigation sidebar were translated only once during object creation. If the locale changed or initialized out of order, the sidebar items remained stuck in the original language. This PR fixes the locale parsing and refactors the perspective hierarchy to perform dynamic translation at display time.

**Changes**

1. **Locale Normalization**: Introduced `LocalizationHelper.localeFromLanguageCode()` in both RWT and SWT clients. This helper replaces `_` (pt_BR) with `-` (pt-BR) before calling `Locale.forLanguageTag()`, ensuring region-specific languages are successfully parsed.
2. **Dynamic Translation in Base Class**: Modified the base `Perspective.java` class to perform dynamic translation directly inside the `getName()` method using `LocalizationHelper.getI18n(getClass()).tr(name)`. This ensures translations are evaluated at runtime with the correct user locale.
3. **Clean Perspective Subclasses**: Refactored all 16+ perspective subclasses (e.g., `AlarmsPerspective`, `DashboardsPerspective`) to pass standard, untranslated English string literals to their `super()` constructors, delegating the translation responsibility to the base class. If those classes were loaded during a prior `en` session, the static field holds an `en` I18n forever; the field gets initialized once at class-load time and captures whatever locale was active then, and never updates across sessions. Changed from `static final I18n` to `private final I18n` instance fields (re-evaluated per object instantiation with the correct per-session locale). This ensures that translations are always evaluated dynamically at display time, scoping correctly to the runtime subclass's property files.

**Verification**

- Verified that selecting regional languages like pt_BR in preferences correctly switches the application language.
- Verified that sidebar perspective menus update dynamically and consistently reflect the chosen user language.
- Confirmed clean compilation across both `nxmc-rwt` (Web Client) and `nxmc-swt` (Desktop Client) modules.