### PR TITLE
Incident management endpoints for webapi

### DIFF
--- a/src/server/core/incident.cpp
+++ b/src/server/core/incident.cpp
@@ -173,6 +173,24 @@ bool IncidentComment::saveToDatabase() const
    return success;
 }
 
+/**
+ * Create JSON representation
+ */
+json_t *IncidentComment::toJson() const
+{
+   wchar_t userName[MAX_USER_NAME];
+
+   json_t *root = json_object();
+   json_object_set_new(root, "id", json_integer(m_id));
+   json_object_set_new(root, "incidentId", json_integer(m_incidentId));
+   json_object_set_new(root, "userId", json_integer(m_userId));
+   json_object_set_new(root, "userName", json_string_t(ResolveUserId(m_userId, userName, true)));
+   json_object_set_new(root, "creationTime", json_time_string(m_creationTime));
+   json_object_set_new(root, "text", json_string_t(CHECK_NULL_EX(m_text)));
+   json_object_set_new(root, "aiGenerated", json_boolean(m_aiGenerated));
+   return root;
+}
+
 /*** Incident implementation ***/
 
 /**
@@ -707,25 +725,49 @@ void Incident::fillSummaryMessage(NXCPMessage *msg, uint32_t baseId) const
 }
 
 /**
+ * Create JSON value from nullable text database field, or JSON null if it is empty
+ */
+static inline json_t *OptionalFieldToJson(DB_RESULT hResult, int row, int col)
+{
+   String value = DBGetFieldAsString(hResult, row, col);
+   return value.isEmpty() ? json_null() : json_string_t(value.cstr());
+}
+
+/**
  * Create JSON representation
  */
-json_t *Incident::toJson() const
+json_t *Incident::toJson(bool includeComments) const
 {
+   // User IDs are always reported together with resolved user names, including ID 0 used as
+   // "unassigned" / "created by event processing rule" sentinel - it resolves to built-in
+   // "system" account, and interpreting the sentinel is left to the client.
+   wchar_t userName[MAX_USER_NAME];
+
+   // Serialization is done under lock, because title can be replaced and linked alarm
+   // list can be modified concurrently. Comments are read outside of it to avoid holding
+   // incident lock for the duration of a database query.
+   lock();
+
    json_t *root = json_object();
    json_object_set_new(root, "id", json_integer(m_id));
-   json_object_set_new(root, "creationTime", json_integer(m_creationTime));
-   json_object_set_new(root, "lastChangeTime", json_integer(m_lastChangeTime));
+   json_object_set_new(root, "creationTime", json_time_string(m_creationTime));
+   json_object_set_new(root, "lastChangeTime", json_time_string(m_lastChangeTime));
    json_object_set_new(root, "state", json_integer(m_state));
    json_object_set_new(root, "stateName", json_string_t(GetIncidentStateName(m_state)));
    json_object_set_new(root, "assignedUserId", json_integer(m_assignedUserId));
-   json_object_set_new(root, "title", json_string_t(m_title));
+   json_object_set_new(root, "assignedUserName", json_string_t(ResolveUserId(m_assignedUserId, userName, true)));
+   json_object_set_new(root, "title", json_string_t(CHECK_NULL_EX(m_title)));
    json_object_set_new(root, "sourceAlarmId", json_integer(m_sourceAlarmId));
    json_object_set_new(root, "sourceObjectId", json_integer(m_sourceObjectId));
+   json_object_set_new(root, "sourceObjectName", json_string_t(GetObjectName(m_sourceObjectId, L"")));
    json_object_set_new(root, "createdByUser", json_integer(m_createdByUser));
+   json_object_set_new(root, "createdByUserName", json_string_t(ResolveUserId(m_createdByUser, userName, true)));
    json_object_set_new(root, "resolvedByUser", json_integer(m_resolvedByUser));
+   json_object_set_new(root, "resolvedByUserName", json_string_t(ResolveUserId(m_resolvedByUser, userName, true)));
    json_object_set_new(root, "closedByUser", json_integer(m_closedByUser));
-   json_object_set_new(root, "resolveTime", json_integer(m_resolveTime));
-   json_object_set_new(root, "closeTime", json_integer(m_closeTime));
+   json_object_set_new(root, "closedByUserName", json_string_t(ResolveUserId(m_closedByUser, userName, true)));
+   json_object_set_new(root, "resolveTime", json_time_string(m_resolveTime));
+   json_object_set_new(root, "closeTime", json_time_string(m_closeTime));
 
    json_t *alarms = json_array();
    for (int i = 0; i < m_linkedAlarms.size(); i++)
@@ -733,6 +775,12 @@ json_t *Incident::toJson() const
       json_array_append_new(alarms, json_integer(m_linkedAlarms.get(i)));
    }
    json_object_set_new(root, "linkedAlarms", alarms);
+   json_object_set_new(root, "alarmCount", json_integer(m_linkedAlarms.size()));
+
+   unlock();
+
+   if (includeComments)
+      json_object_set_new(root, "comments", GetIncidentCommentsAsJson(m_id));
 
    return root;
 }
@@ -845,19 +893,17 @@ uint32_t NXCORE_EXPORTABLE CreateIncident(uint32_t sourceObjectId, const TCHAR *
 }
 
 /**
- * Get incident details
+ * Load incident by ID. Returns in-memory instance for active incidents, and reads from
+ * database for closed ones (those are dropped from memory). Returns nullptr if incident
+ * does not exist at all.
  */
-uint32_t NXCORE_EXPORTABLE GetIncident(uint32_t incidentId, NXCPMessage *msg)
+shared_ptr<Incident> NXCORE_EXPORTABLE LoadIncidentById(uint32_t incidentId)
 {
    s_incidents.lock();
    shared_ptr<Incident> incident = s_incidents.get(incidentId);
    s_incidents.unlock();
-
    if (incident != nullptr)
-   {
-      incident->fillMessage(msg);
-      return RCC_SUCCESS;
-   }
+      return incident;
 
    // Check in database for closed incidents
    DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
@@ -872,18 +918,27 @@ uint32_t NXCORE_EXPORTABLE GetIncident(uint32_t incidentId, NXCPMessage *msg)
    {
       if (DBGetNumRows(hResult) > 0)
       {
-         Incident dbIncident(hResult, 0);
-         dbIncident.loadLinkedAlarms(hdb);
-         dbIncident.fillMessage(msg);
-         DBFreeResult(hResult);
-         DBConnectionPoolReleaseConnection(hdb);
-         return RCC_SUCCESS;
+         incident = make_shared<Incident>(hResult, 0);
+         incident->loadLinkedAlarms(hdb);
       }
       DBFreeResult(hResult);
    }
 
    DBConnectionPoolReleaseConnection(hdb);
-   return RCC_INVALID_INCIDENT_ID;
+   return incident;
+}
+
+/**
+ * Get incident details
+ */
+uint32_t NXCORE_EXPORTABLE GetIncident(uint32_t incidentId, NXCPMessage *msg)
+{
+   shared_ptr<Incident> incident = LoadIncidentById(incidentId);
+   if (incident == nullptr)
+      return RCC_INVALID_INCIDENT_ID;
+
+   incident->fillMessage(msg);
+   return RCC_SUCCESS;
 }
 
 /**
@@ -1150,6 +1205,160 @@ void SendIncidentsToClient(uint32_t objectId, uint32_t requestId, ClientSession 
 
    msg.setField(VID_RCC, RCC_SUCCESS);
    session->sendMessage(msg);
+}
+
+/**
+ * Get incident comments as JSON array, oldest first
+ */
+json_t NXCORE_EXPORTABLE *GetIncidentCommentsAsJson(uint32_t incidentId)
+{
+   json_t *output = json_array();
+
+   DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
+
+   wchar_t query[256];
+   nx_swprintf(query, 256,
+      L"SELECT id,incident_id,creation_time,user_id,comment_text,ai_generated FROM incident_comments WHERE incident_id=%u ORDER BY creation_time,id",
+      incidentId);
+
+   DB_RESULT hResult = DBSelect(hdb, query);
+   if (hResult != nullptr)
+   {
+      int count = DBGetNumRows(hResult);
+      for (int i = 0; i < count; i++)
+      {
+         IncidentComment comment(hResult, i);
+         json_array_append_new(output, comment.toJson());
+      }
+      DBFreeResult(hResult);
+   }
+
+   DBConnectionPoolReleaseConnection(hdb);
+   return output;
+}
+
+/**
+ * Get incident activity log as JSON array, newest first
+ */
+json_t NXCORE_EXPORTABLE *GetIncidentActivityAsJson(uint32_t incidentId)
+{
+   json_t *output = json_array();
+
+   DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
+
+   wchar_t query[512];
+   nx_swprintf(query, 512,
+      L"SELECT id,incident_id,timestamp,user_id,activity_type,old_value,new_value,details "
+      L"FROM incident_activity_log WHERE incident_id=%u ORDER BY timestamp DESC,id DESC",
+      incidentId);
+
+   DB_RESULT hResult = DBSelect(hdb, query);
+   if (hResult != nullptr)
+   {
+      int count = DBGetNumRows(hResult);
+      for (int i = 0; i < count; i++)
+      {
+         uint32_t userId = DBGetFieldUInt32(hResult, i, 3);
+         wchar_t userName[MAX_USER_NAME];
+
+         json_t *entry = json_object();
+         json_object_set_new(entry, "id", json_integer(DBGetFieldUInt32(hResult, i, 0)));
+         json_object_set_new(entry, "incidentId", json_integer(DBGetFieldUInt32(hResult, i, 1)));
+         json_object_set_new(entry, "timestamp", json_time_string(DBGetFieldTime(hResult, i, 2)));
+         json_object_set_new(entry, "userId", json_integer(userId));
+         json_object_set_new(entry, "userName", json_string_t(ResolveUserId(userId, userName, true)));
+         json_object_set_new(entry, "activityType", json_integer(DBGetFieldInt32(hResult, i, 4)));
+         json_object_set_new(entry, "oldValue", OptionalFieldToJson(hResult, i, 5));
+         json_object_set_new(entry, "newValue", OptionalFieldToJson(hResult, i, 6));
+         json_object_set_new(entry, "details", OptionalFieldToJson(hResult, i, 7));
+         json_array_append_new(output, entry);
+      }
+      DBFreeResult(hResult);
+   }
+
+   DBConnectionPoolReleaseConnection(hdb);
+   return output;
+}
+
+/**
+ * Get incident summaries as JSON array, newest first. Reads from database, so closed
+ * incidents (which are not kept in memory) are included. Only incidents on source objects
+ * readable by given user are returned.
+ *
+ * Row limit is applied after access check rather than as SQL LIMIT, because inaccessible
+ * rows would otherwise consume the limit and the endpoint would return fewer summaries
+ * than requested (same approach as connection history endpoint). Result set is read
+ * unbuffered so that fetching stops once the limit is reached - unlike alarms, closed
+ * incidents accumulate indefinitely and must not be materialized in full.
+ */
+json_t NXCORE_EXPORTABLE *GetIncidentSummariesAsJson(uint32_t userId, uint32_t objectId,
+   const IntegerArray<int32_t> *states, time_t from, time_t to, int limit)
+{
+   if (limit <= 0)
+      limit = INT_MAX;
+
+   StringBuffer query(
+      L"SELECT i.id,i.creation_time,i.last_change_time,i.state,i.assigned_user_id,i.title,i.source_object_id,"
+      L"(SELECT COUNT(*) FROM incident_alarms a WHERE a.incident_id=i.id) FROM incidents i WHERE 1=1");
+
+   if (objectId != 0)
+      query.appendFormattedString(L" AND i.source_object_id=%u", objectId);
+
+   if ((states != nullptr) && !states->isEmpty())
+   {
+      query.append(L" AND i.state IN (");
+      for (int i = 0; i < states->size(); i++)
+      {
+         if (i > 0)
+            query.append(L',');
+         query.appendFormattedString(L"%d", states->get(i));
+      }
+      query.append(L')');
+   }
+
+   if (from != 0)
+      query.appendFormattedString(L" AND i.creation_time>=" INT64_FMT, static_cast<int64_t>(from));
+   if (to != 0)
+      query.appendFormattedString(L" AND i.creation_time<=" INT64_FMT, static_cast<int64_t>(to));
+
+   query.append(L" ORDER BY i.id DESC");
+
+   json_t *output = json_array();
+
+   DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
+   DB_UNBUFFERED_RESULT hResult = DBSelectUnbuffered(hdb, query.cstr());
+   if (hResult != nullptr)
+   {
+      while ((json_array_size(output) < static_cast<size_t>(limit)) && DBFetch(hResult))
+      {
+         uint32_t sourceObjectId = DBGetFieldUInt32(hResult, 6);
+         shared_ptr<NetObj> object = FindObjectById(sourceObjectId);
+         if ((object == nullptr) || !object->checkAccessRights(userId, OBJECT_ACCESS_READ))
+            continue;
+
+         uint32_t assignedUserId = DBGetFieldUInt32(hResult, 4);
+         int state = DBGetFieldInt32(hResult, 3);
+         wchar_t title[256], userName[MAX_USER_NAME];
+
+         json_t *summary = json_object();
+         json_object_set_new(summary, "id", json_integer(DBGetFieldUInt32(hResult, 0)));
+         json_object_set_new(summary, "state", json_integer(state));
+         json_object_set_new(summary, "stateName", json_string_t(GetIncidentStateName(state)));
+         json_object_set_new(summary, "title", json_string_t(DBGetField(hResult, 5, title, 256)));
+         json_object_set_new(summary, "sourceObjectId", json_integer(sourceObjectId));
+         json_object_set_new(summary, "sourceObjectName", json_string_t(object->getName()));
+         json_object_set_new(summary, "assignedUserId", json_integer(assignedUserId));
+         json_object_set_new(summary, "assignedUserName", json_string_t(ResolveUserId(assignedUserId, userName, true)));
+         json_object_set_new(summary, "alarmCount", json_integer(DBGetFieldInt32(hResult, 7)));
+         json_object_set_new(summary, "creationTime", json_time_string(DBGetFieldTime(hResult, 1)));
+         json_object_set_new(summary, "lastChangeTime", json_time_string(DBGetFieldTime(hResult, 2)));
+         json_array_append_new(output, summary);
+      }
+      DBFreeResult(hResult);
+   }
+
+   DBConnectionPoolReleaseConnection(hdb);
+   return output;
 }
 
 /**

--- a/src/server/core/incident.cpp
+++ b/src/server/core/incident.cpp
@@ -313,18 +313,19 @@ void Incident::updateInDatabase()
    DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
 
    DB_STATEMENT hStmt = DBPrepare(hdb,
-      _T("UPDATE incidents SET last_change_time=?,state=?,assigned_user_id=?,")
+      _T("UPDATE incidents SET last_change_time=?,state=?,assigned_user_id=?,title=?,")
       _T("resolved_by_user=?,closed_by_user=?,resolve_time=?,close_time=? WHERE id=?"));
    if (hStmt != nullptr)
    {
       DBBind(hStmt, 1, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(m_lastChangeTime));
       DBBind(hStmt, 2, DB_SQLTYPE_INTEGER, m_state);
       DBBind(hStmt, 3, DB_SQLTYPE_INTEGER, m_assignedUserId);
-      DBBind(hStmt, 4, DB_SQLTYPE_INTEGER, m_resolvedByUser);
-      DBBind(hStmt, 5, DB_SQLTYPE_INTEGER, m_closedByUser);
-      DBBind(hStmt, 6, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(m_resolveTime));
-      DBBind(hStmt, 7, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(m_closeTime));
-      DBBind(hStmt, 8, DB_SQLTYPE_INTEGER, m_id);
+      DBBind(hStmt, 4, DB_SQLTYPE_VARCHAR, m_title, DB_BIND_STATIC, 255);
+      DBBind(hStmt, 5, DB_SQLTYPE_INTEGER, m_resolvedByUser);
+      DBBind(hStmt, 6, DB_SQLTYPE_INTEGER, m_closedByUser);
+      DBBind(hStmt, 7, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(m_resolveTime));
+      DBBind(hStmt, 8, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(m_closeTime));
+      DBBind(hStmt, 9, DB_SQLTYPE_INTEGER, m_id);
       DBExecute(hStmt);
       DBFreeStatement(hStmt);
    }
@@ -557,6 +558,8 @@ uint32_t Incident::linkAlarm(uint32_t alarmId, uint32_t userId)
    }
    DBConnectionPoolReleaseConnection(hdb);
 
+   updateInDatabase();
+
    TCHAR alarmIdStr[32];
    _sntprintf(alarmIdStr, 32, _T("%u"), alarmId);
    logActivity(INCIDENT_ACTIVITY_ALARM_LINKED, userId, nullptr, alarmIdStr, nullptr);
@@ -608,6 +611,8 @@ uint32_t Incident::unlinkAlarm(uint32_t alarmId, uint32_t userId)
       DBFreeStatement(hStmt);
    }
    DBConnectionPoolReleaseConnection(hdb);
+
+   updateInDatabase();
 
    TCHAR alarmIdStr[32];
    _sntprintf(alarmIdStr, 32, _T("%u"), alarmId);

--- a/src/server/include/nms_incident.h
+++ b/src/server/include/nms_incident.h
@@ -51,9 +51,12 @@ public:
    time_t getCreationTime() const { return m_creationTime; }
    uint32_t getUserId() const { return m_userId; }
    const TCHAR *getText() const { return m_text; }
+   bool isAiGenerated() const { return m_aiGenerated; }
 
    void fillMessage(NXCPMessage *msg, uint32_t baseId) const;
    bool saveToDatabase() const;
+
+   json_t *toJson() const;
 };
 
 /**
@@ -77,10 +80,10 @@ private:
    time_t m_closeTime;
 
    IntegerArray<uint32_t> m_linkedAlarms;
-   Mutex m_mutex;
+   mutable Mutex m_mutex;
 
-   void lock() { m_mutex.lock(); }
-   void unlock() { m_mutex.unlock(); }
+   void lock() const { m_mutex.lock(); }
+   void unlock() const { m_mutex.unlock(); }
 
    void logActivity(int activityType, uint32_t userId, const TCHAR *oldValue, const TCHAR *newValue, const TCHAR *details);
 
@@ -126,7 +129,7 @@ public:
    void fillMessage(NXCPMessage *msg) const;
    void fillSummaryMessage(NXCPMessage *msg, uint32_t baseId) const;
 
-   json_t *toJson() const;
+   json_t *toJson(bool includeComments = false) const;
 };
 
 /**
@@ -145,6 +148,7 @@ uint32_t NXCORE_EXPORTABLE CreateIncident(uint32_t sourceObjectId, const TCHAR *
 uint32_t NXCORE_EXPORTABLE GetIncident(uint32_t incidentId, NXCPMessage *msg);
 shared_ptr<Incident> NXCORE_EXPORTABLE FindIncidentById(uint32_t incidentId);
 shared_ptr<Incident> NXCORE_EXPORTABLE FindIncidentByAlarmId(uint32_t alarmId);
+shared_ptr<Incident> NXCORE_EXPORTABLE LoadIncidentById(uint32_t incidentId);
 
 uint32_t NXCORE_EXPORTABLE ChangeIncidentState(uint32_t incidentId, int newState, uint32_t userId, const TCHAR *comment = nullptr);
 uint32_t NXCORE_EXPORTABLE AssignIncident(uint32_t incidentId, uint32_t userId, uint32_t assignedBy);
@@ -159,6 +163,15 @@ uint32_t NXCORE_EXPORTABLE AddIncidentComment(uint32_t incidentId, const TCHAR *
 uint32_t NXCORE_EXPORTABLE GetIncidentActivity(uint32_t incidentId, NXCPMessage *msg);
 
 void SendIncidentsToClient(uint32_t objectId, uint32_t requestId, ClientSession *session);
+
+/**
+ * JSON representations for REST API. All of them read from the database, so closed incidents
+ * (which are not kept in memory) are visible as well.
+ */
+json_t NXCORE_EXPORTABLE *GetIncidentSummariesAsJson(uint32_t userId, uint32_t objectId,
+   const IntegerArray<int32_t> *states, time_t from, time_t to, int limit);
+json_t NXCORE_EXPORTABLE *GetIncidentCommentsAsJson(uint32_t incidentId);
+json_t NXCORE_EXPORTABLE *GetIncidentActivityAsJson(uint32_t incidentId);
 
 /**
  * Scheduled task handler for delayed incident creation

--- a/src/server/webapi/Makefile.am
+++ b/src/server/webapi/Makefile.am
@@ -1,7 +1,7 @@
 MODULE = webapi
 
 pkglib_LTLIBRARIES = webapi.la
-webapi_la_SOURCES = 2fa.cpp actions.cpp ai.cpp ai_operators.cpp alarm_categories.cpp alarms.cpp asset_management.cpp chassis.cpp chat_bots.cpp cloud_connectors.cpp conn_history.cpp datacoll.cpp dcst.cpp epp.cpp event_forwarders.cpp events.cpp find.cpp geoareas.cpp grafana.cpp images.cpp info.cpp log_parsers.cpp main.cpp notifications.cpp object_categories.cpp object_collections.cpp object_dashboard.cpp object_dci.cpp object_helpers.cpp object_networkmap.cpp object_node_config.cpp object_properties.cpp objects.cpp objtools.cpp racks.cpp schedules.cpp scripts.cpp snmp_mib.cpp sshkeys.cpp tcpproxy.cpp topology.cpp users.cpp websvc.cpp
+webapi_la_SOURCES = 2fa.cpp actions.cpp ai.cpp ai_operators.cpp alarm_categories.cpp alarms.cpp asset_management.cpp chassis.cpp chat_bots.cpp cloud_connectors.cpp conn_history.cpp datacoll.cpp dcst.cpp epp.cpp event_forwarders.cpp events.cpp find.cpp geoareas.cpp grafana.cpp images.cpp incidents.cpp info.cpp log_parsers.cpp main.cpp notifications.cpp object_categories.cpp object_collections.cpp object_dashboard.cpp object_dci.cpp object_helpers.cpp object_networkmap.cpp object_node_config.cpp object_properties.cpp objects.cpp objtools.cpp racks.cpp schedules.cpp scripts.cpp snmp_mib.cpp sshkeys.cpp tcpproxy.cpp topology.cpp users.cpp websvc.cpp
 webapi_la_CPPFLAGS = -I@top_srcdir@/include -I@top_srcdir@/src/server/include -I@top_srcdir@/build @MICROHTTPD_CPPFLAGS@
 webapi_la_LDFLAGS = -module -avoid-version @MICROHTTPD_LDFLAGS@
 webapi_la_LIBADD = ../../libnetxms/libnetxms.la ../libnxsrv/libnxsrv.la ../core/libnxcore.la @MICROHTTPD_LIBS@

--- a/src/server/webapi/incidents.cpp
+++ b/src/server/webapi/incidents.cpp
@@ -1,0 +1,525 @@
+/*
+** NetXMS - Network Management System
+** Copyright (C) 2003-2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+** File: incidents.cpp
+**
+**/
+
+#include "webapi.h"
+#include <nms_incident.h>
+#include <nms_users.h>
+
+/**
+ * Get incident referenced by :incident-id placeholder. Sets response code and returns nullptr
+ * if incident cannot be accessed.
+ */
+static shared_ptr<Incident> IncidentFromRequest(Context *context, uint32_t objectAccess, int *responseCode)
+{
+   uint32_t incidentId = context->getPlaceholderValueAsUInt32(L"incident-id");
+   if (incidentId == 0)
+   {
+      *responseCode = 400;
+      return shared_ptr<Incident>();
+   }
+
+   shared_ptr<Incident> incident = LoadIncidentById(incidentId);
+   if (incident == nullptr)
+   {
+      *responseCode = 404;
+      return shared_ptr<Incident>();
+   }
+
+   shared_ptr<NetObj> object = FindObjectById(incident->getSourceObjectId());
+   if ((object == nullptr) || !object->checkAccessRights(context->getUserId(), objectAccess))
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, false, incident->getSourceObjectId(),
+         L"Access denied on incident [%u] via REST API", incidentId);
+      *responseCode = 403;
+      return shared_ptr<Incident>();
+   }
+
+   return incident;
+}
+
+/**
+ * Check that incident can still be modified. Closed incidents are terminal - every mutation
+ * on them must be refused. Core functions cannot report this reliably, because closed incidents
+ * are dropped from in-memory list on server restart and would be reported as non-existent.
+ */
+static inline bool CheckIncidentNotClosed(Context *context, const Incident& incident, int *responseCode)
+{
+   if (incident.getState() != INCIDENT_STATE_CLOSED)
+      return true;
+   context->setErrorResponse("Incident is closed");
+   *responseCode = 409;
+   return false;
+}
+
+/**
+ * Convert return code of incident operation to HTTP response code
+ */
+static int IncidentResponseCode(Context *context, uint32_t rcc, int successCode)
+{
+   switch(rcc)
+   {
+      case RCC_SUCCESS:
+         return successCode;
+      case RCC_ACCESS_DENIED:
+         return 403;
+      case RCC_INVALID_INCIDENT_ID:
+         return 404;
+      case RCC_INCIDENT_CLOSED:
+         context->setErrorResponse("Incident is closed");
+         return 409;
+      case RCC_ALARM_ALREADY_IN_INCIDENT:
+         context->setErrorResponse("Alarm is already linked to another incident");
+         return 409;
+      case RCC_INVALID_INCIDENT_STATE:
+         context->setErrorResponse("Invalid incident state");
+         return 400;
+      case RCC_COMMENT_REQUIRED:
+         context->setErrorResponse("Comment is required for this state change");
+         return 400;
+      default:
+         context->setErrorResponse("Database failure");
+         return 500;
+   }
+}
+
+/**
+ * Set incident details as response data. All mutations answer with updated incident, so that
+ * client can refresh from response instead of issuing additional GET.
+ */
+static int SetIncidentResponse(Context *context, const Incident& incident, int responseCode)
+{
+   json_t *output = incident.toJson(true);
+   context->setResponseData(output);
+   json_decref(output);
+   return responseCode;
+}
+
+/**
+ * Check that alarm exists and is visible to current user. Sets response code and returns false
+ * otherwise. Attaching an alarm to an incident makes incident lifecycle resolve and terminate
+ * that alarm, so alarms user cannot see must not be attachable. Uses same read access check as
+ * alarm endpoints.
+ */
+static bool CheckAlarmAccess(Context *context, uint32_t alarmId, int *responseCode)
+{
+   Alarm *alarm = FindAlarmById(alarmId);
+   if (alarm == nullptr)
+   {
+      context->setErrorResponse("Alarm not found");
+      *responseCode = 404;
+      return false;
+   }
+
+   uint32_t sourceObjectId = alarm->getSourceObject();
+   shared_ptr<NetObj> object = FindObjectById(sourceObjectId);
+   bool accessible = (object != nullptr) &&
+       object->checkAccessRights(context->getUserId(), OBJECT_ACCESS_READ_ALARMS) &&
+       alarm->checkCategoryAccess(context->getUserId(), context->getSystemAccessRights());
+   delete alarm;
+
+   if (!accessible)
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, false, sourceObjectId,
+         L"Access denied on attaching alarm [%u] to incident via REST API", alarmId);
+      *responseCode = 403;
+      return false;
+   }
+
+   return true;
+}
+
+/**
+ * Get non-empty string field from request document. Returns nullptr and sets response code
+ * if field is missing or empty.
+ */
+static wchar_t *StringFieldFromRequest(Context *context, json_t *request, const char *name, const char *errorMessage, int *responseCode)
+{
+   wchar_t *value = json_object_get_string_w(request, name, nullptr);
+   if ((value == nullptr) || (*value == 0))
+   {
+      MemFree(value);
+      context->setErrorResponse(errorMessage);
+      *responseCode = 400;
+      return nullptr;
+   }
+   return value;
+}
+
+/**
+ * Handler for GET /v1/incidents
+ */
+int H_Incidents(Context *context)
+{
+   uint32_t objectId = context->getQueryParameterAsUInt32("objectId");
+
+   IntegerArray<int32_t> states;
+   const char *stateFilter = context->getQueryParameter("state");
+   if ((stateFilter != nullptr) && (*stateFilter != 0))
+   {
+      for(const char *p = stateFilter; *p != 0;)
+      {
+         char *eptr;
+         int32_t state = strtol(p, &eptr, 10);
+         if ((eptr == p) || ((*eptr != 0) && (*eptr != ',')) || ((*eptr == ',') && (eptr[1] == 0)) ||
+             (state < INCIDENT_STATE_OPEN) || (state > INCIDENT_STATE_CLOSED))
+         {
+            context->setErrorResponse("Invalid value for \"state\" parameter");
+            return 400;
+         }
+         states.add(state);
+         p = (*eptr == ',') ? eptr + 1 : eptr;
+      }
+   }
+
+   time_t from = context->getQueryParameterAsTime("from", 0);
+   if ((from == 0) && (context->getQueryParameter("from") != nullptr))
+   {
+      context->setErrorResponse("Invalid value for \"from\" parameter");
+      return 400;
+   }
+
+   time_t to = context->getQueryParameterAsTime("to", 0);
+   if ((to == 0) && (context->getQueryParameter("to") != nullptr))
+   {
+      context->setErrorResponse("Invalid value for \"to\" parameter");
+      return 400;
+   }
+
+   int32_t limit = context->getQueryParameterAsInt32("limit", 1000);
+   if (limit <= 0)
+      limit = 1000;
+   else if (limit > 10000)
+      limit = 10000;
+
+   json_t *output = GetIncidentSummariesAsJson(context->getUserId(), objectId, &states, from, to, limit);
+   context->setResponseData(output);
+   json_decref(output);
+   return 200;
+}
+
+/**
+ * Handler for POST /v1/incidents
+ */
+int H_IncidentCreate(Context *context)
+{
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+      return 400;
+
+   uint32_t sourceObjectId = json_object_get_uint32(request, "sourceObjectId", 0);
+   if (sourceObjectId == 0)
+   {
+      context->setErrorResponse("Missing or invalid sourceObjectId field");
+      return 400;
+   }
+
+   shared_ptr<NetObj> object = FindObjectById(sourceObjectId);
+   if (object == nullptr)
+   {
+      context->setErrorResponse("Source object not found");
+      return 404;
+   }
+   if (!object->checkAccessRights(context->getUserId(), OBJECT_ACCESS_MANAGE_INCIDENTS))
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, false, sourceObjectId, L"Access denied on creating incident via REST API");
+      return 403;
+   }
+
+   int responseCode;
+   wchar_t *title = StringFieldFromRequest(context, request, "title", "Incident title cannot be empty", &responseCode);
+   if (title == nullptr)
+      return responseCode;
+
+   uint32_t sourceAlarmId = json_object_get_uint32(request, "sourceAlarmId", 0);
+   if ((sourceAlarmId != 0) && !CheckAlarmAccess(context, sourceAlarmId, &responseCode))
+   {
+      MemFree(title);
+      return responseCode;
+   }
+
+   wchar_t *initialComment = json_object_get_string_w(request, "initialComment", nullptr);
+
+   uint32_t incidentId = 0;
+   uint32_t rcc = CreateIncident(sourceObjectId, title, initialComment, sourceAlarmId, context->getUserId(), &incidentId);
+   MemFree(title);
+   MemFree(initialComment);
+
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 201);
+
+   context->writeAuditLog(AUDIT_OBJECTS, true, sourceObjectId, L"Incident [%u] created via REST API", incidentId);
+
+   wchar_t location[256];
+   nx_swprintf(location, 256, L"/v1/incidents/%u", incidentId);
+   context->setResponseHeader(L"Location", location);
+
+   // Incident was created, so failure to read it back is not a creation failure - answer with
+   // 201 and no body instead of an error, client can follow Location header to get details.
+   shared_ptr<Incident> incident = LoadIncidentById(incidentId);
+   if (incident == nullptr)
+      return 201;
+
+   return SetIncidentResponse(context, *incident, 201);
+}
+
+/**
+ * Handler for GET /v1/incidents/:incident-id
+ */
+int H_IncidentDetails(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_READ, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   return SetIncidentResponse(context, *incident, 200);
+}
+
+/**
+ * Handler for PUT /v1/incidents/:incident-id
+ */
+int H_IncidentUpdate(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_MANAGE_INCIDENTS, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   if (!CheckIncidentNotClosed(context, *incident, &responseCode))
+      return responseCode;
+
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+      return 400;
+
+   wchar_t *title = StringFieldFromRequest(context, request, "title", "Incident title cannot be empty", &responseCode);
+   if (title == nullptr)
+      return responseCode;
+
+   uint32_t rcc = UpdateIncident(incident->getId(), title, context->getUserId());
+   MemFree(title);
+
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 200);
+
+   context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+      L"Incident [%u] updated via REST API", incident->getId());
+   return SetIncidentResponse(context, *incident, 200);
+}
+
+/**
+ * Handler for POST /v1/incidents/:incident-id/state
+ */
+int H_IncidentChangeState(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_MANAGE_INCIDENTS, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   if (!CheckIncidentNotClosed(context, *incident, &responseCode))
+      return responseCode;
+
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+      return 400;
+
+   json_t *jsonState = json_object_get(request, "state");
+   if (!json_is_integer(jsonState))
+   {
+      context->setErrorResponse("Missing or invalid state field");
+      return 400;
+   }
+
+   int newState = static_cast<int>(json_integer_value(jsonState));
+   wchar_t *comment = json_object_get_string_w(request, "comment", nullptr);
+   uint32_t rcc = ChangeIncidentState(incident->getId(), newState, context->getUserId(), comment);
+   MemFree(comment);
+
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 200);
+
+   // Requested state is logged instead of current incident state, because concurrent change
+   // could already move incident to a different state by the time audit record is written.
+   context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+      L"Incident [%u] state changed to \"%s\" via REST API", incident->getId(), GetIncidentStateName(newState));
+   return SetIncidentResponse(context, *incident, 200);
+}
+
+/**
+ * Handler for POST /v1/incidents/:incident-id/assign
+ */
+int H_IncidentAssign(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_MANAGE_INCIDENTS, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   if (!CheckIncidentNotClosed(context, *incident, &responseCode))
+      return responseCode;
+
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+      return 400;
+
+   json_t *jsonUserId = json_object_get(request, "userId");
+   if (!json_is_integer(jsonUserId))
+   {
+      context->setErrorResponse("Missing or invalid userId field");
+      return 400;
+   }
+
+   // User ID 0 clears assignment, any other ID must reference existing user
+   uint32_t assignedUserId = static_cast<uint32_t>(json_integer_value(jsonUserId));
+   wchar_t userName[MAX_USER_NAME];
+   if ((assignedUserId != 0) && (ResolveUserId(assignedUserId, userName) == nullptr))
+   {
+      context->setErrorResponse("Invalid user ID");
+      return 400;
+   }
+
+   uint32_t rcc = AssignIncident(incident->getId(), assignedUserId, context->getUserId());
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 200);
+
+   if (assignedUserId != 0)
+      context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+         L"Incident [%u] assigned to user %s [%u] via REST API", incident->getId(), userName, assignedUserId);
+   else
+      context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+         L"Assignment cleared on incident [%u] via REST API", incident->getId());
+   return SetIncidentResponse(context, *incident, 200);
+}
+
+/**
+ * Handler for POST /v1/incidents/:incident-id/comments
+ */
+int H_IncidentAddComment(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_MANAGE_INCIDENTS, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   if (!CheckIncidentNotClosed(context, *incident, &responseCode))
+      return responseCode;
+
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+      return 400;
+
+   wchar_t *text = StringFieldFromRequest(context, request, "text", "Comment text cannot be empty", &responseCode);
+   if (text == nullptr)
+      return responseCode;
+
+   uint32_t rcc = AddIncidentComment(incident->getId(), text, context->getUserId(), nullptr);
+   MemFree(text);
+
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 201);
+
+   context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+      L"Comment added to incident [%u] via REST API", incident->getId());
+   return SetIncidentResponse(context, *incident, 201);
+}
+
+/**
+ * Handler for POST /v1/incidents/:incident-id/alarms
+ */
+int H_IncidentLinkAlarm(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_MANAGE_INCIDENTS, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   if (!CheckIncidentNotClosed(context, *incident, &responseCode))
+      return responseCode;
+
+   json_t *request = context->getRequestDocument();
+   if (request == nullptr)
+      return 400;
+
+   uint32_t alarmId = json_object_get_uint32(request, "alarmId", 0);
+   if (alarmId == 0)
+   {
+      context->setErrorResponse("Missing or invalid alarmId field");
+      return 400;
+   }
+
+   if (!CheckAlarmAccess(context, alarmId, &responseCode))
+      return responseCode;
+
+   uint32_t rcc = LinkAlarmToIncident(incident->getId(), alarmId, context->getUserId());
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 200);
+
+   context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+      L"Alarm [%u] linked to incident [%u] via REST API", alarmId, incident->getId());
+   return SetIncidentResponse(context, *incident, 200);
+}
+
+/**
+ * Handler for DELETE /v1/incidents/:incident-id/alarms/:alarm-id
+ *
+ * Answers with updated incident instead of 204, so that all incident mutations behave
+ * consistently and client never needs additional GET.
+ */
+int H_IncidentUnlinkAlarm(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_MANAGE_INCIDENTS, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   if (!CheckIncidentNotClosed(context, *incident, &responseCode))
+      return responseCode;
+
+   uint32_t alarmId = context->getPlaceholderValueAsUInt32(L"alarm-id");
+   if (alarmId == 0)
+      return 400;
+
+   uint32_t rcc = UnlinkAlarmFromIncident(incident->getId(), alarmId, context->getUserId());
+   if (rcc != RCC_SUCCESS)
+      return IncidentResponseCode(context, rcc, 200);
+
+   context->writeAuditLog(AUDIT_OBJECTS, true, incident->getSourceObjectId(),
+      L"Alarm [%u] unlinked from incident [%u] via REST API", alarmId, incident->getId());
+   return SetIncidentResponse(context, *incident, 200);
+}
+
+/**
+ * Handler for GET /v1/incidents/:incident-id/activity
+ */
+int H_IncidentActivity(Context *context)
+{
+   int responseCode;
+   shared_ptr<Incident> incident = IncidentFromRequest(context, OBJECT_ACCESS_READ, &responseCode);
+   if (incident == nullptr)
+      return responseCode;
+
+   json_t *output = GetIncidentActivityAsJson(incident->getId());
+   context->setResponseData(output);
+   json_decref(output);
+   return 200;
+}

--- a/src/server/webapi/main.cpp
+++ b/src/server/webapi/main.cpp
@@ -131,6 +131,16 @@ int H_ImageLibraryData(Context *context);
 int H_ImageLibraryCreate(Context *context);
 int H_ImageLibraryUpdate(Context *context);
 int H_ImageLibraryDelete(Context *context);
+int H_Incidents(Context *context);
+int H_IncidentCreate(Context *context);
+int H_IncidentDetails(Context *context);
+int H_IncidentUpdate(Context *context);
+int H_IncidentChangeState(Context *context);
+int H_IncidentAssign(Context *context);
+int H_IncidentAddComment(Context *context);
+int H_IncidentLinkAlarm(Context *context);
+int H_IncidentUnlinkAlarm(Context *context);
+int H_IncidentActivity(Context *context);
 int H_FindMacAddress(Context *context);
 int H_GrafanaGetAlarms(Context *context);
 int H_GrafanaGetSummaryTable(Context *context);
@@ -399,6 +409,32 @@ static bool InitModule(Config *config)
       .build();
    RouteBuilder("v1/alarms/:alarm-id/terminate")
       .POST(H_AlarmTerminate)
+      .build();
+   RouteBuilder("v1/incidents")
+      .GET(H_Incidents)
+      .POST(H_IncidentCreate)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id")
+      .GET(H_IncidentDetails)
+      .PUT(H_IncidentUpdate)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id/state")
+      .POST(H_IncidentChangeState)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id/assign")
+      .POST(H_IncidentAssign)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id/comments")
+      .POST(H_IncidentAddComment)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id/alarms")
+      .POST(H_IncidentLinkAlarm)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id/alarms/:alarm-id")
+      .DELETE(H_IncidentUnlinkAlarm)
+      .build();
+   RouteBuilder("v1/incidents/:incident-id/activity")
+      .GET(H_IncidentActivity)
       .build();
    RouteBuilder("v1/asset-management-schema")
       .GET(H_AssetManagementSchema)

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -8,6 +8,8 @@ tags:
     description: User authentication and session management
   - name: Alarms
     description: Alarm management operations
+  - name: Incidents
+    description: Incident management operations
   - name: Objects
     description: Object management and queries
   - name: Data Collection
@@ -1728,6 +1730,387 @@ paths:
         - BearerAuth: []
       tags:
         - Alarms
+  /v1/incidents:
+    get:
+      operationId: listIncidents
+      summary: List Incidents
+      description: >
+        Retrieve incident summaries, newest first. Reads from the database, so closed incidents
+        are included as well. Only incidents whose source object is readable by the caller are
+        returned.
+      parameters:
+        - name: objectId
+          in: query
+          description: Return only incidents created on given source object (0 or absent for all objects).
+          schema:
+            type: integer
+        - name: state
+          in: query
+          description: Comma-separated list of incident states to include (absent for all states).
+          example: '0,1,2'
+          schema:
+            type: string
+        - name: from
+          in: query
+          description: Return only incidents created at or after this point in time.
+          schema:
+            type: string
+        - name: to
+          in: query
+          description: Return only incidents created at or before this point in time.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of incidents to return (default 1000, maximum 10000).
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful retrieval of incidents.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IncidentSummary'
+        '400':
+          description: Invalid filter parameters
+        '401':
+          description: Unauthorized
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+    post:
+      operationId: createIncident
+      summary: Create Incident
+      description: >
+        Create new incident on given source object. If sourceAlarmId is provided, that alarm is
+        linked to the new incident. An alarm can belong to one incident only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentCreate'
+      responses:
+        '201':
+          description: Incident created.
+          headers:
+            Location:
+              description: URL of created incident.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid request (missing source object or empty title)
+        '401':
+          description: Unauthorized
+        '403':
+          description: >
+            User does not have "Manage incidents" access to source object, or no read access
+            to source alarm
+        '404':
+          description: Source object or source alarm does not exist
+        '409':
+          description: Source alarm is already linked to another incident
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}:
+    get:
+      operationId: getIncident
+      summary: Get Incident Details
+      description: Retrieve full incident details, including linked alarm IDs and comments.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful retrieval of incident.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+    put:
+      operationId: updateIncident
+      summary: Update Incident
+      description: Update incident. Title is the only mutable field.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentUpdate'
+      responses:
+        '200':
+          description: Incident updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid request (empty title)
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have "Manage incidents" access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+        '409':
+          description: Incident is closed and cannot be modified
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}/state:
+    post:
+      operationId: changeIncidentState
+      summary: Change Incident State
+      description: >
+        Change incident state. Moving to RESOLVED resolves all linked alarms, moving to CLOSED
+        terminates them. CLOSED is terminal - no further changes are accepted. Moving to BLOCKED
+        requires a comment.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentStateChange'
+      responses:
+        '200':
+          description: Incident state changed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid state value, or comment missing for BLOCKED state
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have "Manage incidents" access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+        '409':
+          description: Incident is closed and cannot be modified
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}/assign:
+    post:
+      operationId: assignIncident
+      summary: Assign Incident
+      description: Assign incident to a user. User ID 0 clears the assignment.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentAssign'
+      responses:
+        '200':
+          description: Incident assigned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Missing or unknown user ID
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have "Manage incidents" access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+        '409':
+          description: Incident is closed and cannot be modified
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}/comments:
+    post:
+      operationId: addIncidentComment
+      summary: Add Incident Comment
+      description: Add comment to incident. Incident comments cannot be updated or deleted.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentCommentCreate'
+      responses:
+        '201':
+          description: Comment added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Comment text is empty
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have "Manage incidents" access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+        '409':
+          description: Incident is closed and cannot be modified
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}/alarms:
+    post:
+      operationId: linkAlarmToIncident
+      summary: Link Alarm To Incident
+      description: Link an alarm to incident. An alarm can belong to one incident only.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncidentAlarmLink'
+      responses:
+        '200':
+          description: Alarm linked.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Missing or invalid alarm ID
+        '401':
+          description: Unauthorized
+        '403':
+          description: >
+            User does not have "Manage incidents" access to incident's source object, or no
+            read access to the alarm
+        '404':
+          description: Incident or alarm with given ID does not exist
+        '409':
+          description: Incident is closed, or alarm is already linked to another incident
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}/alarms/{alarm-id}:
+    delete:
+      operationId: unlinkAlarmFromIncident
+      summary: Unlink Alarm From Incident
+      description: >
+        Unlink an alarm from incident. Unlike most DELETE endpoints this one answers with the
+        updated incident, so that all incident mutations behave consistently.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: alarm-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Alarm unlinked.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have "Manage incidents" access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+        '409':
+          description: Incident is closed and cannot be modified
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
+  /v1/incidents/{incident-id}/activity:
+    get:
+      operationId: getIncidentActivity
+      summary: Get Incident Activity Log
+      description: Retrieve incident activity log, newest first.
+      parameters:
+        - name: incident-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successful retrieval of activity log.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IncidentActivityEntry'
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to incident's source object
+        '404':
+          description: Incident with given ID does not exist
+      security:
+        - BearerAuth: []
+      tags:
+        - Incidents
   /v1/asset-management-schema:
     get:
       operationId: getAssetManagementSchema
@@ -10682,6 +11065,227 @@ components:
           type: string
           nullable: true
           description: Alarm category name, or null if the category no longer exists
+    IncidentSummary:
+      type: object
+      description: Incident summary as returned by incident list endpoint
+      properties:
+        id:
+          type: integer
+          description: Unique incident identifier.
+        state:
+          type: integer
+          description: 'Incident state: 0 open, 1 in progress, 2 blocked, 3 resolved, 4 closed.'
+        stateName:
+          type: string
+          description: Human-readable incident state name.
+        title:
+          type: string
+          description: Incident title (up to 255 characters).
+        sourceObjectId:
+          type: integer
+          description: ID of object the incident was created on.
+        sourceObjectName:
+          type: string
+          description: Name of the source object.
+        assignedUserId:
+          type: integer
+          description: ID of user the incident is assigned to, or 0 when unassigned.
+        assignedUserName:
+          type: string
+          description: >
+            Login name of assigned user. Unassigned incidents must be detected by testing
+            assignedUserId for 0, not by matching on this name - user ID 0 resolves to the
+            built-in "system" account.
+        alarmCount:
+          type: integer
+          description: Number of alarms linked to the incident.
+        creationTime:
+          type: string
+          format: date-time
+          description: Incident creation time.
+        lastChangeTime:
+          type: string
+          format: date-time
+          description: Time of last incident change.
+    Incident:
+      allOf:
+        - $ref: '#/components/schemas/IncidentSummary'
+        - type: object
+          description: Full incident details
+          properties:
+            sourceAlarmId:
+              type: integer
+              description: ID of alarm the incident was created from, or 0 if created manually.
+            createdByUser:
+              type: integer
+              description: ID of user who created the incident, or 0 when created by event processing rule.
+            createdByUserName:
+              type: string
+              description: >
+                Login name of creating user. Resolves to the built-in "system" account when the
+                incident was created by an event processing rule.
+            resolvedByUser:
+              type: integer
+              description: ID of user who resolved the incident, or 0 if not resolved yet.
+            resolvedByUserName:
+              type: string
+              description: Login name of resolving user. Meaningful only when resolvedByUser is not 0.
+            resolveTime:
+              type: string
+              format: date-time
+              nullable: true
+              description: Time the incident was resolved, or null if not resolved yet.
+            closedByUser:
+              type: integer
+              description: ID of user who closed the incident, or 0 if not closed yet.
+            closedByUserName:
+              type: string
+              description: Login name of closing user. Meaningful only when closedByUser is not 0.
+            closeTime:
+              type: string
+              format: date-time
+              nullable: true
+              description: Time the incident was closed, or null if not closed yet.
+            linkedAlarms:
+              type: array
+              description: IDs of alarms linked to the incident.
+              items:
+                type: integer
+            comments:
+              type: array
+              description: Incident comments, oldest first.
+              items:
+                $ref: '#/components/schemas/IncidentComment'
+    IncidentComment:
+      type: object
+      description: Incident comment. Comments can only be added, not updated or deleted.
+      properties:
+        id:
+          type: integer
+          description: Unique comment identifier.
+        incidentId:
+          type: integer
+          description: ID of incident the comment belongs to.
+        userId:
+          type: integer
+          description: ID of user who added the comment, or 0 for comments added by the server itself.
+        userName:
+          type: string
+          description: >
+            Login name of user who added the comment. Comments added by the server itself
+            (AI analysis, event processing rules) carry user ID 0 and resolve to the built-in
+            "system" account; use aiGenerated to identify AI-authored comments.
+        creationTime:
+          type: string
+          format: date-time
+          description: Comment creation time.
+        text:
+          type: string
+          description: Comment text.
+        aiGenerated:
+          type: boolean
+          description: True if the comment was generated by AI analysis.
+    IncidentActivityEntry:
+      type: object
+      description: Entry in incident activity log
+      properties:
+        id:
+          type: integer
+          description: Unique activity entry identifier.
+        incidentId:
+          type: integer
+          description: ID of incident the entry belongs to.
+        timestamp:
+          type: string
+          format: date-time
+          description: Time the activity was recorded.
+        userId:
+          type: integer
+          description: ID of user who performed the action, or 0 if performed by the server itself.
+        userName:
+          type: string
+          description: >
+            Login name of user who performed the action. Actions performed by the server itself
+            (for example, incident creation by an event processing rule) carry user ID 0 and
+            resolve to the built-in "system" account.
+        activityType:
+          type: integer
+          description: >
+            Activity type: 0 created, 1 state change, 2 assigned, 3 alarm linked,
+            4 alarm unlinked, 5 comment added, 6 updated.
+        oldValue:
+          type: string
+          nullable: true
+          description: Value before the change, if applicable.
+        newValue:
+          type: string
+          nullable: true
+          description: Value after the change, if applicable.
+        details:
+          type: string
+          nullable: true
+          description: Additional details, if any.
+    IncidentCreate:
+      type: object
+      required:
+        - sourceObjectId
+        - title
+      properties:
+        sourceObjectId:
+          type: integer
+          description: ID of object to create the incident on.
+        title:
+          type: string
+          description: Incident title (cannot be empty, truncated to 255 characters).
+        initialComment:
+          type: string
+          description: Optional comment added to the new incident.
+        sourceAlarmId:
+          type: integer
+          description: Optional ID of alarm to create the incident from and link to it.
+    IncidentUpdate:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+          description: New incident title (cannot be empty, truncated to 255 characters).
+    IncidentStateChange:
+      type: object
+      required:
+        - state
+      properties:
+        state:
+          type: integer
+          description: 'New incident state: 0 open, 1 in progress, 2 blocked, 3 resolved, 4 closed.'
+        comment:
+          type: string
+          description: Comment describing the change. Required when new state is 2 (blocked).
+    IncidentAssign:
+      type: object
+      required:
+        - userId
+      properties:
+        userId:
+          type: integer
+          description: ID of user to assign the incident to, or 0 to clear the assignment.
+    IncidentCommentCreate:
+      type: object
+      required:
+        - text
+      properties:
+        text:
+          type: string
+          description: Comment text (cannot be empty).
+    IncidentAlarmLink:
+      type: object
+      required:
+        - alarmId
+      properties:
+        alarmId:
+          type: integer
+          description: ID of alarm to link to the incident.
     User:
       type: object
       description: User account


### PR DESCRIPTION
Incidents are fully implemented in server core, NXCP protocol, Java client and nxmc,
but have no REST API surface — `openapi.yaml` mentions them only in EPP rule fields
and the AI chat binding. This adds that surface so REST clients can work with incidents
that EPP rules (`RF_CREATE_INCIDENT`) already create.

Implemented in new `src/server/webapi/incidents.cpp` on top of the existing
`NXCORE_EXPORTABLE` functions in `nms_incident.h` — no NXCP construction in webapi
sources, per the module guidelines.

## Routes

| Method | Path | Access |
|---|---|---|
| GET | `v1/incidents` | `OBJECT_ACCESS_READ` (silent filter) |
| POST | `v1/incidents` | `OBJECT_ACCESS_MANAGE_INCIDENTS` |
| GET / PUT | `v1/incidents/:incident-id` | READ / MANAGE_INCIDENTS |
| POST | `v1/incidents/:incident-id/state` | MANAGE_INCIDENTS |
| POST | `v1/incidents/:incident-id/assign` | MANAGE_INCIDENTS |
| POST | `v1/incidents/:incident-id/comments` | MANAGE_INCIDENTS |
| POST | `v1/incidents/:incident-id/alarms` | MANAGE_INCIDENTS |
| DELETE | `v1/incidents/:incident-id/alarms/:alarm-id` | MANAGE_INCIDENTS |
| GET | `v1/incidents/:incident-id/activity` | READ |

List filters: `objectId`, `state` (comma-separated), `from`, `to`, `limit` (default 1000, max 10000).

## Core changes

Three gaps prevented a straight passthrough; all three were closed in core rather than
worked around in handlers:

- **`GetIncidentSummariesAsJson()`** lists from the database. The existing path walks
  `s_incidents`, populated at startup from `state<4`, so closed incidents could not be
  listed at all — only fetched by id. Rows are ACL-filtered per source object, as
  `SendIncidentsToClient` does.
- **`Incident::toJson()`** now emits `json_time_string()` timestamps instead of raw epoch
  integers, resolves user names via `ResolveUserId()` the way `alarms.cpp` resolves
  `ackByUserName`, adds `sourceObjectName` and `alarmCount`, and can embed comments.
  User id 0 is reported as `null`, since incidents use it as the "unassigned" /
  "created by EPP rule" sentinel rather than a reference to the built-in `system` account.
- **`GetIncidentCommentsAsJson()`**, **`GetIncidentActivityAsJson()`** and
  **`IncidentComment::toJson()`** added — no JSON serializers existed for these.

`LoadIncidentById()` was extracted from `GetIncident()` so handlers can reach closed
incidents (not kept in memory); the NXCP path now calls it instead of duplicating the SQL.

## Notes for review

- **Closed-state check lives in the handlers.** The core mutators resolve through the
  in-memory index only, so on an incident closed before a restart they return
  `RCC_INVALID_INCIDENT_ID` → a misleading 404. Handlers check the loaded incident's
  state and return 409 instead.
- **`DELETE .../alarms/{id}` answers 200 with the updated incident, not 204.** Deliberate:
  every incident mutation returns the updated detail so clients never need a follow-up GET,
  and making unlink alone return 204 would be inconsistent within the group. Happy to
  change it to 204 if you'd rather keep the DELETE convention.
- **First commit is an independent bug fix** and is a candidate for backporting to stable:
  `updateInDatabase()` never wrote the `title` column, so incident renames were lost on
  server restart; `linkAlarm`/`unlinkAlarm` bumped `m_lastChangeTime` without persisting it.
  The SQL-backed list depends on both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incident management APIs for listing, creating, viewing, and updating incidents.
  * Added incident state changes, assignment, comments, activity history, and alarm linking or unlinking.
  * Incident responses now include names, alarm counts, timestamps, optional comments, and AI-generated comment indicators.
  * Added support for retrieving and viewing closed incidents.
  * Incident updates now reflect alarm linking and unlinking activity.
* **Documentation**
  * Documented incident management endpoints, request formats, responses, validation, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->