### PR TITLE
Add Prometheus endpoint scraper to subagent

### DIFF
--- a/doc/internal/debug_tags.txt
+++ b/doc/internal/debug_tags.txt
@@ -205,6 +205,8 @@ poll.topology	Topology poll
 
 portcheck	Portcheck subagent messages
 
+prometheus	Prometheus subagent
+
 proc.*		Process related trace
 proc.spexec	Sub-process executor
 procexec	Process executor

--- a/src/agent/subagents/prometheus/Makefile.am
+++ b/src/agent/subagents/prometheus/Makefile.am
@@ -7,7 +7,7 @@ generated/%.pb.cc generated/%.pb.h: %.proto
 	@PROTOC@ --cpp_out=generated --proto_path=. $<
 
 pkglib_LTLIBRARIES = prometheus.la
-prometheus_la_SOURCES = main.cpp receiver.cpp handler.cpp printer.cpp
+prometheus_la_SOURCES = main.cpp receiver.cpp handler.cpp parser.cpp printer.cpp scraper.cpp
 nodist_prometheus_la_SOURCES = generated/remote.pb.cc generated/types.pb.cc
 prometheus_la_CPPFLAGS = -I@top_srcdir@/include -I@top_srcdir@/build \
                          -I$(srcdir)/generated @PROTOBUF_CPPFLAGS@ @MICROHTTPD_CPPFLAGS@ @SNAPPY_CPPFLAGS@ @ABSEIL_CPPFLAGS@

--- a/src/agent/subagents/prometheus/README.md
+++ b/src/agent/subagents/prometheus/README.md
@@ -2,28 +2,59 @@
 
 ## Overview
 
-The Prometheus subagent receives metrics via Prometheus remote write protocol and pushes selected metrics to the NetXMS server.
+The Prometheus subagent integrates Prometheus-style metrics into NetXMS in two ways:
+
+- **Remote write receiver** (passive) - receives metrics pushed via Prometheus remote write protocol
+- **Endpoint scraper** (active) - periodically scrapes `/metrics` endpoints exposing Prometheus text exposition format / OpenMetrics
+
+Both modes can be used at the same time and share the same metric mapping mechanism for pushing selected metrics to the NetXMS server.
 
 ## Configuration Section
 
-All configuration options are placed in the `[Prometheus]` section of the agent configuration file.
+All common configuration options are placed in the `[Prometheus]` section of the agent configuration file.
 
-### Server Options
+### Receiver Options
 
 ```ini
 [Prometheus]
+EnableReceiver = yes
 Port = 9090
 Address = 127.0.0.1
 Endpoint = /api/v1/write
 ```
 
-- **Port** (required) - TCP port to listen on for incoming Prometheus remote write requests
+- **EnableReceiver** (optional, default: yes) - enable or disable the remote write receiver
+- **Port** (optional, default: 9090) - TCP port to listen on for incoming Prometheus remote write requests
 - **Address** (optional, default: 127.0.0.1) - IP address to bind to
 - **Endpoint** (optional, default: /api/v1/write) - HTTP endpoint path for receiving data
 
+### Scrape Targets
+
+Each scrape target is defined in its own `[Prometheus/Targets/name]` section, where `name` is a target name of your choice (used as the first argument of `Prometheus.*` metrics):
+
+```ini
+[Prometheus/Targets/kafka]
+URL = http://localhost:9308/metrics
+ScrapeInterval = 60
+Timeout = 10
+Login = monitoring
+Password = secret
+VerifyCertificate = yes
+VerifyHost = yes
+```
+
+- **URL** (required) - HTTP or HTTPS URL of the metrics endpoint; can point to localhost or a remote host (agent acting as proxy)
+- **ScrapeInterval** (optional, default: 60) - scrape interval in seconds
+- **Timeout** (optional, default: 10) - request timeout in seconds
+- **Login** / **Password** (optional) - credentials for HTTP basic authentication; password can be encrypted with nxencpasswd
+- **BearerToken** (optional) - token for bearer authentication (takes precedence over Login/Password)
+- **VerifyCertificate** (optional, default: yes) - verify server certificate when using HTTPS
+- **VerifyHost** (optional, default: yes) - verify that server certificate matches host name when using HTTPS
+- **CACertificate** (optional) - path to CA certificate bundle used for server certificate validation
+
 ### Metric Mappings
 
-Define which Prometheus metrics should be forwarded to NetXMS and how they should be named.
+Define which Prometheus metrics should be forwarded to NetXMS as push DCIs and how they should be named. Mappings apply to metrics received via remote write and to scraped samples alike.
 
 #### Format 1: Based on Prometheus metric value
 
@@ -88,6 +119,34 @@ Pushed to NetXMS:
 Node.Uname(server1) = "Linux 5.14.0-570.17.1.el9_6.x86_64 #1 SMP PREEMPT_DYNAMIC Tue May 13 06:41:18 EDT 2025"
 ```
 
+## Provided Metrics
+
+Scraped samples are kept in memory (last scrape per target) and can be queried directly, without configuring mappings:
+
+| Metric | Description |
+|--------|-------------|
+| `Prometheus.Value(target, metric, label=value...)` | Value of given metric; optional `label=value` arguments select a specific time series |
+| `Prometheus.Target.Status(target)` | 1 if last scrape of given target was successful, 0 otherwise |
+| `Prometheus.Target.LastScrapeTime(target)` | UNIX timestamp of last scrape attempt |
+| `Prometheus.Target.SampleCount(target)` | Number of samples collected by last successful scrape |
+
+| List | Description |
+|------|-------------|
+| `Prometheus.Targets` | Names of configured scrape targets |
+| `Prometheus.LabelValues(target, metric, label)` | Unique values of given label across all time series of given metric |
+
+| Table | Description |
+|-------|-------------|
+| `Prometheus.Targets` | Configured scrape targets with status information |
+| `Prometheus.Series(target, metric)` | One row per time series of given metric: canonical labelset, one column per label, and current value |
+
+## Instance Discovery
+
+Lists and tables above are designed for DCI instance discovery, so prototype DCIs can auto-instantiate per labelset:
+
+- **Single label** (e.g. one instance per Kafka topic): use *Agent List* `Prometheus.LabelValues(kafka, kafka_topic_partitions, topic)` for discovery and `Prometheus.Value(kafka, kafka_topic_partitions, topic={instance})` as the prototype metric.
+- **Multiple labels**: use *Agent Table* `Prometheus.Series(target, metric)` for discovery; the instance column `LABELS` contains the labelset in `label=value,label=value` form (values quoted when necessary), which can be passed directly as label filters: `Prometheus.Value(target, metric, {instance})`.
+
 ## Complete Example
 
 ```ini
@@ -99,13 +158,23 @@ Endpoint = /api/v1/write
 Metric=node_network_transmit_drop_total:Net.Interface.TxDrops:nodename,device
 Metric=node_network_receive_drop_total:Net.Interface.RxDrops:nodename,device
 Metric=node_uname_info:Node.Uname:nodename:sysname,release,version
+
+[Prometheus/Targets/haproxy]
+URL = http://127.0.0.1:8404/metrics
+ScrapeInterval = 30
+
+[Prometheus/Targets/etcd]
+URL = https://etcd1.example.com:2379/metrics
+CACertificate = /etc/ssl/etcd-ca.pem
+BearerToken = exampletoken
 ```
 
 ## Behavior Notes
 
-- Only metrics with configured mappings are processed; others are ignored
-- Unmatched metrics are logged at debug level 6
+- Mappings: only metrics with configured mappings are pushed; others are ignored (logged at debug level 6)
 - If a required label is missing, an empty string is used for that argument
-- Label values are not escaped; special characters (parentheses, commas) may cause issues
 - Configuration is loaded at agent startup; restart required for changes
 - Multiple samples per metric are supported; each sample is pushed separately
+- Scraper keeps data of the last scrape only; if a scrape fails, data from the previous successful scrape remains available (monitor `Prometheus.Target.Status` to detect scrape failures)
+- Histogram and summary metrics are exposed by Prometheus endpoints as separate `_bucket`/`_sum`/`_count` series and can be queried as such
+- `# HELP`, `# TYPE`, and other comment lines, timestamps, and OpenMetrics exemplars are ignored by the parser

--- a/src/agent/subagents/prometheus/handler.cpp
+++ b/src/agent/subagents/prometheus/handler.cpp
@@ -1,6 +1,6 @@
 /*
-** NetXMS Prometheus remote write receiver subagent
-** Copyright (C) 2025 Raden Solutions
+** NetXMS Prometheus subagent
+** Copyright (C) 2025-2026 Raden Solutions
 **
 ** This program is free software; you can redistribute it and/or modify
 ** it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ static const char *GetLabelValue(const prometheus::TimeSeries& ts, const char *n
    return nullptr;
 }
 
-static void AppendEscapedValue(StringBuffer& result, const TCHAR *value)
+void AppendEscapedValue(StringBuffer& result, const TCHAR *value)
 {
    bool needsQuoting = false;
    for (const TCHAR *p = value; *p != 0; p++)
@@ -61,7 +61,7 @@ static void AppendEscapedValue(StringBuffer& result, const TCHAR *value)
    result.append(_T('"'));
 }
 
-static String BuildMetricName(const MetricMapping& mapping, const prometheus::TimeSeries& ts)
+static String BuildMetricName(const MetricMapping& mapping, std::function<const char* (const char*)> getLabel)
 {
    StringBuffer result;
    result.append(mapping.netxmsName);
@@ -76,7 +76,7 @@ static String BuildMetricName(const MetricMapping& mapping, const prometheus::Ti
 #ifdef UNICODE
       char nameBuffer[256];
       WideCharToMultiByteSysLocale(mapping.nameArguments.get(i), nameBuffer, 256);
-      const char *value = GetLabelValue(ts, nameBuffer);
+      const char *value = getLabel(nameBuffer);
       if (value != nullptr)
       {
          WCHAR valueBuffer[1024];
@@ -84,7 +84,7 @@ static String BuildMetricName(const MetricMapping& mapping, const prometheus::Ti
          AppendEscapedValue(result, valueBuffer);
       }
 #else
-      const char *value = GetLabelValue(ts, mapping.nameArguments.get(i));
+      const char *value = getLabel(mapping.nameArguments.get(i));
       if (value != nullptr)
       {
          AppendEscapedValue(result, value);
@@ -97,7 +97,7 @@ static String BuildMetricName(const MetricMapping& mapping, const prometheus::Ti
    return result;
 }
 
-static String BuildValueFromLabels(const MetricMapping& mapping, const prometheus::TimeSeries& ts)
+static String BuildValueFromLabels(const MetricMapping& mapping, std::function<const char* (const char*)> getLabel)
 {
    StringBuffer result;
    bool first = true;
@@ -109,7 +109,7 @@ static String BuildValueFromLabels(const MetricMapping& mapping, const prometheu
 #ifdef UNICODE
       char nameBuffer[256];
       WideCharToMultiByteSysLocale(mapping.valueArguments.get(i), nameBuffer, 256);
-      const char *value = GetLabelValue(ts, nameBuffer);
+      const char *value = getLabel(nameBuffer);
       if (value != nullptr)
       {
          WCHAR valueBuffer[1024];
@@ -117,7 +117,7 @@ static String BuildValueFromLabels(const MetricMapping& mapping, const prometheu
          result.append(valueBuffer);
       }
 #else
-      const char *value = GetLabelValue(ts, mapping.valueArguments.get(i));
+      const char *value = getLabel(mapping.valueArguments.get(i));
       if (value != nullptr)
       {
          result.append(value);
@@ -129,10 +129,53 @@ static String BuildValueFromLabels(const MetricMapping& mapping, const prometheu
    return result;
 }
 
-static void ProcessWriteRequest(const prometheus::WriteRequest& request)
+/**
+ * Match single sample against configured metric mappings and push to server if mapping found
+ */
+void ProcessSample(const char *metricName, double value, std::function<const char* (const char*)> getLabel)
 {
    const ObjectArray<MetricMapping>& mappings = GetMetricMappings();
-   if (mappings.isEmpty())
+
+   const MetricMapping *matchedMapping = nullptr;
+   for(int j = 0; j < mappings.size(); j++)
+   {
+#ifdef UNICODE
+      char prometheusNameMB[256];
+      WideCharToMultiByteSysLocale(mappings.get(j)->prometheusName, prometheusNameMB, 256);
+      if (strcmp(metricName, prometheusNameMB) == 0)
+#else
+      if (strcmp(metricName, mappings.get(j)->prometheusName) == 0)
+#endif
+      {
+         matchedMapping = mappings.get(j);
+         break;
+      }
+   }
+
+   if (matchedMapping == nullptr)
+   {
+      nxlog_debug_tag(DEBUG_TAG, 6, _T("No mapping found for metric: %hs"), metricName);
+      return;
+   }
+
+   String metricNameStr = BuildMetricName(*matchedMapping, getLabel);
+
+   if (matchedMapping->useMetricValue)
+   {
+      AgentPushParameterDataDouble(metricNameStr, value);
+      nxlog_debug_tag(DEBUG_TAG, 7, _T("Pushed metric: %s = %.2f"), metricNameStr.cstr(), value);
+   }
+   else
+   {
+      String labelValue = BuildValueFromLabels(*matchedMapping, getLabel);
+      AgentPushParameterData(metricNameStr, labelValue);
+      nxlog_debug_tag(DEBUG_TAG, 7, _T("Pushed metric: %s = %s"), metricNameStr.cstr(), labelValue.cstr());
+   }
+}
+
+static void ProcessWriteRequest(const prometheus::WriteRequest& request)
+{
+   if (GetMetricMappings().isEmpty())
    {
       return;
    }
@@ -147,48 +190,9 @@ static void ProcessWriteRequest(const prometheus::WriteRequest& request)
          continue;
       }
 
-      const MetricMapping *matchedMapping = nullptr;
-      for(int j = 0; j < mappings.size(); j++)
-      {
-#ifdef UNICODE
-         char prometheusNameMB[256];
-         WideCharToMultiByteSysLocale(mappings.get(j)->prometheusName, prometheusNameMB, 256);
-         if (strcmp(metricName, prometheusNameMB) == 0)
-#else
-         if (strcmp(metricName, mappings.get(j)->prometheusName) == 0)
-#endif
-         {
-            matchedMapping = mappings.get(j);
-            break;
-         }
-      }
-
-      if (matchedMapping == nullptr)
-      {
-         nxlog_debug_tag(DEBUG_TAG, 6, _T("No mapping found for metric: %hs"), metricName);
-         continue;
-      }
-
-      if (ts.samples_size() == 0)
-      {
-         continue;
-      }
-
       for (const auto& sample : ts.samples())
       {
-         String metricNameStr = BuildMetricName(*matchedMapping, ts);
-
-         if (matchedMapping->useMetricValue)
-         {
-            AgentPushParameterDataDouble(metricNameStr, sample.value());
-            nxlog_debug_tag(DEBUG_TAG, 7, _T("Pushed metric: %s = %.2f"), metricNameStr.cstr(), sample.value());
-         }
-         else
-         {
-            String value = BuildValueFromLabels(*matchedMapping, ts);
-            AgentPushParameterData(metricNameStr, value);
-            nxlog_debug_tag(DEBUG_TAG, 7, _T("Pushed metric: %s = %s"), metricNameStr.cstr(), value.cstr());
-         }
+         ProcessSample(metricName, sample.value(), [&ts] (const char *name) { return GetLabelValue(ts, name); });
       }
    }
 }

--- a/src/agent/subagents/prometheus/handler.cpp
+++ b/src/agent/subagents/prometheus/handler.cpp
@@ -61,7 +61,7 @@ void AppendEscapedValue(StringBuffer& result, const TCHAR *value)
    result.append(_T('"'));
 }
 
-static String BuildMetricName(const MetricMapping& mapping, std::function<const char* (const char*)> getLabel)
+static String BuildMetricName(const MetricMapping& mapping, const std::function<const char* (const char*)>& getLabel)
 {
    StringBuffer result;
    result.append(mapping.netxmsName);
@@ -97,7 +97,7 @@ static String BuildMetricName(const MetricMapping& mapping, std::function<const 
    return result;
 }
 
-static String BuildValueFromLabels(const MetricMapping& mapping, std::function<const char* (const char*)> getLabel)
+static String BuildValueFromLabels(const MetricMapping& mapping, const std::function<const char* (const char*)>& getLabel)
 {
    StringBuffer result;
    bool first = true;
@@ -132,7 +132,7 @@ static String BuildValueFromLabels(const MetricMapping& mapping, std::function<c
 /**
  * Match single sample against configured metric mappings and push to server if mapping found
  */
-void ProcessSample(const char *metricName, double value, std::function<const char* (const char*)> getLabel)
+void ProcessSample(const char *metricName, double value, const std::function<const char* (const char*)>& getLabel)
 {
    const ObjectArray<MetricMapping>& mappings = GetMetricMappings();
 
@@ -140,9 +140,7 @@ void ProcessSample(const char *metricName, double value, std::function<const cha
    for(int j = 0; j < mappings.size(); j++)
    {
 #ifdef UNICODE
-      char prometheusNameMB[256];
-      WideCharToMultiByteSysLocale(mappings.get(j)->prometheusName, prometheusNameMB, 256);
-      if (strcmp(metricName, prometheusNameMB) == 0)
+      if (strcmp(metricName, mappings.get(j)->prometheusNameMB) == 0)
 #else
       if (strcmp(metricName, mappings.get(j)->prometheusName) == 0)
 #endif

--- a/src/agent/subagents/prometheus/main.cpp
+++ b/src/agent/subagents/prometheus/main.cpp
@@ -103,24 +103,32 @@ const ObjectArray<MetricMapping>& GetMetricMappings()
  */
 static bool SubagentInit(Config *config)
 {
-   uint16_t port = static_cast<uint16_t>(config->getValueAsUInt(_T("/Prometheus/Port"), 9090));
-   if (port == 0)
-   {
-      nxlog_write_tag(NXLOG_ERROR, DEBUG_TAG, _T("Port not configured"));
-      return false;
-   }
-
-   const TCHAR *endpoint = config->getValue(_T("/Prometheus/Endpoint"), _T("/api/v1/write"));
-   const TCHAR *listen = config->getValue(_T("/Prometheus/Address"), _T("127.0.0.1"));
-
    LoadMetricMappings(config);
+   LoadScrapeTargets(config);
 
-   if (!StartReceiver(listen, port, endpoint))
+   if (config->getValueAsBoolean(_T("/Prometheus/EnableReceiver"), true))
    {
-      return false;
+      uint16_t port = static_cast<uint16_t>(config->getValueAsUInt(_T("/Prometheus/Port"), 9090));
+      if (port == 0)
+      {
+         nxlog_write_tag(NXLOG_ERROR, DEBUG_TAG, _T("Port not configured"));
+         return false;
+      }
+
+      const TCHAR *endpoint = config->getValue(_T("/Prometheus/Endpoint"), _T("/api/v1/write"));
+      const TCHAR *listen = config->getValue(_T("/Prometheus/Address"), _T("127.0.0.1"));
+
+      if (!StartReceiver(listen, port, endpoint))
+      {
+         return false;
+      }
+
+      nxlog_debug_tag(DEBUG_TAG, 1, _T("Prometheus remote write receiver initialized at http://%s:%d%s"), listen, port, endpoint);
    }
 
-   nxlog_debug_tag(DEBUG_TAG, 1, _T("Prometheus subagent initialized at http://%s:%d%s"), listen, port, endpoint);
+   StartScrapers();
+
+   nxlog_debug_tag(DEBUG_TAG, 1, _T("Prometheus subagent initialized"));
    return true;
 }
 
@@ -130,8 +138,38 @@ static bool SubagentInit(Config *config)
 static void SubagentShutdown()
 {
    StopReceiver();
+   StopScrapers();
    nxlog_debug_tag(DEBUG_TAG, 1, _T("Prometheus subagent shutdown"));
 }
+
+/**
+ * Supported parameters
+ */
+static NETXMS_SUBAGENT_PARAM s_parameters[] =
+{
+   { _T("Prometheus.Target.LastScrapeTime(*)"), H_TargetInfo, _T("T"), DCI_DT_UINT64, _T("Prometheus: timestamp of last scrape of target {instance}") },
+   { _T("Prometheus.Target.SampleCount(*)"), H_TargetInfo, _T("C"), DCI_DT_UINT, _T("Prometheus: number of samples in last scrape of target {instance}") },
+   { _T("Prometheus.Target.Status(*)"), H_TargetInfo, _T("S"), DCI_DT_INT, _T("Prometheus: status of last scrape of target {instance}") },
+   { _T("Prometheus.Value(*)"), H_TargetValue, nullptr, DCI_DT_FLOAT, _T("Prometheus: value of metric {instance}") }
+};
+
+/**
+ * Supported lists
+ */
+static NETXMS_SUBAGENT_LIST s_lists[] =
+{
+   { _T("Prometheus.LabelValues(*)"), H_LabelValues, nullptr },
+   { _T("Prometheus.Targets"), H_TargetList, nullptr }
+};
+
+/**
+ * Supported tables
+ */
+static NETXMS_SUBAGENT_TABLE s_tables[] =
+{
+   { _T("Prometheus.Series(*)"), H_SeriesTable, nullptr, _T("LABELS"), _T("Prometheus: time series of metric") },
+   { _T("Prometheus.Targets"), H_TargetsTable, nullptr, _T("NAME"), _T("Prometheus: configured scrape targets") }
+};
 
 /**
  * Subagent information
@@ -141,9 +179,9 @@ static NETXMS_SUBAGENT_INFO s_info =
    NETXMS_SUBAGENT_INFO_MAGIC,
    _T("PROMETHEUS"), NETXMS_VERSION_STRING,
    SubagentInit, SubagentShutdown, nullptr, nullptr, nullptr,
-   0, nullptr, // parameters
-   0, nullptr, // lists
-   0, nullptr, // tables
+   sizeof(s_parameters) / sizeof(NETXMS_SUBAGENT_PARAM), s_parameters,
+   sizeof(s_lists) / sizeof(NETXMS_SUBAGENT_LIST), s_lists,
+   sizeof(s_tables) / sizeof(NETXMS_SUBAGENT_TABLE), s_tables,
    0, nullptr, // actions
    0, nullptr  // push parameters
 };

--- a/src/agent/subagents/prometheus/main.cpp
+++ b/src/agent/subagents/prometheus/main.cpp
@@ -37,6 +37,9 @@ static bool ParseMetricMapping(const TCHAR *config, MetricMapping **result)
 
    MetricMapping *mapping = new MetricMapping();
    _tcslcpy(mapping->prometheusName, parts.get(0), 256);
+#ifdef UNICODE
+   WideCharToMultiByteSysLocale(mapping->prometheusName, mapping->prometheusNameMB, 256);
+#endif
    _tcslcpy(mapping->netxmsName, parts.get(1), 256);
 
    StringList nameArgs = String(parts.get(2)).split(_T(","));

--- a/src/agent/subagents/prometheus/parser.cpp
+++ b/src/agent/subagents/prometheus/parser.cpp
@@ -160,6 +160,11 @@ static MetricSample *ParseSampleLine(const char *line, const char *end)
    while((p < end) && (*p != ' ') && (*p != '\t') && (tokenLen < sizeof(token) - 1))
       token[tokenLen++] = *p++;
    token[tokenLen] = 0;
+   if ((p < end) && (*p != ' ') && (*p != '\t'))
+   {
+      delete sample;   // value token too long to be valid, reject instead of parsing truncated prefix
+      return nullptr;
+   }
 
    char *eptr;
    double value = strtod(token, &eptr);

--- a/src/agent/subagents/prometheus/parser.cpp
+++ b/src/agent/subagents/prometheus/parser.cpp
@@ -1,0 +1,215 @@
+/*
+** NetXMS Prometheus subagent
+** Copyright (C) 2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+**/
+
+#include "prometheus.h"
+
+/**
+ * Check if character is valid within metric or label name
+ */
+static inline bool IsNameChar(char c)
+{
+   return ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) || ((c >= '0') && (c <= '9')) || (c == '_') || (c == ':') || (c == '.');
+}
+
+/**
+ * Skip spaces and tabs
+ */
+static inline const char *SkipWhitespace(const char *p, const char *end)
+{
+   while((p < end) && ((*p == ' ') || (*p == '\t')))
+      p++;
+   return p;
+}
+
+/**
+ * Parse single sample line in text exposition format:
+ *    metric_name [ '{' label '=' '"' value '"' [ ',' ... ] '}' ] value [ timestamp ]
+ * Returns nullptr if line cannot be parsed.
+ */
+static MetricSample *ParseSampleLine(const char *line, const char *end)
+{
+   const char *p = line;
+
+   const char *nameStart = p;
+   while((p < end) && IsNameChar(*p))
+      p++;
+   if (p == nameStart)
+      return nullptr;
+
+   MetricSample *sample = new MetricSample(nameStart, p - nameStart);
+
+   if ((p < end) && (*p == '{'))
+   {
+      p++;
+      while(true)
+      {
+         p = SkipWhitespace(p, end);
+         if (p >= end)
+         {
+            delete sample;
+            return nullptr;
+         }
+         if (*p == '}')
+         {
+            p++;
+            break;
+         }
+
+         const char *labelStart = p;
+         while((p < end) && IsNameChar(*p))
+            p++;
+         size_t labelLen = p - labelStart;
+         p = SkipWhitespace(p, end);
+         if ((p >= end) || (*p != '=') || (labelLen == 0))
+         {
+            delete sample;
+            return nullptr;
+         }
+         p = SkipWhitespace(p + 1, end);
+         if ((p >= end) || (*p != '"'))
+         {
+            delete sample;
+            return nullptr;
+         }
+         p++;
+
+         const char *valueStart = p;
+         while((p < end) && (*p != '"'))
+         {
+            if ((*p == '\\') && (p + 1 < end))
+               p++;
+            p++;
+         }
+         if (p >= end)
+         {
+            delete sample;
+            return nullptr;
+         }
+
+         char *value = MemAllocStringA(p - valueStart + 1);
+         char *out = value;
+         for(const char *s = valueStart; s < p; s++)
+         {
+            if ((*s == '\\') && (s + 1 < p))
+            {
+               s++;
+               if (*s == 'n')
+               {
+                  *out++ = '\n';
+               }
+               else if ((*s == '\\') || (*s == '"'))
+               {
+                  *out++ = *s;
+               }
+               else
+               {
+                  *out++ = '\\';
+                  *out++ = *s;
+               }
+            }
+            else
+            {
+               *out++ = *s;
+            }
+         }
+         *out = 0;
+         sample->addLabel(labelStart, labelLen, value);
+         p++;   // skip closing quote
+
+         p = SkipWhitespace(p, end);
+         if ((p < end) && (*p == ','))
+         {
+            p++;
+         }
+         else if ((p < end) && (*p != '}'))
+         {
+            delete sample;
+            return nullptr;
+         }
+      }
+   }
+
+   p = SkipWhitespace(p, end);
+   if (p >= end)
+   {
+      delete sample;
+      return nullptr;
+   }
+
+   // Copy value token into temporary buffer for strtod (line is not null-terminated);
+   // strtod handles special values NaN, +Inf, -Inf
+   char token[64];
+   size_t tokenLen = 0;
+   while((p < end) && (*p != ' ') && (*p != '\t') && (tokenLen < sizeof(token) - 1))
+      token[tokenLen++] = *p++;
+   token[tokenLen] = 0;
+
+   char *eptr;
+   double value = strtod(token, &eptr);
+   if (eptr == token)
+   {
+      delete sample;
+      return nullptr;
+   }
+   sample->setValue(value);
+
+   // Remainder of the line (timestamp, OpenMetrics exemplar) is ignored
+   return sample;
+}
+
+/**
+ * Parse document in Prometheus text exposition format / OpenMetrics text format.
+ * Comment, HELP, TYPE, and EOF lines are skipped; unparsable lines are logged and skipped.
+ */
+ObjectArray<MetricSample> *ParsePrometheusText(const char *data)
+{
+   auto samples = new ObjectArray<MetricSample>(256, 256, Ownership::True);
+   const char *p = data;
+   while(*p != 0)
+   {
+      const char *eol = strchr(p, '\n');
+      const char *lineEnd = (eol != nullptr) ? eol : p + strlen(p);
+      if ((lineEnd > p) && (*(lineEnd - 1) == '\r'))
+         lineEnd--;
+
+      const char *s = SkipWhitespace(p, lineEnd);
+      if ((s < lineEnd) && (*s != '#'))
+      {
+         MetricSample *sample = ParseSampleLine(s, lineEnd);
+         if (sample != nullptr)
+         {
+            samples->add(sample);
+         }
+         else
+         {
+            char fragment[121];
+            size_t len = std::min(static_cast<size_t>(lineEnd - s), sizeof(fragment) - 1);
+            memcpy(fragment, s, len);
+            fragment[len] = 0;
+            nxlog_debug_tag(DEBUG_TAG, 6, _T("Cannot parse exposition format line \"%hs\""), fragment);
+         }
+      }
+
+      if (eol == nullptr)
+         break;
+      p = eol + 1;
+   }
+   return samples;
+}

--- a/src/agent/subagents/prometheus/prometheus.h
+++ b/src/agent/subagents/prometheus/prometheus.h
@@ -32,6 +32,9 @@
 struct MetricMapping
 {
    TCHAR prometheusName[256];
+#ifdef UNICODE
+   char prometheusNameMB[256];   // multibyte version for matching against incoming metric names
+#endif
    TCHAR netxmsName[256];
    StringList nameArguments;
    StringList valueArguments;
@@ -40,6 +43,9 @@ struct MetricMapping
    MetricMapping()
    {
       prometheusName[0] = 0;
+#ifdef UNICODE
+      prometheusNameMB[0] = 0;
+#endif
       netxmsName[0] = 0;
       useMetricValue = true;
    }
@@ -182,7 +188,7 @@ public:
 
 bool HandleWriteRequest(const char *data, size_t size);
 const ObjectArray<MetricMapping>& GetMetricMappings();
-void ProcessSample(const char *metricName, double value, std::function<const char* (const char*)> getLabel);
+void ProcessSample(const char *metricName, double value, const std::function<const char* (const char*)>& getLabel);
 void AppendEscapedValue(StringBuffer& result, const TCHAR *value);
 
 ObjectArray<MetricSample> *ParsePrometheusText(const char *data);

--- a/src/agent/subagents/prometheus/prometheus.h
+++ b/src/agent/subagents/prometheus/prometheus.h
@@ -1,6 +1,6 @@
 /*
-** NetXMS Prometheus remote write receiver subagent
-** Copyright (C) 2025 Raden Solutions
+** NetXMS Prometheus subagent
+** Copyright (C) 2025-2026 Raden Solutions
 **
 ** This program is free software; you can redistribute it and/or modify
 ** it under the terms of the GNU General Public License as published by
@@ -45,13 +45,163 @@ struct MetricMapping
    }
 };
 
+/**
+ * Single label of a parsed metric sample (UTF-8 strings)
+ */
+struct SampleLabel
+{
+   char *name;
+   char *value;
+
+   SampleLabel(const char *n, size_t nameLen, char *v)
+   {
+      name = MemAllocStringA(nameLen + 1);
+      memcpy(name, n, nameLen);
+      name[nameLen] = 0;
+      value = v;   // takes ownership
+   }
+
+   ~SampleLabel()
+   {
+      MemFree(name);
+      MemFree(value);
+   }
+};
+
+/**
+ * Single sample parsed from text exposition format
+ */
+class MetricSample
+{
+private:
+   char *m_name;
+   ObjectArray<SampleLabel> m_labels;
+   double m_value;
+
+public:
+   MetricSample(const char *name, size_t nameLen) : m_labels(0, 8, Ownership::True)
+   {
+      m_name = MemAllocStringA(nameLen + 1);
+      memcpy(m_name, name, nameLen);
+      m_name[nameLen] = 0;
+      m_value = 0;
+   }
+
+   ~MetricSample()
+   {
+      MemFree(m_name);
+   }
+
+   void addLabel(const char *name, size_t nameLen, char *value)
+   {
+      m_labels.add(new SampleLabel(name, nameLen, value));
+   }
+
+   void setValue(double value)
+   {
+      m_value = value;
+   }
+
+   const char *getName() const { return m_name; }
+   double getValue() const { return m_value; }
+   const ObjectArray<SampleLabel>& getLabels() const { return m_labels; }
+
+   const char *getLabelValue(const char *name) const
+   {
+      for(int i = 0; i < m_labels.size(); i++)
+      {
+         if (strcmp(m_labels.get(i)->name, name) == 0)
+            return m_labels.get(i)->value;
+      }
+      return nullptr;
+   }
+};
+
+/**
+ * Endpoint scrape target
+ */
+class ScrapeTarget
+{
+private:
+   TCHAR m_name[64];
+   char m_url[1024];
+   uint32_t m_interval;         // milliseconds
+   uint32_t m_requestTimeout;   // milliseconds
+   char m_login[128];
+   char m_password[256];
+   char *m_bearerToken;
+   bool m_verifyPeer;
+   bool m_verifyHost;
+   char m_caCertificate[1024];
+   THREAD m_thread;
+   Condition m_stopCondition;
+   mutable Mutex m_lock;
+   ObjectArray<MetricSample> *m_samples;
+   time_t m_lastScrapeTime;
+   bool m_lastScrapeSuccess;
+
+   ScrapeTarget(const TCHAR *name);
+
+   void scraperThread();
+   bool scrape();
+
+public:
+   ~ScrapeTarget();
+
+   static ScrapeTarget *createFromConfig(const ConfigEntry& config);
+
+   void start();
+   void stop();
+
+   const TCHAR *getName() const { return m_name; }
+   const char *getUrl() const { return m_url; }
+   uint32_t getScrapeInterval() const { return m_interval / 1000; }
+
+   bool isLastScrapeSuccessful() const
+   {
+      LockGuard lockGuard(m_lock);
+      return m_lastScrapeSuccess;
+   }
+
+   time_t getLastScrapeTime() const
+   {
+      LockGuard lockGuard(m_lock);
+      return m_lastScrapeTime;
+   }
+
+   int getSampleCount() const
+   {
+      LockGuard lockGuard(m_lock);
+      return (m_samples != nullptr) ? m_samples->size() : 0;
+   }
+
+   LONG getValue(const char *metric, const ObjectArray<SampleLabel>& filters, TCHAR *value) const;
+   LONG getLabelValues(const char *metric, const char *label, StringList *output) const;
+   LONG fillSeriesTable(const char *metric, Table *table) const;
+};
+
 bool HandleWriteRequest(const char *data, size_t size);
 const ObjectArray<MetricMapping>& GetMetricMappings();
+void ProcessSample(const char *metricName, double value, std::function<const char* (const char*)> getLabel);
+void AppendEscapedValue(StringBuffer& result, const TCHAR *value);
+
+ObjectArray<MetricSample> *ParsePrometheusText(const char *data);
 
 void PrintWriteRequest(const prometheus::WriteRequest& request);
 
 bool StartReceiver(const TCHAR *listenAddress, uint16_t port, const TCHAR *endpoint);
 void StopReceiver();
+
+void LoadScrapeTargets(Config *config);
+void StartScrapers();
+void StopScrapers();
+
+LONG H_TargetInfo(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session);
+LONG H_TargetValue(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session);
+LONG H_TargetList(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session);
+LONG H_LabelValues(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session);
+LONG H_TargetsTable(const TCHAR *param, const TCHAR *arg, Table *value, AbstractCommSession *session);
+LONG H_SeriesTable(const TCHAR *param, const TCHAR *arg, Table *value, AbstractCommSession *session);
 
 #define DEBUG_TAG _T("prometheus")
 

--- a/src/agent/subagents/prometheus/prometheus.vcxproj
+++ b/src/agent/subagents/prometheus/prometheus.vcxproj
@@ -179,7 +179,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -194,7 +194,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -209,7 +209,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -228,7 +228,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -247,7 +247,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -266,7 +266,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release - Client Only|Win32'">
@@ -285,7 +285,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release - Client Only|x64'">
@@ -304,7 +304,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release - Client Only|ARM64'">
@@ -323,14 +323,16 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;libcurl.lib;libprotobuf.lib;libmicrohttpd.lib;snappy.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="handler.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="parser.cpp" />
     <ClCompile Include="printer.cpp" />
     <ClCompile Include="receiver.cpp" />
+    <ClCompile Include="scraper.cpp" />
     <ClCompile Include="generated\remote.pb.cc" />
     <ClCompile Include="generated\types.pb.cc" />
   </ItemGroup>

--- a/src/agent/subagents/prometheus/scraper.cpp
+++ b/src/agent/subagents/prometheus/scraper.cpp
@@ -1,0 +1,590 @@
+/*
+** NetXMS Prometheus subagent
+** Copyright (C) 2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+**/
+
+#include "prometheus.h"
+#include <netxms-version.h>
+#include <nxlibcurl.h>
+
+/**
+ * Configured scrape targets (created during initialization, read-only afterwards)
+ */
+static ObjectArray<ScrapeTarget> s_targets(8, 8, Ownership::True);
+
+/**
+ * Create scrape target
+ */
+ScrapeTarget::ScrapeTarget(const TCHAR *name) : m_stopCondition(true), m_lock(MutexType::FAST)
+{
+   _tcslcpy(m_name, name, 64);
+   m_url[0] = 0;
+   m_interval = 60000;
+   m_requestTimeout = 10000;
+   m_login[0] = 0;
+   m_password[0] = 0;
+   m_bearerToken = nullptr;
+   m_verifyPeer = true;
+   m_verifyHost = true;
+   m_caCertificate[0] = 0;
+   m_thread = INVALID_THREAD_HANDLE;
+   m_samples = nullptr;
+   m_lastScrapeTime = 0;
+   m_lastScrapeSuccess = false;
+}
+
+/**
+ * Destroy scrape target
+ */
+ScrapeTarget::~ScrapeTarget()
+{
+   MemFree(m_bearerToken);
+   delete m_samples;
+}
+
+/**
+ * Create scrape target from configuration entry
+ */
+ScrapeTarget *ScrapeTarget::createFromConfig(const ConfigEntry& config)
+{
+   const TCHAR *url = config.getSubEntryValue(_T("URL"));
+   if ((url == nullptr) || (*url == 0))
+   {
+      nxlog_write_tag(NXLOG_WARNING, DEBUG_TAG, _T("Missing URL in definition of scrape target %s"), config.getName());
+      return nullptr;
+   }
+
+   ScrapeTarget *target = new ScrapeTarget(config.getName());
+   tchar_to_utf8(url, -1, target->m_url, sizeof(target->m_url));
+
+   uint32_t interval = config.getSubEntryValueAsUInt(_T("ScrapeInterval"), 0, 60);
+   if (interval < 1)
+      interval = 1;
+   target->m_interval = interval * 1000;
+
+   uint32_t timeout = config.getSubEntryValueAsUInt(_T("Timeout"), 0, 10);
+   if (timeout < 1)
+      timeout = 1;
+   target->m_requestTimeout = timeout * 1000;
+
+   const TCHAR *login = config.getSubEntryValue(_T("Login"));
+   if ((login != nullptr) && (*login != 0))
+   {
+      tchar_to_utf8(login, -1, target->m_login, sizeof(target->m_login));
+      TCHAR password[256];
+      DecryptPassword(login, config.getSubEntryValue(_T("Password"), 0, _T("")), password, 256);
+      tchar_to_utf8(password, -1, target->m_password, sizeof(target->m_password));
+   }
+
+   const TCHAR *token = config.getSubEntryValue(_T("BearerToken"));
+   if ((token != nullptr) && (*token != 0))
+      target->m_bearerToken = UTF8StringFromTString(token);
+
+   target->m_verifyPeer = config.getSubEntryValueAsBoolean(_T("VerifyCertificate"), 0, true);
+   target->m_verifyHost = config.getSubEntryValueAsBoolean(_T("VerifyHost"), 0, true);
+   const TCHAR *caCertificate = config.getSubEntryValue(_T("CACertificate"));
+   if (caCertificate != nullptr)
+      tchar_to_utf8(caCertificate, -1, target->m_caCertificate, sizeof(target->m_caCertificate));
+
+   return target;
+}
+
+/**
+ * Start scraper thread
+ */
+void ScrapeTarget::start()
+{
+   m_thread = ThreadCreateEx(this, &ScrapeTarget::scraperThread);
+}
+
+/**
+ * Stop scraper thread
+ */
+void ScrapeTarget::stop()
+{
+   m_stopCondition.set();
+   ThreadJoin(m_thread);
+   m_thread = INVALID_THREAD_HANDLE;
+}
+
+/**
+ * Scraper thread
+ */
+void ScrapeTarget::scraperThread()
+{
+   nxlog_debug_tag(DEBUG_TAG, 3, _T("Scraper thread for target %s started (URL=%hs, interval=%u sec)"), m_name, m_url, m_interval / 1000);
+   uint32_t sleepTime;
+   do
+   {
+      int64_t startTime = GetCurrentTimeMs();
+      scrape();
+      int64_t elapsed = GetCurrentTimeMs() - startTime;
+      sleepTime = (elapsed >= m_interval) ? 1000 : static_cast<uint32_t>(m_interval - elapsed);
+   } while(!m_stopCondition.wait(sleepTime));
+   nxlog_debug_tag(DEBUG_TAG, 3, _T("Scraper thread for target %s stopped"), m_name);
+}
+
+/**
+ * Do single scrape of the target endpoint
+ */
+bool ScrapeTarget::scrape()
+{
+   CURL *curl = curl_easy_init();
+   if (curl == nullptr)
+   {
+      nxlog_debug_tag(DEBUG_TAG, 5, _T("%s: call to curl_easy_init() failed"), m_name);
+      return false;
+   }
+
+   char errorText[CURL_ERROR_SIZE];
+   errorText[0] = 0;
+   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errorText);
+#if HAVE_DECL_CURLOPT_NOSIGNAL
+   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, static_cast<long>(1));
+#endif
+#if HAVE_DECL_CURLOPT_PROTOCOLS_STR
+   curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+#else
+   curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
+   curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(m_requestTimeout));
+   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, static_cast<long>(1));
+   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, static_cast<long>(8));
+   curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+   curl_easy_setopt(curl, CURLOPT_USERAGENT, "NetXMS Agent/" NETXMS_VERSION_STRING_A);
+   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_verifyPeer ? static_cast<long>(1) : static_cast<long>(0));
+   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_verifyHost ? static_cast<long>(2) : static_cast<long>(0));
+   if (m_caCertificate[0] != 0)
+      curl_easy_setopt(curl, CURLOPT_CAINFO, m_caCertificate);
+   EnableLibCURLUnexpectedEOFWorkaround(curl);
+
+   struct curl_slist *headers = curl_slist_append(nullptr, "Accept: application/openmetrics-text; version=1.0.0; q=0.5, text/plain; version=0.0.4");
+   if (m_bearerToken != nullptr)
+   {
+      char *authHeader = MemAllocStringA(strlen(m_bearerToken) + 32);
+      strcpy(authHeader, "Authorization: Bearer ");
+      strcat(authHeader, m_bearerToken);
+      headers = curl_slist_append(headers, authHeader);
+      MemFree(authHeader);
+   }
+   else if (m_login[0] != 0)
+   {
+      curl_easy_setopt(curl, CURLOPT_USERNAME, m_login);
+      curl_easy_setopt(curl, CURLOPT_PASSWORD, m_password);
+      curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+   }
+   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+   ByteStream responseData(32768);
+   responseData.setAllocationStep(32768);
+   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ByteStream::curlWriteFunction);
+   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseData);
+
+   bool success = false;
+   if (curl_easy_setopt(curl, CURLOPT_URL, m_url) == CURLE_OK)
+   {
+      CURLcode rc = curl_easy_perform(curl);
+      if (rc == CURLE_OK)
+      {
+         long httpCode = 0;
+         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+         if ((httpCode >= 200) && (httpCode <= 299))
+         {
+            responseData.write('\0');
+            ObjectArray<MetricSample> *samples = ParsePrometheusText(reinterpret_cast<const char*>(responseData.buffer()));
+            nxlog_debug_tag(DEBUG_TAG, 6, _T("%s: scrape completed (%d samples)"), m_name, samples->size());
+
+            if (!GetMetricMappings().isEmpty())
+            {
+               for(int i = 0; i < samples->size(); i++)
+               {
+                  MetricSample *sample = samples->get(i);
+                  ProcessSample(sample->getName(), sample->getValue(),
+                     [sample] (const char *labelName) { return sample->getLabelValue(labelName); });
+               }
+            }
+
+            m_lock.lock();
+            delete m_samples;
+            m_samples = samples;
+            m_lock.unlock();
+            success = true;
+         }
+         else
+         {
+            nxlog_debug_tag(DEBUG_TAG, 5, _T("%s: HTTP response code %03ld"), m_name, httpCode);
+         }
+      }
+      else
+      {
+         nxlog_debug_tag(DEBUG_TAG, 5, _T("%s: call to curl_easy_perform() failed (%hs)"), m_name, errorText);
+      }
+   }
+   else
+   {
+      nxlog_debug_tag(DEBUG_TAG, 5, _T("%s: call to curl_easy_setopt(CURLOPT_URL) failed"), m_name);
+   }
+   curl_slist_free_all(headers);
+   curl_easy_cleanup(curl);
+
+   m_lock.lock();
+   m_lastScrapeTime = time(nullptr);
+   m_lastScrapeSuccess = success;
+   m_lock.unlock();
+   return success;
+}
+
+/**
+ * Get value of first sample matching given metric name and label filters
+ */
+LONG ScrapeTarget::getValue(const char *metric, const ObjectArray<SampleLabel>& filters, TCHAR *value) const
+{
+   LockGuard lockGuard(m_lock);
+   if (m_samples == nullptr)
+      return SYSINFO_RC_ERROR;
+
+   for(int i = 0; i < m_samples->size(); i++)
+   {
+      MetricSample *sample = m_samples->get(i);
+      if (strcmp(sample->getName(), metric) != 0)
+         continue;
+
+      bool match = true;
+      for(int j = 0; (j < filters.size()) && match; j++)
+      {
+         const char *v = sample->getLabelValue(filters.get(j)->name);
+         match = (v != nullptr) && (strcmp(v, filters.get(j)->value) == 0);
+      }
+      if (match)
+      {
+         ret_double(value, sample->getValue());
+         return SYSINFO_RC_SUCCESS;
+      }
+   }
+   return SYSINFO_RC_NO_SUCH_INSTANCE;
+}
+
+/**
+ * Get unique values of given label across all samples of given metric
+ */
+LONG ScrapeTarget::getLabelValues(const char *metric, const char *label, StringList *output) const
+{
+   LockGuard lockGuard(m_lock);
+   if (m_samples == nullptr)
+      return SYSINFO_RC_ERROR;
+
+   StringSet uniqueValues;
+   for(int i = 0; i < m_samples->size(); i++)
+   {
+      MetricSample *sample = m_samples->get(i);
+      if (strcmp(sample->getName(), metric) != 0)
+         continue;
+
+      const char *v = sample->getLabelValue(label);
+      if (v != nullptr)
+      {
+         TCHAR *labelValue = TStringFromUTF8String(v);
+         if (!uniqueValues.contains(labelValue))
+         {
+            output->add(labelValue);
+            uniqueValues.addPreallocated(labelValue);
+         }
+         else
+         {
+            MemFree(labelValue);
+         }
+      }
+   }
+   return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Build canonical labelset representation (label=value,label=value with values quoted as needed)
+ */
+static String BuildLabelsetString(const MetricSample& sample)
+{
+   StringBuffer result;
+   const ObjectArray<SampleLabel>& labels = sample.getLabels();
+   for(int i = 0; i < labels.size(); i++)
+   {
+      if (i > 0)
+         result.append(_T(','));
+      SampleLabel *label = labels.get(i);
+      TCHAR *name = TStringFromUTF8String(label->name);
+      result.append(name);
+      MemFree(name);
+      result.append(_T('='));
+      TCHAR *value = TStringFromUTF8String(label->value);
+      AppendEscapedValue(result, value);
+      MemFree(value);
+   }
+   return result;
+}
+
+/**
+ * Fill table with all samples of given metric, one row per labelset
+ */
+LONG ScrapeTarget::fillSeriesTable(const char *metric, Table *table) const
+{
+   LockGuard lockGuard(m_lock);
+   if (m_samples == nullptr)
+      return SYSINFO_RC_ERROR;
+
+   table->addColumn(_T("LABELS"), DCI_DT_STRING, _T("Labels"), true);
+   table->addColumn(_T("VALUE"), DCI_DT_FLOAT, _T("Value"));
+
+   // Add column for each label name seen in matching samples
+   for(int i = 0; i < m_samples->size(); i++)
+   {
+      MetricSample *sample = m_samples->get(i);
+      if (strcmp(sample->getName(), metric) != 0)
+         continue;
+
+      const ObjectArray<SampleLabel>& labels = sample->getLabels();
+      for(int j = 0; j < labels.size(); j++)
+      {
+         TCHAR columnName[MAX_COLUMN_NAME];
+         utf8_to_tchar(labels.get(j)->name, -1, columnName, MAX_COLUMN_NAME);
+         if (table->getColumnIndex(columnName) == -1)
+            table->addColumn(columnName, DCI_DT_STRING, columnName);
+      }
+   }
+
+   for(int i = 0; i < m_samples->size(); i++)
+   {
+      MetricSample *sample = m_samples->get(i);
+      if (strcmp(sample->getName(), metric) != 0)
+         continue;
+
+      table->addRow();
+      table->set(0, BuildLabelsetString(*sample));
+      table->set(1, sample->getValue());
+
+      const ObjectArray<SampleLabel>& labels = sample->getLabels();
+      for(int j = 0; j < labels.size(); j++)
+      {
+         TCHAR columnName[MAX_COLUMN_NAME];
+         utf8_to_tchar(labels.get(j)->name, -1, columnName, MAX_COLUMN_NAME);
+         table->setPreallocated(table->getColumnIndex(columnName), TStringFromUTF8String(labels.get(j)->value));
+      }
+   }
+   return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Load scrape targets from configuration
+ */
+void LoadScrapeTargets(Config *config)
+{
+   unique_ptr<ObjectArray<ConfigEntry>> targets = config->getSubEntries(_T("/Prometheus/Targets"), _T("*"));
+   if (targets == nullptr)
+      return;
+
+   for(int i = 0; i < targets->size(); i++)
+   {
+      ScrapeTarget *target = ScrapeTarget::createFromConfig(*targets->get(i));
+      if (target != nullptr)
+      {
+         s_targets.add(target);
+         nxlog_debug_tag(DEBUG_TAG, 4, _T("Loaded scrape target %s (URL=%hs)"), target->getName(), target->getUrl());
+      }
+   }
+   nxlog_debug_tag(DEBUG_TAG, 3, _T("Loaded %d scrape targets"), s_targets.size());
+}
+
+/**
+ * Start scraper threads
+ */
+void StartScrapers()
+{
+   if (s_targets.isEmpty())
+      return;
+
+   if (!InitializeLibCURL())
+   {
+      nxlog_write_tag(NXLOG_ERROR, DEBUG_TAG, _T("cURL initialization failed, endpoint scraping will not be available"));
+      return;
+   }
+
+   for(int i = 0; i < s_targets.size(); i++)
+      s_targets.get(i)->start();
+}
+
+/**
+ * Stop scraper threads
+ */
+void StopScrapers()
+{
+   for(int i = 0; i < s_targets.size(); i++)
+      s_targets.get(i)->stop();
+}
+
+/**
+ * Find scrape target by name
+ */
+static ScrapeTarget *FindTarget(const TCHAR *name)
+{
+   for(int i = 0; i < s_targets.size(); i++)
+   {
+      if (_tcsicmp(s_targets.get(i)->getName(), name) == 0)
+         return s_targets.get(i);
+   }
+   return nullptr;
+}
+
+/**
+ * Handler for Prometheus.Target.* parameters
+ */
+LONG H_TargetInfo(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session)
+{
+   TCHAR targetName[64];
+   if (!AgentGetParameterArg(param, 1, targetName, 64) || (targetName[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   ScrapeTarget *target = FindTarget(targetName);
+   if (target == nullptr)
+      return SYSINFO_RC_NO_SUCH_INSTANCE;
+
+   switch(*arg)
+   {
+      case 'C':
+         ret_int(value, target->getSampleCount());
+         break;
+      case 'S':
+         ret_boolean(value, target->isLastScrapeSuccessful());
+         break;
+      case 'T':
+         ret_uint64(value, static_cast<uint64_t>(target->getLastScrapeTime()));
+         break;
+      default:
+         return SYSINFO_RC_UNSUPPORTED;
+   }
+   return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Handler for Prometheus.Value parameter
+ */
+LONG H_TargetValue(const TCHAR *param, const TCHAR *arg, TCHAR *value, AbstractCommSession *session)
+{
+   TCHAR targetName[64];
+   if (!AgentGetParameterArg(param, 1, targetName, 64) || (targetName[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   char metric[256];
+   if (!AgentGetParameterArgA(param, 2, metric, 256) || (metric[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   ScrapeTarget *target = FindTarget(targetName);
+   if (target == nullptr)
+      return SYSINFO_RC_NO_SUCH_INSTANCE;
+
+   ObjectArray<SampleLabel> filters(0, 8, Ownership::True);
+   for(int i = 3; ; i++)
+   {
+      char buffer[1024];
+      if (!AgentGetParameterArgA(param, i, buffer, 1024))
+         return SYSINFO_RC_UNSUPPORTED;
+      if (buffer[0] == 0)
+         break;
+      char *separator = strchr(buffer, '=');
+      if (separator == nullptr)
+         return SYSINFO_RC_UNSUPPORTED;
+      *separator = 0;
+      filters.add(new SampleLabel(buffer, strlen(buffer), MemCopyStringA(separator + 1)));
+   }
+
+   return target->getValue(metric, filters, value);
+}
+
+/**
+ * Handler for Prometheus.Targets list
+ */
+LONG H_TargetList(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session)
+{
+   for(int i = 0; i < s_targets.size(); i++)
+      value->add(s_targets.get(i)->getName());
+   return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Handler for Prometheus.LabelValues list
+ */
+LONG H_LabelValues(const TCHAR *param, const TCHAR *arg, StringList *value, AbstractCommSession *session)
+{
+   TCHAR targetName[64];
+   if (!AgentGetParameterArg(param, 1, targetName, 64) || (targetName[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   char metric[256], label[256];
+   if (!AgentGetParameterArgA(param, 2, metric, 256) || (metric[0] == 0) ||
+       !AgentGetParameterArgA(param, 3, label, 256) || (label[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   ScrapeTarget *target = FindTarget(targetName);
+   if (target == nullptr)
+      return SYSINFO_RC_NO_SUCH_INSTANCE;
+
+   return target->getLabelValues(metric, label, value);
+}
+
+/**
+ * Handler for Prometheus.Targets table
+ */
+LONG H_TargetsTable(const TCHAR *param, const TCHAR *arg, Table *value, AbstractCommSession *session)
+{
+   value->addColumn(_T("NAME"), DCI_DT_STRING, _T("Name"), true);
+   value->addColumn(_T("URL"), DCI_DT_STRING, _T("URL"));
+   value->addColumn(_T("INTERVAL"), DCI_DT_UINT, _T("Scrape interval"));
+   value->addColumn(_T("STATUS"), DCI_DT_INT, _T("Last scrape status"));
+   value->addColumn(_T("LAST_SCRAPE"), DCI_DT_UINT64, _T("Last scrape timestamp"));
+   value->addColumn(_T("SAMPLES"), DCI_DT_UINT, _T("Sample count"));
+
+   for(int i = 0; i < s_targets.size(); i++)
+   {
+      ScrapeTarget *target = s_targets.get(i);
+      value->addRow();
+      value->set(0, target->getName());
+      value->set(1, target->getUrl());
+      value->set(2, target->getScrapeInterval());
+      value->set(3, target->isLastScrapeSuccessful() ? 1 : 0);
+      value->set(4, static_cast<uint64_t>(target->getLastScrapeTime()));
+      value->set(5, static_cast<uint32_t>(target->getSampleCount()));
+   }
+   return SYSINFO_RC_SUCCESS;
+}
+
+/**
+ * Handler for Prometheus.Series table
+ */
+LONG H_SeriesTable(const TCHAR *param, const TCHAR *arg, Table *value, AbstractCommSession *session)
+{
+   TCHAR targetName[64];
+   if (!AgentGetParameterArg(param, 1, targetName, 64) || (targetName[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   char metric[256];
+   if (!AgentGetParameterArgA(param, 2, metric, 256) || (metric[0] == 0))
+      return SYSINFO_RC_UNSUPPORTED;
+
+   ScrapeTarget *target = FindTarget(targetName);
+   if (target == nullptr)
+      return SYSINFO_RC_NO_SUCH_INSTANCE;
+
+   return target->fillSeriesTable(metric, value);
+}

--- a/src/agent/subagents/prometheus/scraper.cpp
+++ b/src/agent/subagents/prometheus/scraper.cpp
@@ -23,9 +23,36 @@
 #include <nxlibcurl.h>
 
 /**
+ * Maximum allowed size of response from scraped endpoint
+ */
+#define MAX_RESPONSE_SIZE  (64 * 1024 * 1024)
+
+/**
  * Configured scrape targets (created during initialization, read-only afterwards)
  */
 static ObjectArray<ScrapeTarget> s_targets(8, 8, Ownership::True);
+
+/**
+ * Convert TCHAR string to UTF-8 with guaranteed null termination (conversion may
+ * stop before the source terminator when a multi-byte character does not fit)
+ */
+static void ConvertToUtf8(const TCHAR *src, char *dst, size_t size)
+{
+   size_t bytes = tchar_to_utf8(src, -1, dst, size - 1);
+   dst[bytes] = 0;
+}
+
+/**
+ * cURL write callback with response size limit (returning less than given size aborts the transfer)
+ */
+static size_t CurlWriteFunction(char *ptr, size_t size, size_t nmemb, ByteStream *data)
+{
+   size_t bytes = size * nmemb;
+   if (data->size() + bytes > MAX_RESPONSE_SIZE)
+      return 0;
+   data->write(ptr, bytes);
+   return bytes;
+}
 
 /**
  * Create scrape target
@@ -70,7 +97,7 @@ ScrapeTarget *ScrapeTarget::createFromConfig(const ConfigEntry& config)
    }
 
    ScrapeTarget *target = new ScrapeTarget(config.getName());
-   tchar_to_utf8(url, -1, target->m_url, sizeof(target->m_url));
+   ConvertToUtf8(url, target->m_url, sizeof(target->m_url));
 
    uint32_t interval = config.getSubEntryValueAsUInt(_T("ScrapeInterval"), 0, 60);
    if (interval < 1)
@@ -85,10 +112,10 @@ ScrapeTarget *ScrapeTarget::createFromConfig(const ConfigEntry& config)
    const TCHAR *login = config.getSubEntryValue(_T("Login"));
    if ((login != nullptr) && (*login != 0))
    {
-      tchar_to_utf8(login, -1, target->m_login, sizeof(target->m_login));
+      ConvertToUtf8(login, target->m_login, sizeof(target->m_login));
       TCHAR password[256];
       DecryptPassword(login, config.getSubEntryValue(_T("Password"), 0, _T("")), password, 256);
-      tchar_to_utf8(password, -1, target->m_password, sizeof(target->m_password));
+      ConvertToUtf8(password, target->m_password, sizeof(target->m_password));
    }
 
    const TCHAR *token = config.getSubEntryValue(_T("BearerToken"));
@@ -99,7 +126,7 @@ ScrapeTarget *ScrapeTarget::createFromConfig(const ConfigEntry& config)
    target->m_verifyHost = config.getSubEntryValueAsBoolean(_T("VerifyHost"), 0, true);
    const TCHAR *caCertificate = config.getSubEntryValue(_T("CACertificate"));
    if (caCertificate != nullptr)
-      tchar_to_utf8(caCertificate, -1, target->m_caCertificate, sizeof(target->m_caCertificate));
+      ConvertToUtf8(caCertificate, target->m_caCertificate, sizeof(target->m_caCertificate));
 
    return target;
 }
@@ -176,11 +203,19 @@ bool ScrapeTarget::scrape()
    struct curl_slist *headers = curl_slist_append(nullptr, "Accept: application/openmetrics-text; version=1.0.0; q=0.5, text/plain; version=0.0.4");
    if (m_bearerToken != nullptr)
    {
+#ifdef CURLAUTH_BEARER
+      curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, m_bearerToken);
+      curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
+#else
+      // Token passed as custom header is not stripped by cURL on cross-host redirects,
+      // so disable redirect following to prevent token from leaking to another host
       char *authHeader = MemAllocStringA(strlen(m_bearerToken) + 32);
       strcpy(authHeader, "Authorization: Bearer ");
       strcat(authHeader, m_bearerToken);
       headers = curl_slist_append(headers, authHeader);
       MemFree(authHeader);
+      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, static_cast<long>(0));
+#endif
    }
    else if (m_login[0] != 0)
    {
@@ -192,7 +227,7 @@ bool ScrapeTarget::scrape()
 
    ByteStream responseData(32768);
    responseData.setAllocationStep(32768);
-   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ByteStream::curlWriteFunction);
+   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteFunction);
    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseData);
 
    bool success = false;
@@ -229,6 +264,10 @@ bool ScrapeTarget::scrape()
          {
             nxlog_debug_tag(DEBUG_TAG, 5, _T("%s: HTTP response code %03ld"), m_name, httpCode);
          }
+      }
+      else if (rc == CURLE_WRITE_ERROR)
+      {
+         nxlog_debug_tag(DEBUG_TAG, 5, _T("%s: response size exceeds limit of %d MB"), m_name, MAX_RESPONSE_SIZE / 1048576);
       }
       else
       {
@@ -359,7 +398,12 @@ LONG ScrapeTarget::fillSeriesTable(const char *metric, Table *table) const
       for(int j = 0; j < labels.size(); j++)
       {
          TCHAR columnName[MAX_COLUMN_NAME];
-         utf8_to_tchar(labels.get(j)->name, -1, columnName, MAX_COLUMN_NAME);
+         size_t chars = utf8_to_tchar(labels.get(j)->name, -1, columnName, MAX_COLUMN_NAME - 1);
+         columnName[chars] = 0;
+         // Skip labels colliding with fixed columns (column lookup is case-insensitive);
+         // their values are still visible as part of canonical labelset in LABELS column
+         if (!_tcsicmp(columnName, _T("LABELS")) || !_tcsicmp(columnName, _T("VALUE")))
+            continue;
          if (table->getColumnIndex(columnName) == -1)
             table->addColumn(columnName, DCI_DT_STRING, columnName);
       }
@@ -379,7 +423,10 @@ LONG ScrapeTarget::fillSeriesTable(const char *metric, Table *table) const
       for(int j = 0; j < labels.size(); j++)
       {
          TCHAR columnName[MAX_COLUMN_NAME];
-         utf8_to_tchar(labels.get(j)->name, -1, columnName, MAX_COLUMN_NAME);
+         size_t chars = utf8_to_tchar(labels.get(j)->name, -1, columnName, MAX_COLUMN_NAME - 1);
+         columnName[chars] = 0;
+         if (!_tcsicmp(columnName, _T("LABELS")) || !_tcsicmp(columnName, _T("VALUE")))
+            continue;
          table->setPreallocated(table->getColumnIndex(columnName), TStringFromUTF8String(labels.get(j)->value));
       }
    }


### PR DESCRIPTION
## Summary

Extends the Prometheus subagent with active endpoint scraping capabilities, complementing the existing passive remote write receiver. The subagent can now periodically scrape `/metrics` endpoints exposing Prometheus text exposition format or OpenMetrics, in addition to receiving pushed metrics via remote write protocol.

## Key Changes

- **New scraper module** (`scraper.cpp`): Implements `ScrapeTarget` class managing individual scrape targets with configurable intervals, timeouts, authentication (basic auth and bearer tokens), and TLS verification options. Scraper threads run independently and maintain in-memory sample cache.

- **New parser module** (`parser.cpp`): Implements `ParsePrometheusText()` function to parse Prometheus text exposition format and OpenMetrics text format. Handles metric names, labels with proper escape sequence processing, and numeric values (including special values like NaN and Inf).

- **Data structures**: Added `MetricSample` class representing a parsed metric with name, labels, and value; `SampleLabel` struct for label key-value pairs.

- **Configuration support**: Scrape targets defined in `[Prometheus/Targets/name]` sections with URL, scrape interval, timeout, authentication credentials, and TLS options.

- **Query handlers**: Eight new parameter/list/table handlers:
  - `Prometheus.Target.LastScrapeTime(*)` - timestamp of last scrape
  - `Prometheus.Target.SampleCount(*)` - number of samples in last scrape
  - `Prometheus.Target.Status(*)` - success/failure status of last scrape
  - `Prometheus.Value(*)` - query specific metric value with label filters
  - `Prometheus.Targets` - list of configured target names
  - `Prometheus.LabelValues(*)` - list of unique label values for a metric
  - `Prometheus.Targets` - table with target details (URL, interval, status, etc.)
  - `Prometheus.Series(*)` - table with all samples of a metric

- **Metric mapping integration**: Scraped samples are processed through existing metric mapping mechanism, allowing them to be pushed to NetXMS server as DCIs alongside remote write metrics.

- **Configuration flexibility**: Remote write receiver can now be disabled independently via `EnableReceiver` option; scraper initialization is decoupled from receiver startup.

- **Build integration**: Added libcurl dependency to Visual Studio project and Makefile.

## Implementation Details

- Scraper threads use `Condition` for efficient sleep with early wakeup on shutdown
- Thread-safe sample access via `Mutex` with `LockGuard` RAII locking
- Parser handles both CRLF and LF line endings; skips comments and metadata lines
- Label value escaping follows Prometheus format (backslash escapes for `\`, `&#34;`, and `\n`)
- HTTP requests configured with proper User-Agent, protocol restrictions, and redirect handling
- Bearer token takes precedence over basic auth when both are configured

https://claude.ai/code/session_01Qz7wdf5w3ospC8VtMSNQqE