### PR TITLE
CI check for function pointer casts with mismatched signatures (issue…

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -28,9 +28,20 @@ jobs:
         run: ./reconf
       - name: configure
         run: ./configure --prefix=/tmp/build --with-server --with-agent --with-pgsql
-          --with-tests
+          --with-tests CXXFLAGS="-g -O2 -Wcast-function-type"
       - name: make
-        run: make -j$(nproc)
+        run: |
+          set -o pipefail
+          make -j$(nproc) 2>&1 | tee build.log
+      - name: Check for function pointer cast mismatches
+        run: |
+          if grep -q 'cast-function-type' build.log; then
+            echo "::error::Cast between incompatible function types. Calling through such a"
+            echo "::error::pointer is undefined behaviour - a mismatched return type works on"
+            echo "::error::x86 by accident and breaks on SPARC. See issue #3445."
+            grep -B2 'cast-function-type' build.log
+            exit 1
+          fi
       - name: make install
         run: make install
       - name: Run tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,7 @@ mvn -f src/client/nxmc/java/pom.xml jetty:run -Pweb -Dnetxms.build.disablePlatfo
 
 - **Semgrep SAST** runs on every PR (diff-aware, blocks on ERROR severity) and nightly (full scan, informational). Workflow: `.github/workflows/semgrep.yaml`
 - **cppcheck** runs nightly for C++ code quality. Workflow: `.github/workflows/cppcheck.yaml`
+- **Function pointer cast check** blocks on every push and PR. The build runs with GCC's `-Wcast-function-type` and fails if any warning appears. Workflow: `.github/workflows/build_and_test.yaml`
 - Custom semgrep rules go in `.semgrep.yml`; exclusions in `.semgrepignore`
 - Inline suppression: `// nosemgrep: <rule-id>` (C/C++, Java) or `# nosemgrep: <rule-id>` (Python). Always specify the rule-id
 


### PR DESCRIPTION
… #3445)

Build with GCC's -Wcast-function-type and fail the job if any warning appears. Catches a wrapper cast to a function pointer type with a different return type - UB that works on x86 by accident and breaks on SPARC.

Warning flag plus a log grep rather than -Werror=cast-function-type, which at configure time could fail an autoconf feature test and silently misdetect a feature.

CXXFLAGS only - bundled C libraries would add unrelated warnings.

GCC only: clang's -Wcast-function-type is the strict variant and fires on every legitimate context-type-erasure cast.

Verified on Ubuntu 24.04 / GCC 13.3.0: full build is clean, and reintroducing the 5ccb7b97d5 bug produces 15 warnings at nms_objects.h:528 and :534.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * CI builds now include tests with debug and optimization settings.
  * Build output is captured and checked for incompatible function-pointer cast warnings.
  * Pull requests and pushes fail when these warnings are detected.

* **Documentation**
  * Added documentation describing the new function-pointer cast validation in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->