### PR TITLE
Update node name on IP address change when name is the old IP

### DIFF
--- a/src/server/core/node.cpp
+++ b/src/server/core/node.cpp
@@ -4396,6 +4396,16 @@ void Node::updatePrimaryIpAddr()
          .post();
 
       lockProperties();
+
+      // If node name is the old IP address, update it to the new one
+      wchar_t oldIpText[64];
+      m_ipAddress.toString(oldIpText);
+      if (!wcscmp(oldIpText, m_name))
+      {
+         ipAddr.toString(m_name);
+         setModified(MODIFY_COMMON_PROPERTIES);
+      }
+
       setPrimaryIPAddress(ipAddr);
       unlockProperties();
 
@@ -11609,6 +11619,13 @@ void Node::changeIPAddress(const InetAddress& ipAddr)
       m_ipAddress.toString(ipAddrText);
       if (!_tcscmp(ipAddrText, m_primaryHostName))
          m_primaryHostName = ipAddr.toString();
+
+      // If node name is the old IP address, update it to the new one
+      if (!wcscmp(ipAddrText, m_name))
+      {
+         ipAddr.toString(m_name);
+         setModified(MODIFY_COMMON_PROPERTIES);
+      }
 
       setPrimaryIPAddress(ipAddr);
       m_runtimeFlags |= ODF_FORCE_CONFIGURATION_POLL | NDF_RECHECK_CAPABILITIES;


### PR DESCRIPTION
When a node's display name is exactly its primary IP address (common for
auto-discovered nodes), keep it in sync when the primary IP address changes.
Applied to the two automatic IP-change detection paths:

- Node::changeIPAddress() - triggered by discovery when a known MAC reappears
  on a new address
- Node::updatePrimaryIpAddr() - triggered by configuration poll DNS re-resolution

The name is rewritten only on a strict match against the old IP address string,
mirroring the existing handling of m_primaryHostName. Manual IP changes via the
client are intentionally left untouched.

Issue: #1921

https://claude.ai/code/session_01BwQ5k7vMt7Jkd6ZC9YjsFR