### PR TITLE
Add additional fields to the alarms list webapi response

### DIFF
--- a/src/server/include/nms_alarm.h
+++ b/src/server/include/nms_alarm.h
@@ -93,6 +93,7 @@ public:
    const uuid& getRuleGuid() const { return m_ruleGuid; }
    const TCHAR *getRuleDescription() const { return m_ruleDescription; }
    uint32_t getSourceObject() const { return m_sourceObject; }
+   int32_t getZoneUIN() const { return m_zoneUIN; }
    uint32_t getSourceEventCode() const { return m_sourceEventCode; }
    const TCHAR *getEventTags() const { return m_eventTags; }
    uint32_t getDciId() const { return m_dciId; }

--- a/src/server/webapi/alarms.cpp
+++ b/src/server/webapi/alarms.cpp
@@ -21,6 +21,7 @@
 **/
 
 #include "webapi.h"
+#include <nms_users.h>
 
 /**
  * Handler for /v1/alarms
@@ -46,8 +47,21 @@ int H_Alarms(Context *context)
          json_object_set_new(json, "severity", json_integer(alarm->getCurrentSeverity()));
          json_object_set_new(json, "state", json_integer(alarm->getState() & ALARM_STATE_MASK));
          json_object_set_new(json, "source", json_integer(object->getId()));
+         json_object_set_new(json, "sourceName", json_string_t(object->getName()));
+         json_object_set_new(json, "zoneUIN", json_integer(alarm->getZoneUIN()));
          json_object_set_new(json, "message", json_string_t(alarm->getMessage()));
+         json_object_set_new(json, "repeatCount", json_integer(alarm->getRepeatCount()));
+         json_object_set_new(json, "commentCount", json_integer(alarm->getCommentCount()));
+         json_object_set_new(json, "helpdeskReference", json_string_t(alarm->getHelpDeskRef()));
+         json_object_set_new(json, "creationTime", json_time_string(alarm->getCreationTime()));
          json_object_set_new(json, "lastChangeTime", json_time_string(alarm->getLastChangeTime()));
+
+         wchar_t userName[MAX_USER_NAME];
+         json_object_set_new(json, "ackByUserName", json_string_t(
+            (alarm->getAckByUser() != INVALID_UID) ? ResolveUserId(alarm->getAckByUser(), userName, true) : L""));
+         json_object_set_new(json, "resolvedByUserName", json_string_t(
+            (alarm->getResolvedByUser() != INVALID_UID) ? ResolveUserId(alarm->getResolvedByUser(), userName, true) : L""));
+
          json_object_set_new(json, "categories", alarm->categoryListToJson());
          if (includeObjectDetails)
          {

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -1398,11 +1398,35 @@ paths:
                     source:
                       type: integer
                       description: Source object ID
+                    sourceName:
+                      type: string
+                      description: Name of the source object
+                    zoneUIN:
+                      type: integer
+                      description: Zone UIN of the source object (0 if zoning is disabled)
                     message:
                       type: string
+                    repeatCount:
+                      type: integer
+                      description: Number of times the alarm was raised
+                    commentCount:
+                      type: integer
+                      description: Number of comments attached to the alarm
+                    helpdeskReference:
+                      type: string
+                      description: Helpdesk issue reference (empty if not linked)
+                    creationTime:
+                      type: string
+                      format: date-time
                     lastChangeTime:
                       type: string
                       format: date-time
+                    ackByUserName:
+                      type: string
+                      description: Name of the user who acknowledged the alarm (empty if not acknowledged)
+                    resolvedByUserName:
+                      type: string
+                      description: Name of the user who resolved the alarm (empty if not resolved)
                     categories:
                       type: array
                       description: Alarm categories (as assigned by the event processing policy rule that raised the alarm)


### PR DESCRIPTION
Added source name, zone UIN, counters, timestamps, ack/resolve user n…ames to alarm webapi response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `GET /v1/alarms` responses with additional alarm metadata: `sourceName`, `zoneUIN`, `repeatCount`, `commentCount`, `helpdeskReference`, and `creationTime`.
  - Added `ackByUserName` and `resolvedByUserName`; when an alarm hasn’t been acknowledged/resolved, these return empty strings.

- **Documentation**
  - Updated the OpenAPI spec for `GET /v1/alarms` to include the new fields and clarify timestamp/empty-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->