### PR TITLE
fix: handle NULL items.transformed_datatype in DB migration

### DIFF
--- a/src/server/tools/nxdbmgr/migrate.cpp
+++ b/src/server/tools/nxdbmgr/migrate.cpp
@@ -159,6 +159,7 @@ static COLUMN_IDENTIFIER s_integerFixColumns[] =
    { _T("dct_threshold_instances"), "tt_row_number" },
    { _T("event_policy"), "modification_time" },
    { _T("graphs"), "flags" },
+   { _T("items"), "transformed_datatype" },
    { _T("network_maps"), "bg_zoom" },
    { _T("nodes"), "capabilities" },
    { _T("nodes"), "port_rows" },


### PR DESCRIPTION
## Summary

- `items.transformed_datatype` was added by upgrade v51.17 as `integer NOT NULL`, with a backfill to value `6` and a deferred `NOT NULL` constraint. If any row escapes the backfill (interrupted upgrade, source DB engine where `DBSetNotNullConstraint` silently no-op'd, etc.), it stays NULL.
- `nxdbmgr` reads NULLs as empty strings and only rewrites them to `'0'` for columns listed in the hardcoded `s_integerFixColumns` allowlist in `src/server/tools/nxdbmgr/migrate.cpp`. `transformed_datatype` was missing from that list, so the empty string went straight to the destination — PostgreSQL rejected it with `22P02 invalid input syntax for type integer: ""`.
- Adding the column to the allowlist restores the empty-string → `'0'` rewrite, matching how every other recently-added NOT NULL integer column is handled.

Closes #3284

## Test plan

- [ ] Build `nxdbmgr` (`make -C src/server/tools/nxdbmgr`)
- [ ] Reproduce on a source DB with `UPDATE items SET transformed_datatype = NULL WHERE item_id = <any>`, run `nxdbmgr migrate` to PostgreSQL — migration succeeds, target row has `transformed_datatype = 0`
- [ ] PGSQL → TSDB and TSDB → PGSQL paths both pass
- [ ] Existing rows with a real value are migrated unchanged