### PR TITLE
fix(nxmc): pass URL as separate argv element when launching browser

### DIFF
--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/tools/ExternalWebBrowser.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/tools/ExternalWebBrowser.java
@@ -63,13 +63,13 @@ public class ExternalWebBrowser
       if (Util.isWindows())
       {
          Program.launch(url);
-      } 
+      }
       else if (Util.isMac())
       {
-         try 
+         try
          {
-            Runtime.getRuntime().exec("/usr/bin/open '" + url + "'");
-         } 
+            Runtime.getRuntime().exec(new String[] { "/usr/bin/open", url });
+         }
          catch (IOException e)
          {
             logger.error("Exception while starting external browser", e);
@@ -79,7 +79,7 @@ public class ExternalWebBrowser
       {
          try
          {
-            Runtime.getRuntime().exec("xdg-open " + urlEncode(url));
+            Runtime.getRuntime().exec(new String[] { "xdg-open", url });
          }
          catch(IOException e)
          {
@@ -89,29 +89,9 @@ public class ExternalWebBrowser
    }
 
    /**
-    * This method encodes the URL removing spaces and replacing them with <code>"%20"</code>.
-    */
-   private static String urlEncode(String url)
-   {
-      StringBuilder sb = new StringBuilder(url.length());
-      for(char c : url.toCharArray())
-      {
-         if (c == ' ')
-         {
-            sb.append("%20");
-         }
-         else
-         {
-            sb.append(c);
-         }
-      }
-      return sb.toString();
-   }
-
-   /**
     * Get local address that can be used for connecting to this client. It is always 127.0.0.1 for desktop client but can be
     * different for web client.
-    * 
+    *
     * @param display current display
     * @return local address that can be used for connecting to this client
     */


### PR DESCRIPTION
Fixes #3403.

`Runtime.exec(String)` tokenizes on whitespace instead of invoking a shell, so the quotes in `"/usr/bin/open '" + url + "'"` reached `open` as literal characters and every external URL launch failed silently on macOS.

Both the macOS and Linux branches now use `Runtime.exec(String[])`, so the URL reaches the launcher as one argv element and needs no quoting. `urlEncode()` is removed: it existed only to keep spaces from splitting the Linux command line, and with the array form nothing tokenizes. No other references (it was private, grepped the module).

Scope: `src/swt/` variant only. Windows goes through `Program.launch()` and is untouched. The RWT variant is a separate implementation, so the web client is unaffected.

## Testing

Verified with `mvn -f src/client/nxmc/java/pom.xml compile -Pdesktop` — that profile is what pulls in this SWT-only source root.

macOS: Help -> *Show support options* now opens the browser; on `master` it does nothing.

Linux: not exercised, verified by inspection and compile only. Behavior is unchanged for the URLs in the tree, since none contain spaces — this half is robustness, not a bug fix. A URL-type object tool with a space in the URL is the case that actually changes.

Not addressed: none of the branches check the child's exit status or drain stderr, which is why this failed silently for so long. Separate change if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opening external web pages on macOS and Linux/Unix.
  * URLs containing special characters are now passed correctly to the system browser.
  * Reduced the likelihood of browser launch failures caused by URL quoting or encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->