### PR TITLE
fix: correct EventOrigin numbering in logs

### DIFF
--- a/src/server/aitools/logs.cpp
+++ b/src/server/aitools/logs.cpp
@@ -1537,20 +1537,25 @@ std::string F_SearchEvents(json_t *arguments, uint32_t userId)
    int originValue = -1;
    if ((originFilter != nullptr) && (originFilter[0] != 0))
    {
+      // Map origin name to its canonical EventOrigin enum value (see nms_events.h)
       if (!stricmp(originFilter, "SYSTEM"))
-         originValue = 0;
+         originValue = static_cast<int>(EventOrigin::SYSTEM);
       else if (!stricmp(originFilter, "AGENT"))
-         originValue = 1;
-      else if (!stricmp(originFilter, "SNMP"))
-         originValue = 2;
+         originValue = static_cast<int>(EventOrigin::AGENT);
+      else if (!stricmp(originFilter, "CLIENT"))
+         originValue = static_cast<int>(EventOrigin::CLIENT);
       else if (!stricmp(originFilter, "SYSLOG"))
-         originValue = 3;
-      else if (!stricmp(originFilter, "WINDOWS_EVENT"))
-         originValue = 4;
-      else if (!stricmp(originFilter, "SCRIPT"))
-         originValue = 5;
+         originValue = static_cast<int>(EventOrigin::SYSLOG);
+      else if (!stricmp(originFilter, "SNMP"))
+         originValue = static_cast<int>(EventOrigin::SNMP);
+      else if (!stricmp(originFilter, "NXSL") || !stricmp(originFilter, "SCRIPT"))
+         originValue = static_cast<int>(EventOrigin::NXSL);
       else if (!stricmp(originFilter, "REMOTE_SERVER"))
-         originValue = 6;
+         originValue = static_cast<int>(EventOrigin::REMOTE_SERVER);
+      else if (!stricmp(originFilter, "WINDOWS_EVENT"))
+         originValue = static_cast<int>(EventOrigin::WINDOWS_EVENT);
+      else if (!stricmp(originFilter, "OPENTELEMETRY"))
+         originValue = static_cast<int>(EventOrigin::OPENTELEMETRY);
    }
 
    // Build query

--- a/src/server/aitools/main.cpp
+++ b/src/server/aitools/main.cpp
@@ -942,7 +942,7 @@ static void CreateAssistantSkillList()
                { "time_to", "end time (default: now)" },
                { "event_code", "event code or name" },
                { "severity", "severity (0=Normal to 4=Critical) or array" },
-               { "origin", "event origin (SYSTEM, SNMP, SYSLOG, AGENT, SCRIPT)" },
+               { "origin", "event origin (SYSTEM, AGENT, CLIENT, SYSLOG, SNMP, NXSL, REMOTE_SERVER, WINDOWS_EVENT, OPENTELEMETRY)" },
                { "tags", "event tags filter" },
                { "text_pattern", "text search in message" },
                { "limit", "max results (default: 100)" }


### PR DESCRIPTION
## Summary

The AI log search tool (`F_SearchEvents` in `src/server/aitools/logs.cpp`) parsed `origin` name filters using a hardcoded numbering that no longer matched the canonical `EventOrigin` enum in `src/server/include/nms_events.h`. This change derives every origin value directly from the enum so the mapping stays in sync.

## Why this matters

As diagnosed in #3293, the stale filter numbering caused the AI log tools to match the wrong events:

- Filtering by `SNMP` mapped to value `2`, which is actually `CLIENT`, so it returned CLIENT events.
- Filtering by `WINDOWS_EVENT` mapped to value `4`, which is actually `SNMP`, so it returned SNMP events.
- `CLIENT` and `NXSL` filters were not handled at all and were silently ignored.

The companion "Bug 1" from the issue (`GetEventOriginName()` at the old `logs.cpp:104-117`) no longer exists on `master`: origin labeling now goes through the canonical `EventOriginName()` defined in `nms_events.h`, which already covers all values 0-8 correctly (and is used at `logs.cpp:1697`). So only the origin filter parser needed correcting.

## Changes

- `src/server/aitools/logs.cpp`: map each origin name to its value via `static_cast<int>(EventOrigin::X)` instead of magic numbers; add the missing `CLIENT` and `NXSL` cases (with `SCRIPT` kept as a backward-compatible alias for `NXSL`); add `OPENTELEMETRY` so the parser already lines up with `EventOrigin::OPENTELEMETRY = 8`.
- `src/server/aitools/main.cpp`: update the `origin` parameter description advertised to the assistant to list all valid origin names (`SYSTEM, AGENT, CLIENT, SYSLOG, SNMP, NXSL, REMOTE_SERVER, WINDOWS_EVENT, OPENTELEMETRY`).

## Testing

Full `netxmsd` build requires the generated `config.h` and the complete server dependency tree, so I did not run a full build locally. I verified correctness by review against the canonical enum: every branch now uses the typed `EventOrigin` enumerator (no magic numbers), `EventOrigin` is in scope via `nms_core.h`, and round-trip holds — a label produced by `EventOriginName()` parses back to the same enum value (e.g. `SNMP` -> 4, `WINDOWS_EVENT` -> 7, `NXSL` -> 5).

Fixes #3293

AI was used for assistance.
