### PR TITLE
Add isolated upgrade flow for agent upgrade packages

### DIFF
--- a/include/nms_cscp.h
+++ b/include/nms_cscp.h
@@ -718,6 +718,7 @@ typedef struct
 #define CMD_GET_AI_SKILLS_AND_FUNCTIONS  0x0206
 #define CMD_MODIFY_AI_DISABLED_LIST      0x0207
 #define CMD_GET_POLICY_FILE              0x0208
+#define CMD_SETUP_AGENT_UPGRADE           0x0209
 
 #define CMD_RS_LIST_REPORTS               0x1100
 #define CMD_RS_GET_REPORT_DEFINITION      0x1101
@@ -1721,6 +1722,7 @@ typedef struct
 #define VID_POLICY_FILE_GUID        ((uint32_t)986)
 #define VID_OS_PLATFORM_NAME        ((uint32_t)987)
 #define VID_AGENT_PLATFORM_NAME     ((uint32_t)988)
+#define VID_TRANSFER_ID             ((uint32_t)989)
 
 // Base values for EPP optimistic concurrency
 #define VID_DELETED_RULE_LIST_BASE  ((uint32_t)0x7A000000)

--- a/src/agent/core/comm.cpp
+++ b/src/agent/core/comm.cpp
@@ -68,7 +68,7 @@ void InitSessionList()
 /**
  * Validates server's address
  */
-bool IsValidServerAddress(const InetAddress &addr, bool *pbMasterServer, bool *pbControlServer, bool forceResolve)
+bool IsValidServerAddress(const InetAddress &addr, bool *pbMasterServer, bool *pbControlServer, bool *pbUpgradeServer, bool forceResolve)
 {
    for(int i = 0; i < g_serverList.size(); i++)
 	{
@@ -77,6 +77,7 @@ bool IsValidServerAddress(const InetAddress &addr, bool *pbMasterServer, bool *p
       {
          *pbMasterServer = s->isMaster();
          *pbControlServer = s->isControl();
+         *pbUpgradeServer = s->isUpgrade();
          return true;
       }
 	}
@@ -93,7 +94,9 @@ bool RegisterSession(const shared_ptr<CommSession>& session)
    {
       g_sessions.add(session);
       g_sessionLock.unlock();
-      session->debugPrintf(4, _T("Session registered (control=%s, master=%s)"), BooleanToString(session->isControlServer()), BooleanToString(session->isMasterServer()));
+      session->debugPrintf(4, _T("Session registered (control=%s, master=%s, upgrade=%s)"),
+            BooleanToString(session->isControlServer()), BooleanToString(session->isMasterServer()),
+            BooleanToString(session->isUpgradeServer()));
       return true;
    }
 
@@ -436,15 +439,15 @@ void ListenerThread()
          InetAddress addr = InetAddress::createFromSockaddr((struct sockaddr *)clientAddr);
          nxlog_debug_tag(DEBUG_TAG_COMM, 5, _T("Incoming connection from %s"), addr.toString(buffer));
 
-         bool masterServer, controlServer;
-         if (IsValidServerAddress(addr, &masterServer, &controlServer, false))
+         bool masterServer, controlServer, upgradeServer;
+         if (IsValidServerAddress(addr, &masterServer, &controlServer, &upgradeServer, false))
          {
             g_acceptedConnections++;
             nxlog_debug_tag(DEBUG_TAG_COMM, 5, _T("Connection from %s accepted"), buffer);
 
             // Create new session structure and threads
             shared_ptr<SocketCommChannel> channel = make_shared<SocketCommChannel>(hClientSocket, nullptr, Ownership::True);
-            shared_ptr<CommSession> session = MakeSharedCommSession<CommSession>(channel, addr, masterServer, controlServer);
+            shared_ptr<CommSession> session = MakeSharedCommSession<CommSession>(channel, addr, masterServer, controlServer, upgradeServer);
 
             if (RegisterSession(session))
             {

--- a/src/agent/core/nxagentd.cpp
+++ b/src/agent/core/nxagentd.cpp
@@ -275,6 +275,7 @@ static StringList *s_actionList = new StringList();
 static TCHAR *m_pszServerList = nullptr;
 static TCHAR *m_pszControlServerList = nullptr;
 static TCHAR *m_pszMasterServerList = nullptr;
+static TCHAR *m_pszUpgradeServerList = nullptr;
 static TCHAR *m_pszSubagentList = nullptr;
 static TCHAR *s_externalMetrics = nullptr;
 static TCHAR *s_backgroundExternalMetrics = nullptr;
@@ -390,6 +391,7 @@ static NX_CFG_TEMPLATE m_cfgTemplate[] =
    { _T("LogUnresolvedSymbols"), CT_BOOLEAN_FLAG_32, 0, 0, SF_LOG_UNRESOLVED_SYMBOLS, 0, &s_startupFlags, nullptr },
    { _T("LongRunningQueryThreshold"), CT_LONG, 0, 0, 0, 0, &g_longRunningQueryThreshold, nullptr },
    { _T("MasterServers"), CT_STRING_CONCAT, ',', 0, 0, 0, &m_pszMasterServerList, nullptr },
+   { _T("UpgradeServers"), CT_STRING_CONCAT, ',', 0, 0, 0, &m_pszUpgradeServerList, nullptr },
    { _T("MaxLogSize"), CT_SIZE_BYTES, 0, 0, 0, 0, &s_maxLogSize, nullptr },
    { _T("MaxSessions"), CT_LONG, 0, 0, 0, 0, &g_maxCommSessions, nullptr },
    { _T("OfflineDataExpirationTime"), CT_LONG, 0, 0, 0, 0, &g_dcOfflineExpirationTime, nullptr },
@@ -491,7 +493,7 @@ static TCHAR m_szHelpText[] =
 /**
  * Server info: constructor
  */
-ServerInfo::ServerInfo(const TCHAR *name, bool control, bool master)
+ServerInfo::ServerInfo(const TCHAR *name, bool control, bool master, bool upgrade)
 {
 #ifdef UNICODE
    m_name = MBStringFromWideString(name);
@@ -521,6 +523,7 @@ ServerInfo::ServerInfo(const TCHAR *name, bool control, bool master)
 
    m_control = control;
    m_master = master;
+   m_upgrade = upgrade;
    m_lastResolveTime = time(nullptr);
 }
 
@@ -954,7 +957,7 @@ static void ConfigureAgentDirectory(TCHAR *generatedPath, const TCHAR *suffix, c
 /**
  * Parser server list
  */
-static void ParseServerList(TCHAR *serverList, bool isControl, bool isMaster)
+static void ParseServerList(TCHAR *serverList, bool isControl, bool isMaster, bool isUpgrade)
 {
 	TCHAR *curr, *next;
 	for(curr = next = serverList; next != nullptr && *curr != 0; curr = next + 1)
@@ -965,9 +968,9 @@ static void ParseServerList(TCHAR *serverList, bool isControl, bool isMaster)
 		Trim(curr);
 		if (*curr != 0)
 		{
-         g_serverList.add(new ServerInfo(curr, isControl, isMaster));
-         nxlog_debug_tag(DEBUG_TAG_COMM, 3, _T("Added server access record %s (control=%s, master=%s)"), curr,
-                  BooleanToString(isControl), BooleanToString(isMaster));
+         g_serverList.add(new ServerInfo(curr, isControl, isMaster, isUpgrade));
+         nxlog_debug_tag(DEBUG_TAG_COMM, 3, _T("Added server access record %s (control=%s, master=%s, upgrade=%s)"), curr,
+                  BooleanToString(isControl), BooleanToString(isMaster), BooleanToString(isUpgrade));
 		}
 	}
 	MemFree(serverList);
@@ -1343,11 +1346,13 @@ BOOL Initialize()
 
       // Parse server lists
       if (m_pszMasterServerList != nullptr)
-         ParseServerList(m_pszMasterServerList, true, true);
+         ParseServerList(m_pszMasterServerList, true, true, true);
+      if (m_pszUpgradeServerList != nullptr)
+         ParseServerList(m_pszUpgradeServerList, false, false, true);
 		if (m_pszControlServerList != nullptr)
-			ParseServerList(m_pszControlServerList, true, false);
+			ParseServerList(m_pszControlServerList, true, false, false);
 		if (m_pszServerList != nullptr)
-			ParseServerList(m_pszServerList, false, false);
+			ParseServerList(m_pszServerList, false, false, false);
 
       // Set default accepted environment variable patterns if not configured
       if (g_acceptedEnvVars.contains(_T("none")))

--- a/src/agent/core/nxagentd.h
+++ b/src/agent/core/nxagentd.h
@@ -291,6 +291,7 @@ private:
    InetAddress m_address;
    bool m_control;
    bool m_master;
+   bool m_upgrade;
    time_t m_lastResolveTime;
    bool m_redoResolve;
    Mutex m_mutex;
@@ -298,13 +299,14 @@ private:
    void resolve(bool forceResolve);
 
 public:
-   ServerInfo(const TCHAR *name, bool control, bool master);
+   ServerInfo(const TCHAR *name, bool control, bool master, bool upgrade);
    ~ServerInfo();
 
    bool match(const InetAddress &addr, bool forceResolve);
 
    bool isMaster() const { return m_master; }
    bool isControl() const { return m_control; }
+   bool isUpgrade() const { return m_upgrade || m_master; }
 };
 
 /**
@@ -346,6 +348,7 @@ private:
    bool m_authenticated;
    bool m_masterServer;
    bool m_controlServer;
+   bool m_upgradeServer;
    bool m_proxyConnection;
    bool m_acceptData;
    bool m_acceptTraps;
@@ -357,6 +360,8 @@ private:
    bool m_stopCommandProcessing;
    VolatileCounter m_pendingRequests;
    HashMap<uint32_t, DownloadFileInfo> m_downloadFileMap;
+   TCHAR *m_pendingUpgradeFile;        // Path to private staging file for agent upgrade (owned by session)
+   uint32_t m_pendingUpgradeRequestId; // Request ID used to upload staging file
 	shared_ptr<NXCPEncryptionContext> m_encryptionContext;
    int64_t m_timestamp;       // Last activity timestamp
    SOCKET m_hProxySocket;     // Socket for proxy connection
@@ -376,6 +381,7 @@ private:
    void getTable(NXCPMessage *request, NXCPMessage *response);
    void action(NXCPMessage *request, NXCPMessage *response);
    void recvFile(NXCPMessage *request, NXCPMessage *response);
+   uint32_t setupAgentUpgrade(NXCPMessage *request);
    uint32_t installPackage(NXCPMessage *request);
    uint32_t upgrade(NXCPMessage *request);
    uint32_t setupProxyConnection(NXCPMessage *pRequest);
@@ -400,7 +406,7 @@ private:
    void setResponseSentCondition(uint32_t requestId);
 
 public:
-   CommSession(const shared_ptr<AbstractCommChannel>& channel, const InetAddress &serverAddr, bool masterServer, bool controlServer);
+   CommSession(const shared_ptr<AbstractCommChannel>& channel, const InetAddress &serverAddr, bool masterServer, bool controlServer, bool upgradeServer);
    virtual ~CommSession();
 
    shared_ptr<CommSession> self() const { return static_pointer_cast<CommSession>(AbstractCommSession::self()); }
@@ -426,6 +432,7 @@ public:
 
    virtual bool isMasterServer() override { return m_masterServer; }
    virtual bool isControlServer() override { return m_controlServer; }
+   bool isUpgradeServer() const { return m_upgradeServer; }
    virtual bool canAcceptData() override { return m_acceptData; }
    virtual bool canAcceptTraps() override { return m_acceptTraps; }
    virtual bool canAcceptFileUpdates() override { return m_acceptFileUpdates; }

--- a/src/agent/core/session.cpp
+++ b/src/agent/core/session.cpp
@@ -94,7 +94,7 @@ LONG H_AgentProxyStats(const TCHAR *cmd, const TCHAR *arg, TCHAR *value, Abstrac
 /**
  * Client session class constructor
  */
-CommSession::CommSession(const shared_ptr<AbstractCommChannel>& channel, const InetAddress &serverAddr, bool masterServer, bool controlServer) :
+CommSession::CommSession(const shared_ptr<AbstractCommChannel>& channel, const InetAddress &serverAddr, bool masterServer, bool controlServer, bool upgradeServer) :
          m_channel(channel), m_downloadFileMap(Ownership::True), m_socketWriteMutex(MutexType::FAST), m_tcpProxyLock(MutexType::FAST),
          m_tcpProxies(0, 16, Ownership::True), m_responseConditionMap(Ownership::True)
 {
@@ -111,6 +111,9 @@ CommSession::CommSession(const shared_ptr<AbstractCommChannel>& channel, const I
    m_authenticated = (g_dwFlags & AF_REQUIRE_AUTH) ? false : true;
    m_masterServer = masterServer;
    m_controlServer = controlServer;
+   m_upgradeServer = upgradeServer;
+   m_pendingUpgradeFile = nullptr;
+   m_pendingUpgradeRequestId = 0;
    m_proxyConnection = false;
    m_acceptTraps = false;
    m_acceptData = false;
@@ -153,6 +156,12 @@ CommSession::~CommSession()
    delete m_responseQueue;
 
    m_downloadFileMap.forEach(AbortFileTransfer, this);
+
+   if (m_pendingUpgradeFile != nullptr)
+   {
+      _tremove(m_pendingUpgradeFile);
+      MemFree(m_pendingUpgradeFile);
+   }
 }
 
 /**
@@ -649,6 +658,9 @@ void CommSession::processCommand(NXCPMessage *request)
          case CMD_INSTALL_PACKAGE:
             response.setField(VID_RCC, installPackage(request));
             break;
+         case CMD_SETUP_AGENT_UPGRADE:
+            response.setField(VID_RCC, setupAgentUpgrade(request));
+            break;
          case CMD_UPGRADE_AGENT:
             response.setField(VID_RCC, upgrade(request));
             break;
@@ -749,7 +761,7 @@ void CommSession::processCommand(NXCPMessage *request)
             m_allowCompression = request->getFieldAsBoolean(VID_ENABLE_COMPRESSION);
             m_acceptKeepalive = request->getFieldAsBoolean(VID_ACCEPT_KEEPALIVE);
             response.setField(VID_RCC, ERR_SUCCESS);
-            response.setField(VID_FLAGS, static_cast<uint16_t>((m_controlServer ? 0x01 : 0x00) | (m_masterServer ? 0x02 : 0x00)));
+            response.setField(VID_FLAGS, static_cast<uint16_t>((m_controlServer ? 0x01 : 0x00) | (m_masterServer ? 0x02 : 0x00) | ((m_masterServer || m_upgradeServer) ? 0x04 : 0x00)));
             debugPrintf(4, _T("Server capabilities: IPv6: %s; bulk reconciliation: %s; compression: %s"),
                         m_ipv6Aware ? _T("yes") : _T("no"),
                         m_bulkReconciliationSupported ? _T("yes") : _T("no"),
@@ -1156,28 +1168,130 @@ bool CommSession::sendFile(uint32_t requestId, const TCHAR *file, off64_t offset
 }
 
 /**
- * Upgrade agent from package in the file store
+ * Set up isolated staging area for agent upgrade package upload.
+ * Server is expected to stream package bytes via CMD_FILE_DATA chunks
+ * keyed by this message's request ID, then trigger the upgrade with
+ * CMD_UPGRADE_AGENT carrying VID_TRANSFER_ID equal to the same request ID.
+ *
+ * The staging file lives in <FileStore>/upgrade/, a subdirectory that
+ * BuildFullPath() (used by CMD_TRANSFER_FILE) cannot address because it
+ * strips path components from server-supplied filenames. The path is
+ * stored only on the session and unlinked on session teardown.
+ */
+uint32_t CommSession::setupAgentUpgrade(NXCPMessage *request)
+{
+   if (!m_masterServer && !m_upgradeServer)
+   {
+      writeLog(NXLOG_WARNING, _T("Agent upgrade setup request from server without upgrade access"));
+      return ERR_ACCESS_DENIED;
+   }
+
+   // Only one staging file per session; replace any prior incomplete staging
+   if (m_pendingUpgradeFile != nullptr)
+   {
+      DownloadFileInfo *prev = m_downloadFileMap.get(m_pendingUpgradeRequestId);
+      if (prev != nullptr)
+      {
+         prev->close(false);
+         m_downloadFileMap.remove(m_pendingUpgradeRequestId);
+      }
+      _tremove(m_pendingUpgradeFile);
+      MemFreeAndNull(m_pendingUpgradeFile);
+      m_pendingUpgradeRequestId = 0;
+   }
+
+   // Build staging directory path: <FileStore>/upgrade/
+   TCHAR stagingDir[MAX_PATH];
+   _tcslcpy(stagingDir, g_szFileStore, MAX_PATH);
+   size_t len = _tcslen(stagingDir);
+   if ((len > 0) && (stagingDir[len - 1] != _T('\\')) && (stagingDir[len - 1] != _T('/')))
+   {
+      _tcslcat(stagingDir, FS_PATH_SEPARATOR, MAX_PATH);
+   }
+   _tcslcat(stagingDir, _T("upgrade"), MAX_PATH);
+   if (!CreateDirectoryTree(stagingDir))
+   {
+      debugPrintf(3, _T("setupAgentUpgrade(): cannot create staging directory \"%s\" (%s)"), stagingDir, _tcserror(errno));
+      return ERR_IO_FAILURE;
+   }
+
+   BYTE randomBytes[12];
+   GenerateRandomBytes(randomBytes, sizeof(randomBytes));
+   TCHAR randomHex[sizeof(randomBytes) * 2 + 1];
+   BinToStr(randomBytes, sizeof(randomBytes), randomHex);
+
+   TCHAR *stagingPath = MemAllocString(MAX_PATH);
+   _sntprintf(stagingPath, MAX_PATH, _T("%s") FS_PATH_SEPARATOR _T("agent-upgrade-%s.pkg"), stagingDir, randomHex);
+
+   uint32_t requestId = request->getId();
+   NXCPMessage probe(NXCP_VERSION);
+   openFile(&probe, stagingPath, requestId, 0, FileTransferResumeMode::OVERWRITE);
+   uint32_t rcc = probe.getFieldAsUInt32(VID_RCC);
+   if (rcc != ERR_SUCCESS)
+   {
+      MemFree(stagingPath);
+      return rcc;
+   }
+
+   m_pendingUpgradeFile = stagingPath;
+   m_pendingUpgradeRequestId = requestId;
+   debugPrintf(4, _T("Agent upgrade staging area prepared at \"%s\""), m_pendingUpgradeFile);
+   return ERR_SUCCESS;
+}
+
+/**
+ * Upgrade agent from a previously staged package.
+ *
+ * Two flows are supported:
+ *  - New flow: VID_TRANSFER_ID identifies a session-private staging file
+ *    prepared by setupAgentUpgrade(). Available to upgrade-only servers.
+ *  - Legacy flow: VID_FILE_NAME names a file in the agent file store
+ *    (uploaded via CMD_TRANSFER_FILE). Master access required as before.
  */
 uint32_t CommSession::upgrade(NXCPMessage *request)
 {
-   if (m_masterServer)
+   if (request->isFieldExist(VID_TRANSFER_ID))
    {
-      TCHAR packageName[MAX_PATH] = _T("");
-      request->getFieldAsString(VID_FILE_NAME, packageName, MAX_PATH);
-            
-      // Store upgrade file name to delete it after system start
-      WriteRegistry(_T("upgrade.file"), packageName);
-      writeLog(NXLOG_INFO, _T("Starting agent upgrade using package %s"), packageName);
+      if (!m_masterServer && !m_upgradeServer)
+      {
+         writeLog(NXLOG_WARNING, _T("Upgrade request from server without upgrade access"));
+         return ERR_ACCESS_DENIED;
+      }
+      uint32_t transferId = request->getFieldAsUInt32(VID_TRANSFER_ID);
+      if ((m_pendingUpgradeFile == nullptr) || (transferId != m_pendingUpgradeRequestId))
+      {
+         writeLog(NXLOG_WARNING, _T("Upgrade request with unknown transfer ID"));
+         return ERR_BAD_ARGUMENTS;
+      }
 
       TCHAR fullPath[MAX_PATH];
-      BuildFullPath(packageName, fullPath);
+      _tcslcpy(fullPath, m_pendingUpgradeFile, MAX_PATH);
+
+      // Hand ownership of the staging file to the post-restart cleanup path.
+      WriteRegistry(_T("upgrade.file"), fullPath);
+      writeLog(NXLOG_INFO, _T("Starting agent upgrade using staged package %s"), fullPath);
+
+      MemFreeAndNull(m_pendingUpgradeFile);
+      m_pendingUpgradeRequestId = 0;
       return UpgradeAgent(fullPath);
    }
-   else
+
+   if (!m_masterServer)
    {
       writeLog(NXLOG_WARNING, _T("Upgrade request from server which is not master (upgrade will not start)"));
       return ERR_ACCESS_DENIED;
    }
+
+   TCHAR packageName[MAX_PATH] = _T("");
+   request->getFieldAsString(VID_FILE_NAME, packageName, MAX_PATH);
+
+   // Store upgrade file name to delete it after system start
+   WriteRegistry(_T("upgrade.file"), packageName);
+   writeLog(NXLOG_INFO, _T("Starting agent upgrade using package %s"), packageName);
+
+   TCHAR fullPath[MAX_PATH];
+   BuildFullPath(packageName, fullPath);
+   return UpgradeAgent(fullPath);
 }
 
 /**

--- a/src/agent/core/tunnel.cpp
+++ b/src/agent/core/tunnel.cpp
@@ -34,7 +34,7 @@
 /**
  * Check if server address is valid
  */
-bool IsValidServerAddress(const InetAddress &addr, bool *pbMasterServer, bool *pbControlServer, bool forceResolve);
+bool IsValidServerAddress(const InetAddress &addr, bool *pbMasterServer, bool *pbControlServer, bool *pbUpgradeServer, bool forceResolve);
 
 /**
  * Register session
@@ -1484,14 +1484,14 @@ void Tunnel::createSession(const NXCPMessage& request)
    NXCPMessage response(CMD_REQUEST_COMPLETED, request.getId(), 4);
 
    // Assume that peer always have minimal access, so don't check return value
-   bool masterServer, controlServer;
-   IsValidServerAddress(m_address, &masterServer, &controlServer, m_forceResolve);
+   bool masterServer, controlServer, upgradeServer;
+   IsValidServerAddress(m_address, &masterServer, &controlServer, &upgradeServer, m_forceResolve);
    m_forceResolve = false;
 
    shared_ptr<TunnelCommChannel> channel = createChannel();
    if (channel != nullptr)
    {
-      shared_ptr<CommSession> session = MakeSharedCommSession<CommSession>(channel, m_address, masterServer, controlServer);
+      shared_ptr<CommSession> session = MakeSharedCommSession<CommSession>(channel, m_address, masterServer, controlServer, upgradeServer);
       if (RegisterSession(session))
       {
          response.setField(VID_RCC, ERR_SUCCESS);

--- a/src/libnetxms/nxcp.cpp
+++ b/src/libnetxms/nxcp.cpp
@@ -563,7 +563,8 @@ TCHAR LIBNETXMS_EXPORTABLE *NXCPMessageCodeName(uint16_t code, TCHAR *buffer)
       _T("CMD_GET_CONNECTION_HISTORY"),
       _T("CMD_GET_AI_SKILLS_AND_FUNCTIONS"),
       _T("CMD_MODIFY_AI_DISABLED_LIST"),
-      _T("CMD_GET_POLICY_FILE")
+      _T("CMD_GET_POLICY_FILE"),
+      _T("CMD_SETUP_AGENT_UPGRADE")
    };
    static const TCHAR *reportingMessageNames[] =
    {
@@ -579,7 +580,7 @@ TCHAR LIBNETXMS_EXPORTABLE *NXCPMessageCodeName(uint16_t code, TCHAR *buffer)
       _T("CMD_RS_DEPLOY_REPORT_PACKAGE")
    };
 
-   if ((code >= CMD_LOGIN) && (code <= CMD_GET_POLICY_FILE))
+   if ((code >= CMD_LOGIN) && (code <= CMD_SETUP_AGENT_UPGRADE))
    {
       _tcscpy(buffer, messageNames[code - CMD_LOGIN]);
    }

--- a/src/server/core/package.cpp
+++ b/src/server/core/package.cpp
@@ -447,9 +447,9 @@ void PackageDeploymentJob::notifyClients() const
 /**
  * Upgrade agent
  */
-static bool UpgradeAgent(PackageDeploymentJob *job, Node *node, AgentConnectionEx *upgradeConnection, const wchar_t **errorMessage)
+static bool UpgradeAgent(PackageDeploymentJob *job, Node *node, AgentConnectionEx *upgradeConnection, uint32_t transferId, const wchar_t **errorMessage)
 {
-   if (upgradeConnection->startUpgrade(job->getPackageFile()) != ERR_SUCCESS)
+   if (upgradeConnection->startUpgrade(job->getPackageFile(), transferId) != ERR_SUCCESS)
    {
       nxlog_debug_tag(DEBUG_TAG, 4, L"UpgradeAgent(): cannot start agent upgrade on node %s [%u] in job [%u]", node->getName(), node->getId(), job->getId());
       *errorMessage = L"Unable to start upgrade process";
@@ -611,7 +611,30 @@ void PackageDeploymentJob::execute()
    packageFile.append(m_packageFile);
    uint32_t bwLimit = node->getCustomAttributeAsUInt32(L"SysConfig:Agent.UploadBandwidthLimit", g_agentUploadBandwidthLimit);
    uint32_t bandwidthLimit = (bwLimit > 0) ? bwLimit * 1024 : 0;
-   uint32_t rcc = agentConn->uploadFile(packageFile, nullptr, false, nullptr, NXCP_STREAM_COMPRESSION_NONE, bandwidthLimit);
+
+   bool isAgentUpgrade = !wcscmp(m_packageType, L"agent-installer");
+   uint32_t upgradeTransferId = 0;
+   uint32_t rcc;
+
+   if (isAgentUpgrade)
+   {
+      // Prefer the isolated upload flow so agents configured with UpgradeServers
+      // (but not MasterServers) can still receive upgrades. Falls back to legacy
+      // CMD_TRANSFER_FILE for older agents that don't implement the new command.
+      rcc = agentConn->uploadAgentUpgradePackage(packageFile, &upgradeTransferId, nullptr, bandwidthLimit);
+      if ((rcc == ERR_NOT_IMPLEMENTED) || (rcc == ERR_UNKNOWN_COMMAND))
+      {
+         nxlog_debug_tag(DEBUG_TAG, 5, L"PackageDeploymentJob::execute(): agent on node %s [%u] does not support isolated upgrade flow, falling back to legacy upload",
+            node->getName(), m_nodeId);
+         upgradeTransferId = 0;
+         rcc = agentConn->uploadFile(packageFile, nullptr, false, nullptr, NXCP_STREAM_COMPRESSION_NONE, bandwidthLimit);
+      }
+   }
+   else
+   {
+      rcc = agentConn->uploadFile(packageFile, nullptr, false, nullptr, NXCP_STREAM_COMPRESSION_NONE, bandwidthLimit);
+   }
+
    if (rcc != ERR_SUCCESS)
    {
       nxlog_debug_tag(DEBUG_TAG, 4, L"PackageDeploymentJob::execute(): file transfer failed to node %s [%u] in job [%u] (%u: %s)",
@@ -623,10 +646,10 @@ void PackageDeploymentJob::execute()
    setStatus(PKG_JOB_INSTALLATION_RUNNING);
 
    bool success;
-   if (!wcscmp(m_packageType, L"agent-installer"))
+   if (isAgentUpgrade)
    {
       const wchar_t *errorMessage;
-      success = UpgradeAgent(this, node.get(), agentConn.get(), &errorMessage);
+      success = UpgradeAgent(this, node.get(), agentConn.get(), upgradeTransferId, &errorMessage);
       if (!success)
          markAsFailed(errorMessage, false);
    }

--- a/src/server/include/nxsrvapi.h
+++ b/src/server/include/nxsrvapi.h
@@ -1319,7 +1319,9 @@ public:
    uint32_t downloadFile(const TCHAR *localFile, const TCHAR *destinationFile = nullptr, bool allowPathExpansion = false,
          std::function<void (size_t)> progressCallback = nullptr, NXCPStreamCompressionMethod compMethod = NXCP_STREAM_COMPRESSION_NONE);
    uint32_t cancelFileMonitoring(const TCHAR *agentFileId);
-   uint32_t startUpgrade(const TCHAR *pkgName);
+   uint32_t startUpgrade(const TCHAR *pkgName, uint32_t transferId = 0);
+   uint32_t uploadAgentUpgradePackage(const TCHAR *localFile, uint32_t *transferId,
+         std::function<void (size_t)> progressCallback = nullptr, uint32_t bandwidthLimit = 0);
    uint32_t installPackage(const TCHAR *pkgName, const TCHAR *pkgType, const TCHAR *command);
    uint32_t checkNetworkService(uint32_t *status, const InetAddress& addr, int serviceType, uint16_t port = 0, uint16_t proto = 0,
          const TCHAR *serviceRequest = nullptr, const TCHAR *serviceResponse = nullptr, uint32_t *responseTime = nullptr);

--- a/src/server/libnxsrv/agent.cpp
+++ b/src/server/libnxsrv/agent.cpp
@@ -2192,18 +2192,80 @@ uint32_t AgentConnection::getFileFingerprint(const TCHAR *file, RemoteFileFinger
 }
 
 /**
- * Send upgrade command
+ * Upload an agent upgrade package into the agent's session-private staging area.
+ *
+ * On success, *transferId receives the request ID used for the upload, which
+ * the caller must pass back via VID_TRANSFER_ID when triggering the upgrade.
+ * Returns ERR_NOT_IMPLEMENTED / ERR_UNKNOWN_COMMAND when the agent is too old
+ * to support this flow; callers should fall back to uploadFile() + startUpgrade().
  */
-uint32_t AgentConnection::startUpgrade(const TCHAR *pkgName)
+uint32_t AgentConnection::uploadAgentUpgradePackage(const TCHAR *localFile, uint32_t *transferId,
+      std::function<void (size_t)> progressCallback, uint32_t bandwidthLimit)
+{
+   if (!m_isConnected)
+      return ERR_NOT_CONNECTED;
+
+   uint32_t requestId = generateRequestId();
+   NXCPMessage setup(CMD_SETUP_AGENT_UPGRADE, requestId, m_nProtocolVersion);
+   if (!sendMessage(&setup))
+      return ERR_CONNECTION_BROKEN;
+
+   uint32_t rcc = waitForRCC(requestId, m_commandTimeout);
+   if (rcc != ERR_SUCCESS)
+      return rcc;
+
+   shared_ptr<AbstractCommChannel> channel = acquireChannel();
+   if (channel == nullptr)
+      return ERR_CONNECTION_BROKEN;
+
+   debugPrintf(5, _T("Streaming agent upgrade package \"%s\" into private staging area"), localFile);
+   m_fileUploadInProgress = true;
+   shared_ptr<NXCPEncryptionContext> ctx = acquireEncryptionContext();
+
+   FileUploadContext context;
+   context.connection = this;
+   context.userCallback = progressCallback;
+   context.lastProbeTime = time(nullptr);
+   context.messageCount = 0;
+
+   if (SendFileOverNXCP(channel.get(), requestId, localFile, ctx.get(), 0, FileUploadProgressCalback, &context,
+            &m_mutexSocketWrite, NXCP_STREAM_COMPRESSION_NONE, nullptr, bandwidthLimit))
+   {
+      rcc = waitForRCC(requestId, std::max(m_commandTimeout, static_cast<uint32_t>(30000)));
+   }
+   else
+   {
+      rcc = ERR_IO_FAILURE;
+   }
+   m_fileUploadInProgress = false;
+
+   if ((rcc == ERR_SUCCESS) && (transferId != nullptr))
+      *transferId = requestId;
+   return rcc;
+}
+
+/**
+ * Send upgrade command. If transferId is non-zero, references a session-private
+ * staging file uploaded via uploadAgentUpgradePackage(); otherwise pkgName must
+ * name a file previously uploaded into the agent's file store via uploadFile().
+ */
+uint32_t AgentConnection::startUpgrade(const TCHAR *pkgName, uint32_t transferId)
 {
    if (!m_isConnected)
       return ERR_NOT_CONNECTED;
 
    NXCPMessage request(CMD_UPGRADE_AGENT, generateRequestId(), m_nProtocolVersion);
-   int i;
-   for(i = (int)_tcslen(pkgName) - 1;
-       (i >= 0) && (pkgName[i] != '\\') && (pkgName[i] != '/'); i--);
-   request.setField(VID_FILE_NAME, &pkgName[i + 1]);
+   if (transferId != 0)
+   {
+      request.setField(VID_TRANSFER_ID, transferId);
+   }
+   else
+   {
+      int i;
+      for(i = (int)_tcslen(pkgName) - 1;
+          (i >= 0) && (pkgName[i] != '\\') && (pkgName[i] != '/'); i--);
+      request.setField(VID_FILE_NAME, &pkgName[i + 1]);
+   }
 
    uint32_t rcc;
    if (sendMessage(&request))


### PR DESCRIPTION
## Summary
This change introduces a new isolated upgrade flow for agent packages that allows servers configured with upgrade-only access (without master server privileges) to deploy agent upgrades. The implementation adds a session-private staging area for upgrade packages, separate from the general file store.

## Key Changes

### Agent-side changes (nxagentd)
- Added `UpgradeServers` configuration option to specify servers with upgrade-only access
- Extended `ServerInfo` class to track upgrade server status
- Modified `CommSession` to support upgrade server designation and manage pending upgrade files
- Implemented `setupAgentUpgrade()` method to create isolated staging directories for upgrade packages
- Enhanced `upgrade()` method to support both new flow (via `VID_TRANSFER_ID`) and legacy flow (via `VID_FILE_NAME`)
- Added cleanup of pending upgrade files in session destructor
- Updated server validation to check upgrade server status alongside master/control flags
- Added `CMD_SETUP_AGENT_UPGRADE` command handler

### Server-side changes (libnxsrv)
- Added `uploadAgentUpgradePackage()` method to stream packages into agent's private staging area
- Modified `startUpgrade()` to accept optional `transferId` parameter for new flow
- Maintains backward compatibility with legacy file store-based upgrades

### Package deployment changes (package.cpp)
- Updated `PackageDeploymentJob::execute()` to prefer new isolated upload flow for agent installers
- Implements fallback to legacy `uploadFile()` for older agents that don't support `CMD_SETUP_AGENT_UPGRADE`
- Passes transfer ID to upgrade command when using new flow

### Protocol changes
- Added `CMD_SETUP_AGENT_UPGRADE` (0x0209) command to NXCP protocol
- Updated server capability flags to indicate upgrade server support (0x04 flag)

## Implementation Details

- Upgrade packages are stored in `<FileStore>/upgrade/` subdirectory with randomized filenames to prevent path traversal
- Session-private staging files are automatically cleaned up on session teardown
- The new flow uses the same request ID for both upload and upgrade trigger, linking them together
- Backward compatibility is maintained: master servers can still use the legacy flow, and older agents automatically fall back to it
- Access control: upgrade-only servers can only use the new isolated flow; legacy flow requires master server access

https://claude.ai/code/session_01N3jrCBk3DckyekLTFkVn6V