### PR TITLE
Added alarm comments CRUD and related events endpoints to webapi

### DIFF
--- a/src/server/core/alarm.cpp
+++ b/src/server/core/alarm.cpp
@@ -1131,6 +1131,28 @@ static void FillEventData(NXCPMessage *msg, uint32_t baseId, DB_RESULT hResult, 
 }
 
 /**
+ * Prepare query for selecting events correlated to given event
+ */
+static DB_STATEMENT PrepareCorrelatedEventsQuery(DB_HANDLE hdb)
+{
+   switch(g_dbSyntax)
+   {
+      case DB_SYNTAX_ORACLE:
+         return DBPrepare(hdb,
+                  L"SELECT e.event_id,e.event_code,c.event_name,e.event_severity,e.event_source,e.event_timestamp,e.event_message "
+                  L"FROM event_log e,event_cfg c WHERE zero_to_null(e.root_event_id)=? AND c.event_code=e.event_code");
+      case DB_SYNTAX_TSDB:
+         return DBPrepare(hdb,
+                  L"SELECT e.event_id,e.event_code,c.event_name,e.event_severity,e.event_source,date_part('epoch',e.event_timestamp)::int,e.event_message "
+                  L"FROM event_log e,event_cfg c WHERE e.root_event_id=? AND c.event_code=e.event_code");
+      default:
+         return DBPrepare(hdb,
+                  L"SELECT e.event_id,e.event_code,c.event_name,e.event_severity,e.event_source,e.event_timestamp,e.event_message "
+                  L"FROM event_log e,event_cfg c WHERE e.root_event_id=? AND c.event_code=e.event_code");
+   }
+}
+
+/**
  * Get events correlated to given event into NXCP message
  *
  * @return number of consumed variable identifiers
@@ -1138,25 +1160,7 @@ static void FillEventData(NXCPMessage *msg, uint32_t baseId, DB_RESULT hResult, 
 static uint32_t GetCorrelatedEvents(uint64_t eventId, NXCPMessage *msg, uint32_t baseId, DB_HANDLE hdb)
 {
 	uint32_t fieldId = baseId;
-	DB_STATEMENT hStmt;
-	switch(g_dbSyntax)
-	{
-	   case DB_SYNTAX_ORACLE:
-	      hStmt = DBPrepare(hdb,
-	               _T("SELECT e.event_id,e.event_code,c.event_name,e.event_severity,e.event_source,e.event_timestamp,e.event_message ")
-	               _T("FROM event_log e,event_cfg c WHERE zero_to_null(e.root_event_id)=? AND c.event_code=e.event_code"));
-	      break;
-	   case DB_SYNTAX_TSDB:
-         hStmt = DBPrepare(hdb,
-                  _T("SELECT e.event_id,e.event_code,c.event_name,e.event_severity,e.event_source,date_part('epoch',e.event_timestamp)::int,e.event_message ")
-                  _T("FROM event_log e,event_cfg c WHERE e.root_event_id=? AND c.event_code=e.event_code"));
-         break;
-	   default:
-         hStmt = DBPrepare(hdb,
-                  _T("SELECT e.event_id,e.event_code,c.event_name,e.event_severity,e.event_source,e.event_timestamp,e.event_message ")
-                  _T("FROM event_log e,event_cfg c WHERE e.root_event_id=? AND c.event_code=e.event_code"));
-         break;
-	}
+	DB_STATEMENT hStmt = PrepareCorrelatedEventsQuery(hdb);
 	if (hStmt != nullptr)
 	{
 		DBBind(hStmt, 1, DB_SQLTYPE_BIGINT, eventId);
@@ -1179,29 +1183,31 @@ static uint32_t GetCorrelatedEvents(uint64_t eventId, NXCPMessage *msg, uint32_t
 }
 
 /**
+ * Get query for selecting alarm's related events (limited to 200 most recent)
+ */
+static const wchar_t *AlarmEventsQuery()
+{
+   switch(g_dbSyntax)
+   {
+      case DB_SYNTAX_ORACLE:
+         return L"SELECT * FROM (SELECT event_id,event_code,event_name,severity,source_object_id,event_timestamp,message FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC) WHERE ROWNUM<=200";
+      case DB_SYNTAX_MSSQL:
+         return L"SELECT TOP 200 event_id,event_code,event_name,severity,source_object_id,event_timestamp,message FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC";
+      case DB_SYNTAX_DB2:
+         return L"SELECT event_id,event_code,event_name,severity,source_object_id,event_timestamp,message "
+                L"FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC FETCH FIRST 200 ROWS ONLY";
+      default:
+         return L"SELECT event_id,event_code,event_name,severity,source_object_id,event_timestamp,message FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC LIMIT 200";
+   }
+}
+
+/**
  * Fill NXCP message with alarm's related events
  */
 static void FillAlarmEventsMessage(NXCPMessage *msg, uint32_t alarmId)
 {
    DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
-   const TCHAR *query;
-   switch(g_dbSyntax)
-   {
-		case DB_SYNTAX_ORACLE:
-			query = _T("SELECT * FROM (SELECT event_id,event_code,event_name,severity,source_object_id,event_timestamp,message FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC) WHERE ROWNUM<=200");
-			break;
-		case DB_SYNTAX_MSSQL:
-			query = _T("SELECT TOP 200 event_id,event_code,event_name,severity,source_object_id,event_timestamp,message FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC");
-			break;
-		case DB_SYNTAX_DB2:
-			query = _T("SELECT event_id,event_code,event_name,severity,source_object_id,event_timestamp,message ")
-			   _T("FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC FETCH FIRST 200 ROWS ONLY");
-			break;
-		default:
-			query = _T("SELECT event_id,event_code,event_name,severity,source_object_id,event_timestamp,message FROM alarm_events WHERE alarm_id=? ORDER BY event_timestamp DESC LIMIT 200");
-			break;
-	}
-	DB_STATEMENT hStmt = DBPrepare(hdb, query);
+	DB_STATEMENT hStmt = DBPrepare(hdb, AlarmEventsQuery());
 	if (hStmt != nullptr)
 	{
 		DBBind(hStmt, 1, DB_SQLTYPE_INTEGER, alarmId);
@@ -1223,6 +1229,84 @@ static void FillAlarmEventsMessage(NXCPMessage *msg, uint32_t alarmId)
       DBFreeStatement(hStmt);
    }
    DBConnectionPoolReleaseConnection(hdb);
+}
+
+/**
+ * Create JSON object from event data in SQL query result
+ * Expected field order: event_id,event_code,event_name,severity,source_object_id,event_timestamp,message
+ */
+static json_t *EventDataToJson(DB_RESULT hResult, int row, uint64_t parentId)
+{
+   wchar_t buffer[MAX_EVENT_MSG_LENGTH];
+
+   json_t *event = json_object();
+   json_object_set_new(event, "id", json_integer(DBGetFieldUInt64(hResult, row, 0)));
+   json_object_set_new(event, "parentId", json_integer(parentId));
+   json_object_set_new(event, "code", json_integer(DBGetFieldULong(hResult, row, 1)));
+   json_object_set_new(event, "name", json_string_t(DBGetField(hResult, row, 2, buffer, MAX_DB_STRING)));
+   json_object_set_new(event, "severity", json_integer(DBGetFieldLong(hResult, row, 3)));
+   uint32_t sourceObjectId = DBGetFieldULong(hResult, row, 4);
+   json_object_set_new(event, "source", json_integer(sourceObjectId));
+   json_object_set_new(event, "sourceName", json_string_t(GetObjectName(sourceObjectId, L"")));
+   json_object_set_new(event, "timestamp", json_time_string(DBGetFieldULong(hResult, row, 5)));
+   json_object_set_new(event, "message", json_string_t(DBGetField(hResult, row, 6, buffer, MAX_EVENT_MSG_LENGTH)));
+   return event;
+}
+
+/**
+ * Add events correlated to given event to JSON array
+ */
+static void AddCorrelatedEventsToJson(json_t *events, uint64_t eventId, DB_HANDLE hdb)
+{
+   DB_STATEMENT hStmt = PrepareCorrelatedEventsQuery(hdb);
+   if (hStmt == nullptr)
+      return;
+
+   DBBind(hStmt, 1, DB_SQLTYPE_BIGINT, eventId);
+   DB_RESULT hResult = DBSelectPrepared(hStmt);
+   if (hResult != nullptr)
+   {
+      int count = DBGetNumRows(hResult);
+      for(int i = 0; i < count; i++)
+      {
+         json_array_append_new(events, EventDataToJson(hResult, i, eventId));
+         AddCorrelatedEventsToJson(events, DBGetFieldUInt64(hResult, i, 0), hdb);
+      }
+      DBFreeResult(hResult);
+   }
+   DBFreeStatement(hStmt);
+}
+
+/**
+ * Get alarm's related events as JSON array. Events are ordered from newest to oldest, and each root event
+ * is followed by events correlated to it. Correlation is expressed by "parentId" attribute, which is set
+ * to 0 for root events.
+ */
+json_t NXCORE_EXPORTABLE *GetAlarmEventsAsJson(uint32_t alarmId)
+{
+   json_t *events = json_array();
+
+   DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
+   DB_STATEMENT hStmt = DBPrepare(hdb, AlarmEventsQuery());
+   if (hStmt != nullptr)
+   {
+      DBBind(hStmt, 1, DB_SQLTYPE_INTEGER, alarmId);
+      DB_RESULT hResult = DBSelectPrepared(hStmt);
+      if (hResult != nullptr)
+      {
+         int count = DBGetNumRows(hResult);
+         for(int i = 0; i < count; i++)
+         {
+            json_array_append_new(events, EventDataToJson(hResult, i, 0));
+            AddCorrelatedEventsToJson(events, DBGetFieldUInt64(hResult, i, 0), hdb);
+         }
+         DBFreeResult(hResult);
+      }
+      DBFreeStatement(hStmt);
+   }
+   DBConnectionPoolReleaseConnection(hdb);
+
+   return events;
 }
 
 /**

--- a/src/server/include/nms_alarm.h
+++ b/src/server/include/nms_alarm.h
@@ -272,6 +272,7 @@ uint32_t NXCORE_EXPORTABLE UpdateAlarmComment(uint32_t alarmId, uint32_t *noteId
 uint32_t NXCORE_EXPORTABLE DeleteAlarmCommentByID(uint32_t alarmId, uint32_t noteId);
 uint32_t NXCORE_EXPORTABLE GetAlarmComments(uint32_t alarmId, NXCPMessage *msg);
 ObjectArray<AlarmComment> NXCORE_EXPORTABLE *GetAlarmComments(uint32_t alarmId);
+json_t NXCORE_EXPORTABLE *GetAlarmEventsAsJson(uint32_t alarmId);
 
 bool DeleteObjectAlarms(uint32_t objectId, DB_HANDLE hdb);
 

--- a/src/server/webapi/alarms.cpp
+++ b/src/server/webapi/alarms.cpp
@@ -128,6 +128,241 @@ int H_AlarmDetails(Context *context)
 }
 
 /**
+ * Convert alarm comment to JSON
+ */
+static json_t *AlarmCommentToJson(uint32_t alarmId, uint32_t commentId, time_t changeTime, uint32_t userId, const wchar_t *text)
+{
+   wchar_t userName[MAX_USER_NAME];
+
+   json_t *json = json_object();
+   json_object_set_new(json, "id", json_integer(commentId));
+   json_object_set_new(json, "alarmId", json_integer(alarmId));
+   json_object_set_new(json, "userId", json_integer(userId));
+   json_object_set_new(json, "userName", json_string_t(ResolveUserId(userId, userName, true)));
+   json_object_set_new(json, "lastChangeTime", json_time_string(changeTime));
+   json_object_set_new(json, "text", json_string_t(CHECK_NULL_EX(text)));
+   return json;
+}
+
+/**
+ * Get text of given alarm comment. Returns nullptr if comment does not exist or has no text.
+ */
+static wchar_t *AlarmCommentText(uint32_t alarmId, uint32_t commentId)
+{
+   wchar_t *text = nullptr;
+   ObjectArray<AlarmComment> *comments = GetAlarmComments(alarmId);
+   for(int i = 0; i < comments->size(); i++)
+   {
+      AlarmComment *comment = comments->get(i);
+      if (comment->getId() == commentId)
+         text = MemCopyString(comment->getText());
+      delete comment;   // array is created with Ownership::False
+   }
+   delete comments;
+   return text;
+}
+
+/**
+ * Convert return code of alarm comment operation to HTTP response code
+ */
+static int AlarmCommentResponseCode(Context *context, uint32_t rcc, int successCode)
+{
+   switch(rcc)
+   {
+      case RCC_SUCCESS:
+         return successCode;
+      case RCC_INVALID_ALARM_ID:
+      case RCC_INVALID_ALARM_NOTE_ID:
+         return 404;
+      default:
+         context->setErrorResponse("Database failure");
+         return 500;
+   }
+}
+
+/**
+ * Get comment text from request document. Returns nullptr and sets response code if text is missing or empty.
+ */
+static wchar_t *CommentTextFromRequest(Context *context, int *responseCode)
+{
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+   {
+      *responseCode = 400;
+      return nullptr;
+   }
+
+   wchar_t *text = json_object_get_string_w(request, "text", nullptr);
+   if ((text == nullptr) || (*text == 0))
+   {
+      MemFree(text);
+      context->setErrorResponse("Comment text cannot be empty");
+      *responseCode = 400;
+      return nullptr;
+   }
+
+   return text;
+}
+
+/**
+ * Handler for GET /v1/alarms/:alarm-id/comments
+ */
+int H_AlarmComments(Context *context)
+{
+   int responseCode;
+   Alarm *alarm = AlarmFromRequest(context, OBJECT_ACCESS_READ_ALARMS, &responseCode);
+   if (alarm == nullptr)
+      return responseCode;
+
+   json_t *output = json_array();
+   ObjectArray<AlarmComment> *comments = GetAlarmComments(alarm->getAlarmId());
+   for(int i = 0; i < comments->size(); i++)
+   {
+      AlarmComment *comment = comments->get(i);
+      json_array_append_new(output, AlarmCommentToJson(alarm->getAlarmId(), comment->getId(), comment->getChangeTime(),
+         comment->getUserId(), comment->getText()));
+      delete comment;   // array is created with Ownership::False
+   }
+   delete comments;
+
+   context->setResponseData(output);
+   json_decref(output);
+
+   delete alarm;
+   return 200;
+}
+
+/**
+ * Handler for POST /v1/alarms/:alarm-id/comments
+ */
+int H_AlarmCommentCreate(Context *context)
+{
+   int responseCode;
+   Alarm *alarm = AlarmFromRequest(context, OBJECT_ACCESS_UPDATE_ALARMS, &responseCode);
+   if (alarm == nullptr)
+      return responseCode;
+
+   wchar_t *text = CommentTextFromRequest(context, &responseCode);
+   if (text == nullptr)
+   {
+      delete alarm;
+      return responseCode;
+   }
+
+   uint32_t commentId = 0;   // 0 means new comment
+   uint32_t rcc = UpdateAlarmComment(alarm->getAlarmId(), &commentId, text, context->getUserId());
+   responseCode = AlarmCommentResponseCode(context, rcc, 201);
+   if (rcc == RCC_SUCCESS)
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, true, alarm->getSourceObject(), L"Comment [%u] added to alarm %u on object %s via REST API",
+         commentId, alarm->getAlarmId(), GetObjectName(alarm->getSourceObject(), L""));
+
+      json_t *output = AlarmCommentToJson(alarm->getAlarmId(), commentId, time(nullptr), context->getUserId(), text);
+      context->setResponseData(output);
+      json_decref(output);
+   }
+
+   MemFree(text);
+   delete alarm;
+   return responseCode;
+}
+
+/**
+ * Handler for PUT /v1/alarms/:alarm-id/comments/:comment-id
+ */
+int H_AlarmCommentUpdate(Context *context)
+{
+   int responseCode;
+   Alarm *alarm = AlarmFromRequest(context, OBJECT_ACCESS_UPDATE_ALARMS, &responseCode);
+   if (alarm == nullptr)
+      return responseCode;
+
+   uint32_t commentId = context->getPlaceholderValueAsUInt32(L"comment-id");
+   if (commentId == 0)
+   {
+      delete alarm;
+      return 400;
+   }
+
+   wchar_t *text = CommentTextFromRequest(context, &responseCode);
+   if (text == nullptr)
+   {
+      delete alarm;
+      return responseCode;
+   }
+
+   wchar_t *oldText = AlarmCommentText(alarm->getAlarmId(), commentId);
+
+   uint32_t rcc = UpdateAlarmComment(alarm->getAlarmId(), &commentId, text, context->getUserId());
+   responseCode = AlarmCommentResponseCode(context, rcc, 200);
+   if (rcc == RCC_SUCCESS)
+   {
+      context->writeAuditLogWithValues(AUDIT_OBJECTS, true, alarm->getSourceObject(), oldText, text, 'T',
+         L"Comment [%u] of alarm %u on object %s updated via REST API",
+         commentId, alarm->getAlarmId(), GetObjectName(alarm->getSourceObject(), L""));
+
+      json_t *output = AlarmCommentToJson(alarm->getAlarmId(), commentId, time(nullptr), context->getUserId(), text);
+      context->setResponseData(output);
+      json_decref(output);
+   }
+
+   MemFree(oldText);
+   MemFree(text);
+   delete alarm;
+   return responseCode;
+}
+
+/**
+ * Handler for DELETE /v1/alarms/:alarm-id/comments/:comment-id
+ */
+int H_AlarmCommentDelete(Context *context)
+{
+   int responseCode;
+   Alarm *alarm = AlarmFromRequest(context, OBJECT_ACCESS_UPDATE_ALARMS, &responseCode);
+   if (alarm == nullptr)
+      return responseCode;
+
+   uint32_t commentId = context->getPlaceholderValueAsUInt32(L"comment-id");
+   if (commentId == 0)
+   {
+      delete alarm;
+      return 400;
+   }
+
+   uint32_t rcc = DeleteAlarmCommentByID(alarm->getAlarmId(), commentId);
+   responseCode = AlarmCommentResponseCode(context, rcc, 204);
+   if (rcc == RCC_SUCCESS)
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, true, alarm->getSourceObject(), L"Comment [%u] deleted from alarm %u on object %s via REST API",
+         commentId, alarm->getAlarmId(), GetObjectName(alarm->getSourceObject(), L""));
+   }
+
+   delete alarm;
+   return responseCode;
+}
+
+/**
+ * Handler for GET /v1/alarms/:alarm-id/events
+ */
+int H_AlarmEvents(Context *context)
+{
+   if (!context->checkSystemAccessRights(SYSTEM_ACCESS_VIEW_EVENT_LOG))
+      return 403;
+
+   int responseCode;
+   Alarm *alarm = AlarmFromRequest(context, OBJECT_ACCESS_READ_ALARMS, &responseCode);
+   if (alarm == nullptr)
+      return responseCode;
+
+   json_t *output = GetAlarmEventsAsJson(alarm->getAlarmId());
+   context->setResponseData(output);
+   json_decref(output);
+
+   delete alarm;
+   return 200;
+}
+
+/**
  * Handler for /v1/alarms/:alarm-id/acknowledge
  */
 int H_AlarmAcknowledge(Context *context)

--- a/src/server/webapi/main.cpp
+++ b/src/server/webapi/main.cpp
@@ -81,7 +81,12 @@ int H_AlarmCategoryCreate(Context *context);
 int H_AlarmCategoryDelete(Context *context);
 int H_AlarmCategoryDetails(Context *context);
 int H_AlarmCategoryUpdate(Context *context);
+int H_AlarmCommentCreate(Context *context);
+int H_AlarmCommentDelete(Context *context);
+int H_AlarmCommentUpdate(Context *context);
+int H_AlarmComments(Context *context);
 int H_AlarmDetails(Context *context);
+int H_AlarmEvents(Context *context);
 int H_AlarmResolve(Context *context);
 int H_AlarmTerminate(Context *context);
 int H_Alarms(Context *context);
@@ -370,6 +375,17 @@ static bool InitModule(Config *config)
       .build();
    RouteBuilder("v1/alarms/:alarm-id/acknowledge")
       .POST(H_AlarmAcknowledge)
+      .build();
+   RouteBuilder("v1/alarms/:alarm-id/comments")
+      .GET(H_AlarmComments)
+      .POST(H_AlarmCommentCreate)
+      .build();
+   RouteBuilder("v1/alarms/:alarm-id/comments/:comment-id")
+      .PUT(H_AlarmCommentUpdate)
+      .DELETE(H_AlarmCommentDelete)
+      .build();
+   RouteBuilder("v1/alarms/:alarm-id/events")
+      .GET(H_AlarmEvents)
       .build();
    RouteBuilder("v1/alarms/:alarm-id/resolve")
       .POST(H_AlarmResolve)

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -1491,6 +1491,193 @@ paths:
         - BearerAuth: []
       tags:
         - Alarms
+  /v1/alarms/{alarm-id}/comments:
+    get:
+      operationId: getAlarmComments
+      summary: List Alarm Comments
+      description: Retrieve all comments attached to an alarm.
+      parameters:
+        - name: alarm-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of alarm comments.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AlarmComment'
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to alarm or alarm's source object
+        '404':
+          description: Alarm with given ID does not exist
+      security:
+        - BearerAuth: []
+      tags:
+        - Alarms
+    post:
+      operationId: createAlarmComment
+      summary: Create Alarm Comment
+      description: Add a new comment to an alarm. If the alarm is linked to an open helpdesk issue, the comment is also added to that issue.
+      parameters:
+        - name: alarm-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  type: string
+                  description: Comment text
+      responses:
+        '201':
+          description: Comment created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlarmComment'
+        '400':
+          description: Invalid alarm ID or empty comment text
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have update access to alarm or alarm's source object
+        '404':
+          description: Alarm with given ID does not exist
+        '500':
+          description: Database failure
+      security:
+        - BearerAuth: []
+      tags:
+        - Alarms
+  /v1/alarms/{alarm-id}/comments/{comment-id}:
+    put:
+      operationId: updateAlarmComment
+      summary: Update Alarm Comment
+      description: Update text of an existing alarm comment.
+      parameters:
+        - name: alarm-id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: comment-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  type: string
+                  description: Comment text
+      responses:
+        '200':
+          description: Comment updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlarmComment'
+        '400':
+          description: Invalid alarm ID, invalid comment ID, or empty comment text
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have update access to alarm or alarm's source object
+        '404':
+          description: Alarm with given ID does not exist, or comment with given ID does not belong to that alarm
+        '500':
+          description: Database failure
+      security:
+        - BearerAuth: []
+      tags:
+        - Alarms
+    delete:
+      operationId: deleteAlarmComment
+      summary: Delete Alarm Comment
+      description: Delete an alarm comment.
+      parameters:
+        - name: alarm-id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: comment-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Comment deleted.
+        '400':
+          description: Invalid alarm ID or invalid comment ID
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have update access to alarm or alarm's source object
+        '404':
+          description: Alarm with given ID does not exist, or comment with given ID does not belong to that alarm
+        '500':
+          description: Database failure
+      security:
+        - BearerAuth: []
+      tags:
+        - Alarms
+  /v1/alarms/{alarm-id}/events:
+    get:
+      operationId: getAlarmEvents
+      summary: List Alarm Related Events
+      description: >-
+        Retrieve events related to an alarm, limited to the 200 most recent root events. The list is flat and ordered from newest to oldest,
+        with each root event immediately followed by the events correlated to it. Correlation is expressed by the parentId attribute, so the
+        client can rebuild the correlation tree. Requires system-wide "view event log" access in addition to read access to the alarm.
+      parameters:
+        - name: alarm-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of related events.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AlarmEvent'
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have "view event log" system access right, or read access to alarm or alarm's source object
+        '404':
+          description: Alarm with given ID does not exist
+      security:
+        - BearerAuth: []
+      tags:
+        - Alarms
   /v1/alarms/{alarm-id}/resolve:
     post:
       operationId: resolveAlarm
@@ -10121,6 +10308,63 @@ components:
           description: Alarm categories (as assigned by the event processing policy rule that raised the alarm)
           items:
             $ref: '#/components/schemas/AlarmCategoryReference'
+    AlarmComment:
+      type: object
+      description: Comment attached to an alarm
+      properties:
+        id:
+          type: integer
+          description: Comment ID
+        alarmId:
+          type: integer
+          description: ID of the alarm this comment belongs to
+        userId:
+          type: integer
+          description: ID of the user who created or last edited the comment
+        userName:
+          type: string
+          description: Name of the user who created or last edited the comment
+        lastChangeTime:
+          type: string
+          format: date-time
+          description: Time when the comment was created or last edited
+        text:
+          type: string
+          description: Comment text
+    AlarmEvent:
+      type: object
+      description: Event related to an alarm
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Event ID
+        parentId:
+          type: integer
+          format: int64
+          description: ID of the event this event is correlated to (0 for a root event)
+        code:
+          type: integer
+          description: Event code
+        name:
+          type: string
+          description: Event name
+        severity:
+          type: integer
+          description: "Event severity: 0=Normal, 1=Warning, 2=Minor, 3=Major, 4=Critical"
+        source:
+          type: integer
+          description: Source object ID
+        sourceName:
+          type: string
+          description: Name of the source object (empty if the object no longer exists)
+        timestamp:
+          type: string
+          format: date-time
+          description: Event timestamp
+        message:
+          type: string
+          description: Event message
     AlarmCategoryReference:
       type: object
       description: Reference to an alarm category assigned to an alarm


### PR DESCRIPTION
GET/POST /v1/alarms/{id}/comments, PUT/DELETE /v1/alarms/{id}/comments/{comment-id}, and GET /v1/alarms/{id}/events. Access control mirrors the NXCP handlers: read alarms for reads, update alarms for comment mutations, and view event log in addition for related events.

Added GetAlarmEventsAsJson() to server core, so webapi handlers do not have to build NXCP messages. Per-DB-syntax queries for alarm events and correlated events extracted into helpers shared with the existing NXCP code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST API support for listing, creating, updating, and deleting alarm comments; comment `"text"` is required and must be non-empty (400 on invalid requests), with standard success responses (201/200/204).
  * Added an endpoint to view alarm events as JSON, returning root alarms with their correlated descendant events included in a single payload, linked via a `parentId` relationship and ordered newest-to-oldest.
  * Added OpenAPI documentation for alarm comments and alarm events.
  * Alarm event retrieval enforces the required permission to view the event log (403 if missing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->