### PR TITLE
Single-use authentication tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,6 +298,7 @@ compile_commands.json
 /tests/integration/.settings/
 /tests/suite/netxms-test-suite
 /tests/ha/ha-node-sim
+/tests/test-authtokens/test-authtokens
 /tests/test-libethernetip/test-libethernetip
 /tests/test-libnetxms/test-libnetxms
 /tests/test-libnxdb/test-libnxdb

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -170,7 +170,7 @@ TESTS_DIRS = \
     tests/agent/unit/entsoe \
     tests/agent/unit/openmeteo
 ifeq ($(BUILD_SERVER),1)
-TESTS_DIRS += tests/test-libnxsrv
+TESTS_DIRS += tests/test-libnxsrv tests/test-authtokens
 endif
 endif
 
@@ -272,6 +272,9 @@ $(TESTS_DIRS): $(LIBS)
 
 # test-libnxsrv links libnxsrv, which belongs to the server tier
 tests/test-libnxsrv: src/server/libnxsrv
+
+# test-authtokens compiles server core sources and links libnxsrv
+tests/test-authtokens: src/server/libnxsrv
 
 # ATM subsystem links the agent, server and core import libraries, so it is
 # built after every in-tree tier it depends on.

--- a/configure.ac
+++ b/configure.ac
@@ -1043,7 +1043,7 @@ AC_ARG_WITH(dist,
 [AS_HELP_STRING(--with-dist,for maintainers only)],
 	DB_DRIVERS="mysql mariadb pgsql odbc mssql sqlite oracle db2 informix"
 	MODULES="jansson libargon2 java-common libnetxms libnxjava install sqlite snmp ethernetip libnxsl libnxmb libnxlp libnxnetconf db client server agent nxscript nxcproxy mobile-agent"
-	TEST_MODULES="agent ha test-libethernetip test-libnxsl test-libnxnetconf test-libnxsnmp test-libnxsrv test-ncd-webhook"
+	TEST_MODULES="agent ha test-authtokens test-libethernetip test-libnxsl test-libnxnetconf test-libnxsnmp test-libnxsrv test-ncd-webhook"
 	AGENT_UNIT_TESTS="entsoe openmeteo linux-cpu-usage-collector"
 	TOOLS="nxlptest"
 	SUBAGENT_DIRS="linux ds18x20 fbdev freebsd openbsd mqtt mysql pgsql netbsd sunos aix informix oracle prometheus lmsensors darwin rpi java jmx opcua ubntlw db2 tuxedo mongodb netconf ssh vmgr xen asterisk redis lldpd"
@@ -1292,7 +1292,7 @@ if test $? = 0; then
 
 	BUILD_SERVER="yes"
 	MODULES="$MODULES libnxsl server nxscript"
-	TEST_MODULES="$TEST_MODULES ha test-libnxsl test-libnxsrv test-ncd-webhook"
+	TEST_MODULES="$TEST_MODULES ha test-authtokens test-libnxsl test-libnxsrv test-ncd-webhook"
 	TOP_LEVEL_MODULES="$TOP_LEVEL_MODULES sql images"
 	CONTRIB_MODULES="$CONTRIB_MODULES mibs backgrounds music oui templates"
 	NCDRV_MODULES="$NCDRV_MODULES nxagent"
@@ -4815,6 +4815,7 @@ AC_CONFIG_FILES([
 	tests/include/Makefile
 	tests/suite/Makefile
 	tests/ha/Makefile
+	tests/test-authtokens/Makefile
 	tests/test-libethernetip/Makefile
 	tests/test-libnetxms/Makefile
 	tests/test-libnxdb/Makefile

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,11 +1,29 @@
 # Copyright (C) 2004 NetXMS Team <bugs@netxms.org>
-#  
+#
 # This file is free software; as a special exception the author gives
-# unlimited permission to copy and/or distribute it, with or without 
+# unlimited permission to copy and/or distribute it, with or without
 # modifications, as long as this notice is preserved.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 SUBDIRS = internal
+
+EXTRA_DIST = \
+	AGENT_EXTENSION_PROTOCOL.md \
+	Chat_Bots_Design.md \
+	CPP_DEVELOPER_GUIDE.md \
+	DBPasswordCommand.md \
+	doxygen.md \
+	ENTSOE_Integration_Design.md \
+	HA_Design.md \
+	NC_Drivers_Server_Subtree.md \
+	netxms-ldap-integration-guide.md \
+	Single_Use_Authentication_Tokens.md \
+	Traffic_Observer_Admin_Guide.md \
+	Traffic_Observer_Example_Template.md \
+	Traffic_Observer_Integration_Design.md \
+	Traffic_Observer_Phase0_Validation.md \
+	VaultIntegration.md \
+	Windows_MinGW_Build_System_Design.md

--- a/doc/Single_Use_Authentication_Tokens.md
+++ b/doc/Single_Use_Authentication_Tokens.md
@@ -1,0 +1,163 @@
+---
+title: "Single-Use Authentication Tokens"
+author: [NetXMS Team]
+date: "2026-08-02"
+lang: "en"
+...
+
+# Single-Use Authentication Tokens
+
+This document explains what a single-use authentication token is, why the NetXMS server treats it
+differently from every other token it issues, and what an administrator should expect from one in
+operation. It is not a procedure — the REST field and the NXCP flag that request such a token are
+described in the WebAPI schema and the Java client API.
+
+## Context
+
+A NetXMS authentication token is a bearer credential: whoever holds the value can act as the user it
+was issued for, until it expires or is revoked. The server issues four kinds:
+
+- **Ephemeral** tokens live in server memory only. The management console requests one after every
+  successful login so that it can reconnect without prompting for the password again.
+- **Persistent** tokens are stored in the `auth_tokens` table and survive a server restart. These are
+  the long-lived API credentials an administrator creates for an integration.
+- **Service** tokens are issued internally, currently only by the reporting subsystem.
+- **Single-use** tokens live in memory only and are destroyed by the login that spends them. They
+  exist to hand a session from one process to another, and they are what the rest of this document is
+  about.
+
+The first three share one property: they can be presented as many times as the holder likes for as
+long as they remain valid. For a credential that only ever travels inside a TLS session, that is
+reasonable. It stops being reasonable the moment the value has to leave the process that received it.
+
+The concrete case is `nxmc-launcher`. It logs in with the user's credentials, asks the server for a
+short-lived token, closes its own connection, and starts the console as a separate process with the
+token on the command line. That command line is readable by any local user running `ps`. The token
+cannot be made instantaneous — the console needs time to start, so the value has to stay valid across
+the launch window, which today means it stays *replayable* for that whole window too. Anybody who
+looked at the process list during those ten minutes holds a working credential for the rest of them.
+
+## What single-use changes
+
+A single-use token is spent exactly once, and the act of spending destroys it.
+
+The interesting part is not that the token is deleted — it is *where* it can be deleted. The server
+has several places that accept a token: an NXCP login, a REST request carrying a bearer header, and
+the anonymous object access endpoint. Only one of them, the NXCP login, is allowed to spend a
+single-use token. Everywhere else, presenting one is simply an authentication failure: the REST layer
+answers 401 and the token is left untouched, still spendable by the login it was actually meant for.
+
+That asymmetry is the whole design. It means a stolen value cannot be burned through some unrelated
+API call, and it cannot be used to do anything the legitimate client was not already going to do.
+What is left is a race to the login, and the server does not take sides in it: whichever login
+claims the token first gets it, and the other one is refused. That is still the outcome we want,
+because the race is both bounded and visible — if a stolen value wins it, the console's own login
+fails where the user can see it, instead of the token staying quietly replayable for the rest of its
+lifetime. The exposure window closes on consumption instead of on expiry, which is why the token's
+TTL can stay comfortably long without weakening anything.
+
+Because destruction is the point, the server is deliberately unforgiving about it. Once a login has
+claimed the token, the token is gone even if that login then fails — a disabled account, an intruder
+lockout, anything. Letting a failed attempt hand the credential back would turn a one-shot token into
+a retry oracle, which is precisely the property we were trying to remove. The trade-off is real: a
+user whose account is locked out will need a fresh token, not a second try with the old one. We
+consider that the correct side to err on for a credential whose entire purpose is to be unusable
+twice.
+
+The same rule applies to a login that is not finished yet. Consumption happens during authentication,
+before two-factor authentication is evaluated, so a user with 2FA configured spends the token and is
+then still asked for a second factor. Abandoning or failing that challenge does not give the token
+back — the client must request a new one. The alternative, holding the token until the login
+completes, would keep a spendable credential alive for the whole duration of a challenge the attacker
+could be racing, which is the exposure the single-use property exists to close.
+
+Two smaller behaviours follow from treating these tokens as handoffs rather than as fresh logins:
+
+- A login that spends a single-use token does **not** close the user's other sessions, even if the
+  account has `UF_CLOSE_OTHER_SESSIONS` set. A handoff is the same person opening one more client,
+  not a new login that should displace what is already running. In the launcher flow this is
+  defensive more than load-bearing — the launcher's own credential login has already done any closing
+  by then — but it matters when the issuer is something that stays connected, such as a WebAPI
+  integration.
+- Issuance is always written to the audit log, including when a user issues one for themselves. The
+  server normally skips that audit entry for self-issued ephemeral tokens because the console
+  requests them constantly and the noise would drown the log. A single-use token is a deliberate
+  handoff, not background chatter, so it is always recorded.
+
+## Memory only, and what that costs
+
+Single-use tokens exist in server memory and nowhere else. They are never written to `auth_tokens`,
+and asking for one that is both persistent and single-use is rejected outright — over NXCP with
+`RCC_INVALID_ARGUMENT`, over REST with HTTP 400. Note that the REST `persistent` field defaults to
+**true**, so a request body containing only `singleUse` is rejected as well; it has to say
+`"persistent": false` explicitly. A zero validity time is rejected on both surfaces too — such a
+token expires at the instant it is issued. That rule is not specific to single-use tokens: it now
+applies to every type, and a request that previously returned an already-expired token fails with
+`RCC_INVALID_ARGUMENT` or HTTP 400 instead. A single-use token in particular is worth nothing unless
+it stays valid across the handoff window.
+
+The practical consequence for an administrator is that **a single-use token does not survive a server
+restart**. It also does not exist on any other node of an HA pair. If the server goes down between
+issuance and the login that was supposed to spend it, the token is simply gone and a new one must be
+requested. For a credential that lives for seconds or minutes on its way from one process to another,
+that is not much of a loss.
+
+We could have stored them, but the cost is out of proportion to the benefit: a new column on
+`auth_tokens`, an `nxdbmgr` upgrade procedure, and propagation of that schema change across every
+supported release branch — all to persist something designed to be consumed within the next minute.
+Unclaimed tokens are cleaned up by the same expiration sweep that handles ordinary ephemeral tokens,
+so nothing special is needed to reclaim the memory either.
+
+## Observing them
+
+In the server console, `show authtokens` lists live tokens with a `Type` column naming the type:
+`ephemeral`, `persistent`, `service` or `single-use`. A single-use token disappears from the listing
+the moment it is consumed — which is the most direct way to confirm a handoff actually happened.
+(The `Token` column reads `unavailable` when the server does not hold the clear-text value, which is
+the case for persistent tokens read back from the database.)
+
+Until it is spent, a single-use token is also readable in full through the token listings —
+`GET /v1/users/{id}/tokens` over REST and `CMD_GET_AUTH_TOKENS` over NXCP — by the owning user and by
+anyone holding `MANAGE_USERS`. This is not specific to single-use: any token whose clear-text value
+the server still holds in memory is returned there. Being single-use bounds the replay of a *leaked*
+value; it does not restrict who may read that value from the server while the token is still live.
+
+Everything else the feature does is logged under the existing `auth` debug tag. Level 4 covers the
+rejections an administrator would want to see: a single-use token presented somewhere other than the
+login entry point, and an attempt to reuse one that has already been claimed. Level 5 records the
+successful consumption.
+
+## Where this fits
+
+Single-use is a token *type*, not a property layered on top of one. `AuthenticationTokenType` has
+four values — `EPHEMERAL`, `PERSISTENT`, `SERVICE` and `SINGLE_USE` — and they are mutually
+exclusive. One field answers both "where does this token live and how does the login behave" and
+"how many times can it be spent".
+
+An earlier iteration modelled single-use as a boolean orthogonal to the type. That advertised a
+freedom of combination which did not exist: persistent + single-use was silently corrected back to
+persistent by the descriptor constructor, and service + single-use was a combination nothing ever
+asked for. Making the invalid pairings unrepresentable is the point of the current model. The
+composition with `SERVICE` is deliberately gone; if a service-like handoff is ever needed it belongs
+on `SINGLE_USE` as behaviour, not as a resurrected flag.
+
+The type is a server-side concept. Neither protocol carries it: NXCP and REST both represent a token
+as a set of booleans, which the server derives from the type when it serializes a descriptor and maps
+back to a type when it accepts an issuance request.
+
+There is deliberately no REST equivalent of the login spend point — a single-use token cannot be
+exchanged over HTTP for a session token. Such a route would give REST clients the same handoff
+capability and would be defensible over TLS, but it adds an authentication-critical endpoint that
+nothing needs yet. It is worth revisiting if a REST-only integration ever wants the handoff.
+
+Finally, note that the launcher does not yet ask for single-use tokens. `nxmc-launcher` lives in its
+own repository and has to opt in; until it does, its handoff token behaves exactly as it always has.
+The request field is a boolean that defaults to false everywhere, so no existing client changes
+behaviour by upgrading the server.
+
+## Further reading
+
+- WebAPI schema: `singleUse` on `AuthenticationTokenCreateInput` and `AuthenticationToken` in
+  `src/server/webapi/openapi.yaml`
+- Java client: `NXCSession.requestAuthenticationToken()` and `AuthenticationToken.isSingleUse()`
+- Debug tags: `doc/internal/debug_tags.txt`

--- a/docs/plans/completed/20260731-single-use-auth-tokens.md
+++ b/docs/plans/completed/20260731-single-use-auth-tokens.md
@@ -1,0 +1,701 @@
+# Single-Use Authentication Tokens
+
+> **Superseded by** [20260804-single-use-token-type.md](20260804-single-use-token-type.md). This
+> plan modelled single-use as a boolean orthogonal to `AuthenticationTokenType`; the shipped code
+> has `SINGLE_USE` as a fourth value of that enum. Two consequences for the text below: references
+> to a `U` display flag in `show authtokens` are obsolete — the listing has a `Type` column naming
+> the type — and the composition of single-use with `SERVICE` no longer exists.
+
+## Overview
+
+Add single-use (one-shot) authentication tokens to the NetXMS server. A single-use token is a
+bootstrap credential: it authenticates exactly one login and is destroyed in the process.
+
+Primary use case is the existing `nxmc-launcher` (separate repository). Today the launcher logs in
+with the user's credentials, requests an ephemeral token valid for 600 seconds, **closes its own
+connection**, and spawns `java -jar <cached build> -server=<address> -token=<token> -auto`. This
+change lets that token be single-use.
+
+**The token must have a non-zero TTL, and that is precisely what makes single-use necessary.** nxmc
+takes time to start, so the token cannot be instantaneous — it has to stay valid across the launch.
+During that window the value sits in the new process's command line, where any local user running
+`ps` can read it. Single-use bounds that exposure: the moment nxmc completes its login the observed
+value is worthless. The current 600-second ephemeral token stays replayable for its entire lifetime
+by anyone who saw it.
+
+Single-use is modelled as a property **orthogonal** to the existing `AuthenticationTokenType` enum
+rather than as a fourth enum value, so it composes freely with EPHEMERAL and SERVICE semantics.
+The feature is memory-only: no schema change, no `nxdbmgr` upgrade procedure, and no cross-branch
+DB backport.
+
+Key benefits:
+
+- A handoff credential that cannot be replayed, even though it is necessarily observable on the
+  command line during the launch window.
+- A single designated spend point, so a stolen token cannot be burned through some unrelated API.
+- No database or schema impact whatsoever.
+
+## Context (from discovery)
+
+All line numbers below were verified against HEAD `24539db517` with a clean working tree.
+
+Files/components involved:
+
+- `src/server/include/auth-token.h` — `AuthenticationTokenType` enum (EPHEMERAL / PERSISTENT /
+  SERVICE) and `AuthenticationTokenDescriptor` with `fillMessage()` (fields at `baseId+0` ..
+  `baseId+7`, stride 10 — `baseId+8` is free) and `toJson()`.
+- `src/server/core/authtokens.cpp` — `IssueAuthenticationToken()` (line 128),
+  `ValidateAuthenticationToken()` (line 269), the `validFor` extension block (lines 299-307),
+  `CheckUserAuthenticationTokens()` expiry sweep (line 321), `ShowAuthenticationTokens()` console
+  dump (line 389, prints `P`/`S`/`V` at lines 397-400), and the static
+  `SynchronizedSharedHashMap<UserAuthenticationTokenHash, AuthenticationTokenDescriptor> s_tokens`
+  (line 95).
+- `src/server/include/nms_users.h:617-622` — declarations of both functions.
+- `src/server/core/session.cpp` — `authenticateUserByToken()` (line 2560) with its validator call
+  (2571) and the service-token `closeOtherSessions = false` line (2581); the 300s ephemeral
+  reconnect token issued after every successful login (3016); `issueAuthToken()` /
+  CMD_REQUEST_AUTH_TOKEN handler (3041); the deliberate audit skip for self-issued ephemeral tokens
+  (3057-3059).
+- `src/server/core/webapi_router.cpp:306` — REST token validation, executed on every authenticated
+  request; returns 401 on failure (lines 307-313). Passes `AUTH_TOKEN_VALIDITY_TIME` (14400s) as
+  `validFor`.
+- `src/server/webapi/users.cpp:334` — `H_UserTokenCreate`, POST `/v1/users/:user-id/tokens`. Note
+  its `persistent` parameter defaults to **true** (line 360).
+- `include/nms_cscp.h` — VID constants. `VID_PERSISTENT` is 596; `VID_MARKDOWN` = 1023 (line 1792)
+  is the top of the base range, so **1024 is free**. `NXCPCodes.java` is contiguous through 1023
+  (line 1602) — there are no gaps to fill.
+- `src/client/java/netxms-client/.../NXCSession.java:2936` —
+  `requestAuthenticationToken(boolean, int, String, int)`;
+  `org.netxms.client.users.AuthenticationToken` reads `baseId+0` .. `baseId+6` only.
+
+**All three existing `ValidateAuthenticationToken()` call sites**, and what each becomes:
+
+| Site | After this change |
+|------|-------------------|
+| `session.cpp:2571` (`authenticateUserByToken`) | switches to `ConsumeAuthenticationToken()` — **the sole spend point** |
+| `session.cpp:4203` (`enableAnonymousObjectAccess`) | validation call unchanged; rejects single-use tokens. Its token is issued PERSISTENT (line 4217) so it can never be single-use anyway. The surrounding handler did change — see "Changes that landed beyond the original plan" |
+| `webapi_router.cpp:306` | unchanged; rejects single-use tokens → 401, **zero changes needed** |
+
+Related patterns found:
+
+- `SERVICE` tokens already suppress `closeOtherSessions` (session.cpp:2581) — the mechanism this
+  feature reuses.
+- `VolatileCounter` + `InterlockedIncrement` is the established atomic-counter idiom.
+  `SynchronizedSharedHashMap::remove()` returns `void` (`include/nms_util.h:3741-3746`) and there is
+  no atomic take-and-report primitive, so an explicit claim counter is the minimal correct
+  mechanism, not gold-plating.
+
+Dependencies identified:
+
+- The `tests/ha` precedent cited during design is **not** a usable model: `halease.cpp` includes only
+  `<halease.h>` and is self-contained, and `tests/ha` has no `Makefile.w32` at all (the HA harness is
+  deliberately POSIX-only — see `Makefile.w32:155-157`). Use `tests/test-libnxsrv/` as the template
+  for both the autotools and Windows wiring.
+- `authtokens.cpp` includes `nxcore.h`, `nms_users.h`, and `netxms-webapi.h`. The latter includes
+  `<microhttpd.h>` (`netxms-webapi.h:29`), so `@MICROHTTPD_CPPFLAGS@` is required to compile it.
+- Standalone compilation confirms the server-core link surface is exactly **four** symbols:
+  `ConfigReadULong`, `CreateUniqueId`, `ExecuteQueryOnObject`, `ResolveUserId`. Note
+  `GetAuthTokenMaxLifetime()` is `static inline` (`netxms-webapi.h:48`) and cannot be stubbed — it
+  inlines a call to `ConfigReadULong`, which is the symbol to stub. `ServerConsole::printf` is
+  `LIBNXSRV_EXPORTABLE` and defined in `src/server/libnxsrv/console.cpp:44` — link `libnxsrv`, do not
+  stub it.
+- There are currently **no tests of any kind** covering authentication tokens.
+
+## Development Approach
+
+- **testing approach**: Regular (code first, then tests) — the C++ unit-test harness for
+  `authtokens.cpp` does not exist yet and cannot be written before the fields it exercises exist.
+- complete each task fully before moving to the next
+- make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  - Tasks 1 and 2 legitimately defer their tests to Task 3, which builds the harness; this is the
+    documented partial-implementation exception and is called out explicitly in those tasks
+  - tests cover both success and error scenarios
+- **CRITICAL: all tests must pass before starting next task** — no exceptions
+- **CRITICAL: update this plan file when scope changes during implementation**
+- run tests after each change
+- maintain backward compatibility: `IssueAuthenticationToken()` gains only a trailing defaulted
+  parameter, and `ValidateAuthenticationToken()` keeps its existing signature, so all ten existing
+  call sites compile unchanged
+
+## Testing Strategy
+
+- **unit tests**: new C++ test binary `tests/test-authtokens`, covering the two-function contract
+  and the atomic claim. Built only under `--with-tests`, wired through `@TEST_MODULES@`.
+- **integration tests**: Java/Maven test in `tests/integration/` against a running server, covering
+  the real end-to-end NXCP path — issue, spend, and confirm the second use fails.
+- **e2e tests**: not applicable; the nxmc UI is explicitly out of scope.
+- Manual verification of the WebAPI surface via `curl` (see Post-Completion), since REST handlers
+  have no unit-test harness in this tree.
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+- update plan if implementation deviates from original scope
+- keep plan in sync with actual work done
+
+## Solution Overview
+
+**The central rule — one designated spend point, expressed as a separate function.**
+
+A single-use token is spent at exactly one place in the codebase. Rather than encode that with a
+boolean parameter on the existing validator, the two operations get two functions:
+
+- `ValidateAuthenticationToken()` — unchanged signature. **Never** consumes, and **always** rejects
+  a single-use token. Every existing caller keeps calling this and is correct by default.
+- `ConsumeAuthenticationToken()` — new. Validates the token and, if it is single-use, consumes it.
+  Called from exactly one place: `authenticateUserByToken()`.
+
+Both share one internal static helper so the expiry and max-lifetime logic is not duplicated.
+
+Why a separate function rather than a `bool consume` flag: the requirement is a *single entry
+point*, and a function name states that where a defaulted boolean does not. It also removes the
+failure mode where a future caller passes `true` without meaning to, and it keeps the common
+signature untouched.
+
+**`ConsumeAuthenticationToken()` must NOT be marked `NXCORE_EXPORTABLE`.** Its only caller,
+`session.cpp`, sits in the same shared library as `authtokens.cpp` (both are in
+`libnxcore_la_SOURCES` — `src/server/core/Makefile.am:11,34`), so an undecorated symbol resolves
+intra-library on every platform. Exporting it would publish the spend primitive to every module that
+includes `nms_users.h` — `webapi/users.cpp`, `webapi/grafana.cpp`, `webapi/2fa.cpp`,
+`webapi/alarms.cpp`, `webapi/object_collections.cpp`, and others — which is precisely the surface
+this design exists to close. Leaving the decoration off makes the single-entry-point rule structural
+rather than advisory: the linker enforces it, not a comment.
+
+Why the spend point is NXCP login and not "wherever the token is first presented": a stolen token
+observed in `ps` should not be burnable through some unrelated REST call. Restricting the spend to
+login means the only thing an attacker can do with the token is exactly the thing the legitimate
+client does — and they lose the race the moment nxmc logs in.
+
+**Why an orthogonal flag, not a fourth enum value.** Note that as scoped, single-use does not
+actually compose with anything: `PERSISTENT + singleUse` is rejected at both issuance surfaces, and
+`SERVICE` tokens are only ever issued from two hardcoded internal sites (`reporting.cpp:375` and
+`:424`) that this plan does not touch — so every single-use token this change can produce is
+EPHEMERAL. The argument is therefore not about composition. It is that `AuthenticationTokenType`
+answers "where does this token live and how does it behave on login", while single-use answers "how
+many times can it be spent" — two independent questions. A fourth enum value would force
+`type == SINGLE_USE` special-casing at every site that currently tests for `PERSISTENT` or
+`SERVICE`, and would have no honest value to report in the `DB_RESULT` constructor, which
+reconstructs persistent tokens only. A separate bool keeps both questions answerable independently
+and leaves the door open if a future caller does want `SERVICE + singleUse`.
+
+**Why memory-only.** A persistent single-use token would require a column on `auth_tokens`, an
+`nxdbmgr` upgrade procedure, and propagation across release branches — a large cost for a
+credential meant to live for seconds. `PERSISTENT + singleUse` is rejected at the issuance surfaces.
+
+**Why single-use suppresses `closeOtherSessions`.** `UF_CLOSE_OTHER_SESSIONS` is a per-user account
+flag. This is **defensive rather than load-bearing** in the launcher flow: the launcher closes its
+own connection before spawning nxmc, and its own credential login has already closed the user's
+other sessions by then, so there is usually nothing left for the token login to close. It matters
+when a single-use token is issued by something that stays connected — a WebAPI integration, or a
+future launcher that keeps its session — where a handoff would otherwise tear down the issuer. A
+handoff token is the same user starting one more client, not a fresh login that should displace
+everything else.
+
+**Why a claimed token is burnt even if login then fails.** If the token is claimed and
+`AuthenticateUser()` subsequently fails (disabled account, intruder lockout), the token is already
+gone and cannot be retried. This is deliberate: a one-shot credential that survives a failed
+attempt is a retry oracle.
+
+## Technical Details
+
+Descriptor additions (`AuthenticationTokenDescriptor`):
+
+```cpp
+bool singleUse;            // token is destroyed when consumed
+VolatileCounter claimed;   // atomic claim guard, 0 until consumed
+```
+
+Function signatures:
+
+```cpp
+// Trailing defaulted parameter - all 7 existing call sites unaffected
+shared_ptr<AuthenticationTokenDescriptor> NXCORE_EXPORTABLE IssueAuthenticationToken(
+   uint32_t userId, uint32_t validFor, AuthenticationTokenType type = AuthenticationTokenType::EPHEMERAL,
+   const wchar_t *description = nullptr, uint32_t maxLifetime = 0, bool singleUse = false);
+
+// UNCHANGED signature. Now additionally rejects single-use tokens.
+bool NXCORE_EXPORTABLE ValidateAuthenticationToken(
+   const UserAuthenticationToken& token, uint32_t *userId, bool *serviceToken = nullptr,
+   uint32_t validFor = 0, time_t *expiresAt = nullptr, time_t *maxExpiresAt = nullptr);
+
+// NEW. The single spend point. Validates any token; consumes it if single-use.
+// Deliberately NOT NXCORE_EXPORTABLE - see Solution Overview.
+bool ConsumeAuthenticationToken(
+   const UserAuthenticationToken& token, uint32_t *userId, bool *serviceToken = nullptr,
+   bool *singleUseToken = nullptr);
+```
+
+The `singleUseToken` out-parameter is **required**, not optional polish: on a successful consume the
+descriptor is removed from `s_tokens`, so the caller cannot look it up afterwards to discover what
+it was. Without it, `authenticateUserByToken()` has no way to suppress `closeOtherSessions`. It
+mirrors the existing `serviceToken` out-parameter.
+
+**It must be written unconditionally on every success path**, exactly as `serviceToken` is at
+`authtokens.cpp:309-310` — not only inside the single-use branch. If it were assigned only when the
+token is single-use, the caller's local would be read uninitialised on every ordinary reconnect
+login, and `closeOtherSessions` would be suppressed at random on the hottest login path in the
+product. The caller initialises its local to `false` as well, so neither side depends on the other
+getting it right.
+
+`ConsumeAuthenticationToken()` deliberately takes no `validFor`, `expiresAt`, or `maxExpiresAt`.
+This is behaviour-preserving, not a simplification: the call being replaced
+(`session.cpp:2571`) passes only three arguments today, so `validFor` is already 0 and the extension
+block at `authtokens.cpp:299-307` never executes at this call site. Ordinary reconnect tokens are
+unaffected.
+
+Shared internal helper, holding the logic currently in `ValidateAuthenticationToken()`
+(authtokens.cpp:269-316), with one new branch:
+
+| Condition | Outcome |
+|-----------|---------|
+| token absent from `s_tokens` | FAIL (existing behaviour) |
+| past `maxExpirationTime` or `expirationTime` | FAIL, remove, delete from DB if persistent (existing behaviour) |
+| `singleUse && !consuming` | FAIL; level-4 debug line noting a single-use token was presented outside the login entry point |
+| `singleUse && consuming` | `InterlockedIncrement(&claimed)`; if result != 1 another thread won the race → FAIL. Otherwise remove from `s_tokens` and proceed |
+| `!singleUse` | proceed; `validFor` extension applies as today |
+
+Two things about placement and the branches are load-bearing:
+
+- **The single-use branches must sit before the `validFor` extension block (lines 299-307).**
+  `webapi_router.cpp:306` passes `AUTH_TOKEN_VALIDITY_TIME` (14400s). If the rejection landed after
+  the extension, every REST replay of a stolen one-shot would silently push its expiry out by four
+  hours (capped by `maxExpirationTime`). The token still could not be spent, but the
+  bounded-exposure property in the Overview would be substantially weakened.
+- **The losing thread must not call `remove()`.** Only the caller observing an increment result of 1
+  removes the entry.
+
+Wire format: `fillMessage()` writes the flag at `baseId + 8` (`+7` is the existing service flag,
+stride is 10). `toJson()` adds a `"singleUse"` boolean.
+
+Processing flow for the launcher handoff (steps 1-4 already exist today):
+
+1. Launcher authenticates to the server with the user's credentials.
+2. Launcher requests a token — **this call gains `singleUse = true`** — with a `validFor` long enough
+   to cover nxmc startup (the launcher currently uses 600s).
+3. Server issues an EPHEMERAL single-use token and returns the clear-text value in the response.
+   (The value also remains readable through a token listing for as long as the descriptor is in
+   memory — it is the descriptor's removal on consumption, not the response, that ends exposure.)
+4. Launcher closes its own connection and spawns nxmc with `-token=<token>`. The value is
+   observable in the process command line for the duration of the startup window.
+5. nxmc logs in over NXCP; `authenticateUserByToken()` calls `ConsumeAuthenticationToken()`.
+6. Token is atomically claimed, removed from `s_tokens`, and `closeOtherSessions` is forced false.
+7. Session receives its normal 300s ephemeral reconnect token (session.cpp:3016) as usual.
+8. Any replay of the still-visible value fails — the descriptor no longer exists. The exposure
+   window closes at step 5 rather than at token expiry.
+
+Note that step 2 is a change in `nxmc-launcher`, a **separate repository**, and is not part of this
+plan. See Post-Completion.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): all code, build wiring, tests, and documentation
+  changes inside this repository.
+- **Post-Completion** (no checkboxes): the `nxmc-launcher` change, GitHub issue creation, manual REST
+  verification, and follow-up observations recorded but deliberately not fixed here.
+
+## Implementation Steps
+
+### Task 1: Add single-use fields to the token descriptor
+
+**Files:**
+- Modify: `src/server/include/auth-token.h`
+
+- [x] add `bool singleUse` and `VolatileCounter claimed` members to `AuthenticationTokenDescriptor`
+- [x] add a trailing `bool singleUse = false` parameter to the issuing constructor; initialise
+      `claimed` to 0
+- [x] in the `DB_RESULT` constructor, always set `singleUse = false` and `claimed = 0` — persistent
+      tokens are never single-use
+- [x] extend `fillMessage()` to write the flag at `baseId + 8` (leaving the service flag at
+      `baseId + 7` untouched)
+- [x] extend `toJson()` with a `"singleUse"` boolean
+- [x] tests deferred to Task 3, which builds the harness these fields are exercised by — no test
+      infrastructure for `authtokens.cpp` exists yet
+- [x] verify the tree still compiles: `make -C src/server/core`
+
+### Task 2: Split validate and consume, and add single-use issuance
+
+**Files:**
+- Modify: `src/server/include/nms_users.h`
+- Modify: `src/server/core/authtokens.cpp`
+
+- [x] add trailing `bool singleUse = false` to the `IssueAuthenticationToken()` declaration
+      (`nms_users.h:617-618`) and definition (`authtokens.cpp:128`); pass through to the descriptor
+- [x] extract the body of `ValidateAuthenticationToken()` (`authtokens.cpp:269-316`) into a file-static
+      helper taking a `bool consuming` argument, the existing out-parameters, **and the new
+      `bool *singleUseToken`**
+- [x] have the helper write `*singleUseToken` (when non-null) **unconditionally on every success
+      path**, mirroring how `serviceToken` is handled at `authtokens.cpp:309-310` — assigning it only
+      inside the single-use branch would leave the caller reading an uninitialised value on every
+      ordinary reconnect login
+- [x] add the two single-use branches from Technical Details to that helper, positioned after the
+      expiry/max-lifetime checks (ending line 298) and **before** the `validFor` extension block
+      (lines 299-307)
+- [x] use `InterlockedIncrement(&descriptor->claimed)` for the claim; only the caller observing a
+      result of 1 wins, and **only that caller** calls `s_tokens.remove()`
+- [x] add a comment at the claim site recording that a claimed-then-failed login deliberately burns
+      the token (fail-closed; a survivable one-shot is a retry oracle)
+- [x] keep `ValidateAuthenticationToken()`'s signature exactly as it is; reimplement it as a call to
+      the helper with `consuming = false`
+- [x] add `ConsumeAuthenticationToken()` in `nms_users.h` next to the existing declarations, as a
+      call to the helper with `consuming = true`, exposing the `singleUseToken` out-parameter
+- [x] declare it **without** `NXCORE_EXPORTABLE`. Its only caller is in the same shared library
+      (`src/server/core/Makefile.am:11,34`), so it links fine undecorated; exporting it would publish
+      the spend primitive to the five webapi sources that include `nms_users.h` and defeat the
+      single-entry-point rule
+- [x] document in a comment above both functions that `ConsumeAuthenticationToken()` is the single
+      designated spend point, and that the missing export decoration is deliberate so a future
+      maintainer does not "fix" it
+- [x] add a level-4 debug line for the `singleUse && !consuming` rejection, using
+      `token.toMaskedString()` as the surrounding code does
+- [x] add a `U` flag character to `ShowAuthenticationTokens()` (`authtokens.cpp:397-400`) — the
+      format is `%c%c%c` followed by three spaces inside a 7-char column whose separator rule is at
+      line 392, so drop one trailing space when adding the 4th `%c`
+- [x] confirm no changes are needed in `CheckUserAuthenticationTokens()` — unclaimed single-use
+      tokens expire through the existing `expirationTime` sweep
+- [x] tests deferred to Task 3 (harness does not exist yet)
+- [x] verify the tree still compiles and links: `make -C src/server` — libnxcore, netxmsd and webapi
+      build clean. ⚠️ `nxdbmgr`, `nxget`, `nddload`, `nxwsget` and `nxminfo` fail to link in this
+      build tree with missing `nx_wcsnicmp`/`nx_wcslwr`/`nx_wcsupr`; verified identical with the
+      change stashed, so it is a pre-existing stale-libnetxms issue unrelated to this work
+
+### Task 3: Build the C++ unit-test harness and cover both functions
+
+**Files:**
+- Create: `tests/test-authtokens/Makefile.am`
+- Create: `tests/test-authtokens/Makefile.w32`
+- Create: `tests/test-authtokens/test-authtokens.cpp`
+- Modify: `configure.ac`
+- Modify: `tests/suite/netxms-test-suite.in`
+- Modify: `tests/suite/netxms-test-suite.cmd`
+- Modify: `Makefile.w32`
+
+- [x] create `tests/test-authtokens/Makefile.am` modelled on **`tests/test-libnxsrv/Makefile.am`**
+      (not `tests/ha`): `bin_PROGRAMS = test-authtokens`, sources
+      `test-authtokens.cpp ../../src/server/core/authtokens.cpp`
+- [x] set CPPFLAGS to `-I@top_srcdir@/include -I@top_srcdir@/src/server/include -I../include
+      -I@top_srcdir@/build -DNXCORE_EXPORTS @MICROHTTPD_CPPFLAGS@`. All four additions are load
+      bearing: `-DNXCORE_EXPORTS` because otherwise `NXCORE_EXPORTABLE` resolves to
+      `__declspec(dllimport)` (`src/server/include/nms_core.h:32`, `include/symbol_visibility.h:34`)
+      and defining dllimport-decorated symbols is a hard error on MinGW; `@MICROHTTPD_CPPFLAGS@`
+      because `netxms-webapi.h:29` includes `<microhttpd.h>`; `-I../include` for `testtools.h`
+- [x] set LDADD to the `libnxsrv` chain from `tests/test-libnxsrv/Makefile.am:15-22` (libnxsrv,
+      libnxsnmp, libnxsl, libnxdb, libnxagent, libnetxms, plus the `USE_INTERNAL_JANSSON`
+      conditional) — `ServerConsole::printf` lives in `libnxsrv` and must be linked, not stubbed
+- [x] add stub definitions for exactly four server-core symbols: `ConfigReadULong`,
+      `CreateUniqueId`, `ExecuteQueryOnObject`, `ResolveUserId`. Do **not** try to stub
+      `GetAuthTokenMaxLifetime` — it is `static inline` in `netxms-webapi.h:48` and inlines
+      `ConfigReadULong`
+- [x] restrict all test cases to EPHEMERAL and SERVICE tokens so the DB code paths are never entered
+      and `ExecuteQueryOnObject` can stay a no-op
+- [x] write test: `ValidateAuthenticationToken()` rejects a single-use token **and leaves it valid**
+      for a subsequent `ConsumeAuthenticationToken()` call
+- [x] write test: `ConsumeAuthenticationToken()` succeeds once on a single-use token, reports
+      `singleUseToken = true`, and fails on every subsequent attempt
+- [x] write test: `ConsumeAuthenticationToken()` on a non-single-use token succeeds, reports
+      `singleUseToken = false`, and leaves the token reusable — guards the reconnect-token regression
+- [x] write test: `ValidateAuthenticationToken()` on a non-single-use token behaves exactly as before
+      this change, including `validFor` extension
+- [x] write test: rejection happens before expiry extension. `ValidateAuthenticationToken()` writes
+      `*expiresAt` only on success (`authtokens.cpp:311-312`), so a rejected call reports nothing —
+      instead hold the `shared_ptr<AuthenticationTokenDescriptor>` that `IssueAuthenticationToken()`
+      returns (`authtokens.cpp:180`), record `descriptor->expirationTime`, validate the single-use
+      token with a large `validFor`, and assert the field is unchanged
+- [x] write test: concurrent `ConsumeAuthenticationToken()` from N threads yields exactly one success
+- [x] write test: unclaimed single-use token past its expiration time is rejected. Use **two
+      separate expired tokens**, one per function — the first call to either function hits the expiry
+      branch and calls `s_tokens.remove()` (`authtokens.cpp:293`), so reusing one token would make
+      the second call exercise the "does not exist" branch at line 274 instead
+- [x] wire into `configure.ac`: add `test-authtokens` to the `TEST_MODULES` assignment at line 1295
+      (the `--with-server` group) and `tests/test-authtokens/Makefile` to `AC_CONFIG_FILES` near
+      line 4817. `tests/Makefile.am:11` already picks up `@TEST_MODULES@` and needs no edit.
+      ➕ also added to the `--with-dist` `TEST_MODULES` list (line 1046) so maintainer dist builds
+      pick it up, and added the binary to `.gitignore` alongside the other test binaries
+- [x] create `Makefile.w32` modelled on `tests/test-libnxsrv/Makefile.w32`; add the directory to the
+      **nested** `ifeq ($(BUILD_SERVER),1)` block at `Makefile.w32:173` (not the flat `TESTS_DIRS`
+      list), and add a dependency edge alongside `Makefile.w32:274`. A `vpath` entry locates
+      `authtokens.cpp` under `src/server/core` so the object lands in the test's own directory
+- [x] add a guarded `if [ -x $BINDIR/test-authtokens ]` block to `tests/suite/netxms-test-suite.in`
+      and the equivalent to `netxms-test-suite.cmd`
+- [x] regenerate the build system after editing `configure.ac`: `./init-source-tree` (or
+      `autoreconf`), then re-run `./configure --with-tests ...`
+- [x] `make && make install` — the suite runner executes binaries from `$BINDIR`
+      (`netxms-test-suite.in:8-16`), so an uninstalled binary will be silently skipped.
+      ⚠️ top-level `make install` aborts in `src/client/nxshell` (`Shell.java` calls
+      `NXCSession.parseConnectionAddress()`, which does not exist); pre-existing and unrelated, so
+      the C++ libraries and `tests` were installed directly
+- [x] run tests — must pass before next task: `./tests/suite/netxms-test-suite` — full suite green,
+      including the 7 new `test-authtokens` cases
+
+### Task 4: Make NXCP login the single spend point
+
+**Files:**
+- Modify: `src/server/core/session.cpp`
+
+- [x] in `ClientSession::authenticateUserByToken()` (line 2560), replace the
+      `ValidateAuthenticationToken()` call at line 2571 with `ConsumeAuthenticationToken()`, passing
+      a `bool singleUseToken = false` out-parameter — initialise the local explicitly rather than
+      relying on the helper always writing it
+- [x] set `loginInfo->closeOtherSessions = false` when `singleUseToken` is true, alongside the
+      existing service-token line at 2581
+- [x] add a debug line recording that a single-use token was consumed for this login
+- [x] verify by inspection that this is the **only** `ConsumeAuthenticationToken()` call site in the
+      tree, and that `webapi_router.cpp:306` and `session.cpp:4203` still call
+      `ValidateAuthenticationToken()` unchanged — confirmed by tree-wide grep; the anonymous access
+      site is now at `session.cpp:4207` after the edit
+- [x] behavioural coverage is provided by the Java integration test in Task 8; the login path
+      requires a running server and has no C++ unit-test harness
+- [x] run tests — must pass before next task: `./tests/suite/netxms-test-suite` — full suite green,
+      including all 7 `test-authtokens` cases
+
+### Task 5: Add the NXCP issuance surface
+
+**Files:**
+- Modify: `include/nms_cscp.h`
+- Modify: `src/java-common/netxms-base/src/main/java/org/netxms/base/NXCPCodes.java`
+- Modify: `src/server/core/session.cpp`
+
+- [x] add `VID_SINGLE_USE` to `include/nms_cscp.h` as 1024, immediately after `VID_MARKDOWN` (1023,
+      line 1792); re-confirm 1024 is still free at implementation time — confirmed free
+- [x] mirror the constant into `NXCPCodes.java` after line 1602. The file is contiguous through
+      1023 — there are no adjacent gaps to fill
+- [x] in `ClientSession::issueAuthToken()` (line 3041), read `VID_SINGLE_USE` and pass it through to
+      `IssueAuthenticationToken()` (explicit `maxLifetime = 0` so the trailing flag can be passed)
+- [x] reject `persistent && singleUse` with `RCC_INVALID_ARGUMENT` before issuing
+- [x] extend the audit log to record the single-use flag, and ensure single-use tokens are audited
+      **even when self-issued** — the deliberate skip at lines 3057-3059 targets high-frequency
+      ephemeral reconnect tokens, which these are not. Token type is now a single `tokenType` string
+      (`persistent` / `single-use ephemeral` / `ephemeral`) shared by both audit branches
+- [x] behavioural coverage is provided by Task 8
+- [x] run tests — must pass before next task: `./tests/suite/netxms-test-suite` — full suite green,
+      including all 7 `test-authtokens` cases. `make -C src/server` now builds clean end to end; the
+      stale-libnetxms link failures noted in Task 2 are gone after the Task 3 install
+
+### Task 6: Add the WebAPI issuance surface
+
+**Files:**
+- Modify: `src/server/webapi/users.cpp`
+- Modify: `src/server/webapi/openapi.yaml`
+
+- [x] in `H_UserTokenCreate` (line 334), read `"singleUse"` from the request body, defaulting to
+      false
+- [x] reject `persistent && singleUse` with HTTP 400. Because `persistent` defaults to **true**
+      (line 360), a body of `{"singleUse": true}` alone hits this path — the error message must
+      state explicitly that `singleUse` requires `"persistent": false`
+- [x] pass the flag through to `IssueAuthenticationToken()` and include it in the audit log entry
+      (token type string mirrors the NXCP handler: `persistent` / `single-use ephemeral` /
+      `ephemeral`)
+- [x] add `singleUse` to the **`AuthenticationTokenCreateInput`** schema (`openapi.yaml:11036`),
+      documenting the rejected combination and the 400 response
+- [x] add `singleUse` to the **`AuthenticationToken`** schema (`openapi.yaml:11008`) — this is the
+      response schema fed by `toJson()`, used by both the 201 response and
+      `GET /v1/users/{user-id}/tokens`
+- [x] document in the `singleUse` property description that such a token can only be spent on an
+      NXCP login and will be rejected if presented as a REST bearer credential
+- [x] verify the `toJson()` output added in Task 1 surfaces `"singleUse"` in the 201 response body —
+      `auth-token.h:209` emits it unconditionally, so it appears in both the 201 body and the list
+- [x] REST handlers have no unit-test harness in this tree; manual `curl` verification is recorded
+      in Post-Completion
+- [x] run tests — must pass before next task: `./tests/suite/netxms-test-suite` — full suite green,
+      including all 7 `test-authtokens` cases; `make -C src/server/webapi` builds clean
+
+### Task 7: Extend the Java client
+
+**Files:**
+- Modify: `src/client/java/netxms-client/src/main/java/org/netxms/client/NXCSession.java`
+- Modify: `src/client/java/netxms-client/src/main/java/org/netxms/client/users/AuthenticationToken.java`
+
+- [x] add a `requestAuthenticationToken(boolean persistent, int validFor, String description,
+      int userId, boolean singleUse)` overload (line 2936 area) that sets `VID_SINGLE_USE`
+- [x] keep the existing four-argument signature working by delegating with `singleUse = false` —
+      `nxmc-launcher` depends on it and must keep building until it opts in
+- [x] read the flag at `baseId + 8` in the `AuthenticationToken` NXCP constructor and add an
+      `isSingleUse()` getter with Javadoc
+- [x] do **not** touch the orphaned `service` flag at `baseId + 7` — out of scope, recorded in
+      Post-Completion
+- [x] build the client libraries: `mvn -f src/java-common/netxms-base/pom.xml install` then
+      `mvn -f src/client/java/netxms-client/pom.xml install` — both install clean
+- [x] run tests — must pass before next task: `./tests/suite/netxms-test-suite` (guards against C++
+      side regressions; the Java behavioural coverage lands in Task 8) — full suite green, including
+      all 7 `test-authtokens` cases
+
+### Task 8: Add the end-to-end integration test
+
+**Files:**
+- Create: `tests/integration/src/test/java/org/netxms/tests/SingleUseTokenTest.java`
+
+- [x] create the test following the conventions of the existing tests in that directory — extends
+      `AbstractSessionTest`, uses `TestConstants` for connection parameters, JUnit 5
+- [x] write test: issue a single-use token, log in with it, assert success (`testLoginWithSingleUseToken`,
+      also asserts `isSingleUse()` and `!isPersistent()` on the issued token)
+- [x] write test: assert a second login with the same token value fails (`testSingleUseTokenCannotBeReused`,
+      expects `RCC.ACCESS_DENIED`)
+- [x] write test: assert a non-single-use ephemeral token still supports repeated reconnect —
+      guards the regression that the login path must not consume ordinary tokens
+      (`testOrdinaryTokenIsNotConsumed`, three consecutive logins)
+- [x] write test: assert requesting `persistent = true` together with `singleUse = true` is rejected
+      (`testPersistentSingleUseTokenRejected`, expects `RCC.INVALID_ARGUMENT`)
+- [x] the WebAPI-bearer-401 case is deliberately **not** covered here: `tests/integration/pom.xml`
+      declares no HTTP client and the harness supplies no WebAPI base URL, and Task 3 already covers
+      that rule at the validator where it lives
+- [x] run the integration suite against a running server (skipped — not automatable in this
+      environment). ⚠️ No NetXMS server is running locally and no local database matches this build's
+      schema (dev databases are at 62.26, build requires 70.15), so the suite cannot be executed here.
+      Verified instead that the module compiles clean: `mvn -f tests/integration/pom.xml test-compile`
+      (required installing `src/mobile-agent/java` into the local repository first). The live run is
+      recorded as manual verification and is repeated as a checkbox in Task 9.
+
+### Task 9: Verify acceptance criteria
+
+- [x] verify all requirements from Overview are implemented — orthogonal `singleUse` flag (not a
+      fourth enum value), memory-only, single NXCP spend point, both issuance surfaces, Java client
+      support, `U` console flag
+- [x] verify the single-entry-point rule holds: grep the tree for `ConsumeAuthenticationToken` and
+      confirm the call inside `authenticateUserByToken()` (line 2572 today) is the only call site —
+      confirmed; the only other occurrences are the declaration, the definition, two doc comments,
+      and `tests/test-authtokens`
+- [x] verify `ConsumeAuthenticationToken()` is **not** marked `NXCORE_EXPORTABLE`, and that the
+      webapi module still builds — proving nothing outside libnxcore reaches for it. Declaration at
+      `nms_users.h:638` is undecorated and `make -C src/server/webapi` builds clean
+- [x] verify every `ValidateAuthenticationToken()` call site rejects single-use tokens — structural:
+      both remaining sites (`session.cpp:4219`, `webapi_router.cpp:306`) go through
+      `ProcessAuthenticationToken(..., consuming = false)`, whose rejection branch is covered by two
+      unit tests
+- [x] verify no existing call site of `IssueAuthenticationToken()` (7 sites) or
+      `ValidateAuthenticationToken()` (3 sites, one of which moves to the new function) needed
+      signature changes — the diff touches only the two issuance sites that deliberately pass the new
+      flag (`session.cpp:3065`, `webapi/users.cpp:372`); `reporting.cpp:375,424`,
+      `webapi_auth.cpp:80`, `session.cpp:3020,4233` are unmodified
+- [x] verify `webapi_router.cpp` is genuinely unmodified — `git diff master...HEAD` on that file is
+      empty
+- [x] verify no database schema change was introduced anywhere in the diff — no `nxdbmgr`,
+      `upgrade_v*`, `netxmsdb.h` or SQL file appears in the branch diff
+- [x] verify server code added uses `L"..."` literals and no `_T()`/TCHAR, 3-space indent, and
+      C++11 constructs only. ➕ fixed one new `_T()` literal in the `debugPrintf()` line added by
+      Task 4 (`session.cpp:2573`). The `_T()` uses left in `ShowAuthenticationTokens()` are the
+      pre-existing statement being extended, not new code
+- [x] run full test suite: `./tests/suite/netxms-test-suite` — 566 cases OK, exit 0
+- [x] run the Java integration suite against a running server (skipped — not automatable in this
+      environment, same blocker as Task 8: no running server and no database matching this build's
+      schema level). Compile-level verification stands; the live run remains manual
+- [x] confirm the MinGW build still succeeds, since Task 3 adds a Windows test directory — a real
+      cross-build is not possible here (`build/config.mingw` and the Windows dependency SDK tree are
+      absent), so verified by inspection against `src/server/core/Makefile.w32` and
+      `tests/test-libnxsrv/Makefile.w32`. ⚠️ that inspection found a genuine defect: the new
+      `tests/test-authtokens/Makefile.w32` compiled `authtokens.cpp` without
+      `-I$(MICROHTTPD_ROOT)/include`, which `authtokens.cpp` needs via
+      `netxms-webapi.h` → `<microhttpd.h>` — the Windows counterpart of the `@MICROHTTPD_CPPFLAGS@`
+      already present in `Makefile.am`. Fixed; the MinGW build would otherwise have failed on that
+      directory
+
+### Task 10: [Final] Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (only if a new pattern emerged)
+- Move: `docs/plans/20260731-single-use-auth-tokens.md` → `docs/plans/completed/`
+
+- [x] document single-use token semantics for administrators — including that they can only be spent
+      on a login, and that they do not survive a server restart. Written as
+      `doc/Single_Use_Authentication_Tokens.md`, an explanation-type document following the
+      conventions of the other standalone guides in `doc/` (pandoc YAML header). Covers the spend
+      point, the REST 401 / non-consuming rejection, memory-only lifetime and restart behaviour, the
+      `persistent + singleUse` rejection at both surfaces (including the REST `persistent: true`
+      default), suppressed `closeOtherSessions`, the burnt-on-failed-login trade-off, always-on
+      auditing, the `U` flag in `show auth-tokens`, and the `auth` debug tag levels
+- [x] no change needed to `doc/internal/debug_tags.txt`: the `auth` tag already exists (line 18) and
+      this change adds no new tag — confirmed
+- [x] update `CLAUDE.md` only if a genuinely new pattern emerged. ➕ recorded in
+      `src/server/CLAUDE.md` under "Exporting Functions for Modules": a *missing*
+      `NXCORE_EXPORTABLE` can be deliberate, restricting a primitive to intra-core callers so the
+      linker enforces a single call site. That is the generalisable half of the validate/consume
+      split; the split itself is feature-specific and already documented in code comments and in the
+      new admin document
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems — no checkboxes, informational only*
+
+**Follow-up change in `nxmc-launcher` (separate repository):**
+
+- This plan delivers only the server and client-library support. The `nxmc-launcher` repository must
+  be updated separately to pass `singleUse = true` when it requests its handoff token (currently an
+  ephemeral 600s token, per step 5 of its README). Until that change lands, nothing about the
+  launcher's behaviour changes — the new flag defaults to false.
+- Keep the TTL as it is. Single-use bounds the exposure window by consumption, not by expiry, so
+  there is no reason to shorten it and risk a token expiring during a cold start on a slow machine.
+
+**Contribution workflow:**
+
+- The project follows an issue-first workflow. A GitHub issue describing this feature and the design
+  decisions above should exist before the pull request is opened, and the PR must reference it.
+
+**Manual verification:**
+
+- Exercise the REST surface against a running server:
+  - `POST /v1/users/{id}/tokens` with `{"validFor": 60, "persistent": false, "singleUse": true}` →
+    201 with `"singleUse": true` and a clear-text value in the response.
+  - The same body with `"persistent": true` → 400 with a message naming the constraint.
+  - The issued token in an `Authorization: Bearer` header on any authenticated route → 401, and the
+    token still usable for a subsequent nxmc login (rejection must not consume it).
+  - The same token used for an nxmc login → success; a second login attempt → failure.
+- Confirm the handoff end to end with a user account that has `UF_CLOSE_OTHER_SESSIONS` set.
+- Verify `show authtokens` in the server console names the token type and that the column
+  alignment still matches the separator rule.
+
+**Deliberate omission — REST token exchange:**
+
+- There is no REST equivalent of the NXCP login spend point: a single-use token cannot be exchanged
+  for a session token over HTTP. A `POST /v1/tokens/exchange` route accepting a single-use token and
+  returning a fresh ephemeral one would give REST clients the same handoff capability, and returning
+  a session token over TLS is acceptable from a security standpoint. It is omitted because the
+  launcher flow does not need it and it adds an auth-critical route. Revisit if a REST-only
+  integration needs the handoff.
+
+**Observations recorded but deliberately not fixed** (per the project's Scope rule — pre-existing and
+unrelated to single-use tokens, in files this change touches):
+
+- `AuthenticationToken.java` never reads the `service` flag the server writes at `baseId + 7`.
+- The clear-text token value is returned by token *listings*, not only by the issue response, for as
+  long as the descriptor is held in memory (`auth-token.h`, `validClearText`). Access is gated on
+  own-user-or-`SYSTEM_ACCESS_MANAGE_USERS` and a successful listing is not audited. This is
+  pre-existing behaviour that the server console and the token management UI rely on; narrowing it to
+  issue time is a product decision and needs its own issue.
+
+**Changes that landed beyond the original plan** (recorded here because the plan requires scope
+changes to be written down; each is small, and all are in the token issuance paths this change
+already rewrites):
+
+- `MAX_PERSISTENT_TOKEN_EXPIRATION_TIME` clamp plus rejection of a persistent token whose expiration
+  time would not survive the 32-bit database column, at both issuance surfaces.
+- Rejection of `validFor == 0` on `CMD_REQUEST_AUTH_TOKEN`. Note this is an NXCP behaviour change:
+  such a request previously returned `RCC_SUCCESS` with an already-expired token and now returns
+  `RCC_INVALID_ARGUMENT`. `IssueTokenDialog` computes validity from a picked date, so a date at or
+  before now now yields a generic error popup — worth a follow-up to validate in the dialog.
+- Rejection of an over-long `description` for a persistent token on the REST surface, which
+  previously let the `INSERT` fail with only a warning while returning 201 (`MAX_TOKEN_DESCRIPTION_LENGTH`).
+- Null checks on every `IssueAuthenticationToken()` result. The earlier revision of this plan recorded
+  the `fillMessage()` call site as deliberately unfixed; it and the four other unchecked call sites
+  (`session.cpp` reconnect token, `webapi_auth.cpp` `CompleteLogin()`, both `reporting.cpp` sites)
+  were fixed instead, because `reporting.cpp:424` issues a token for a user id captured when a report
+  was *scheduled* and crashes the server if that user has since been deleted.
+- `getAuthenticationTokens()` in `NXCSession.java` advanced the field id by 9 instead of the server's
+  stride of 10, so every listed token but the first was decoded from the wrong offsets. This one is a
+  prerequisite: without it `isSingleUse()` is wrong for every token after the first.
+- `RevokeAuthenticationToken(tokenId, userId)` now rejects `tokenId == 0` with `RCC_INVALID_TOKEN_ID`.
+  Only persistent tokens are assigned an ID, so a lookup by 0 previously matched an arbitrary
+  memory-only token — including one belonging to another user when the caller holds `MANAGE_USERS`.
+- `enableAnonymousObjectAccess()` grants `OBJECT_ACCESS_READ` to the `anonymous` user only after the
+  token was issued, and returns `RCC_RESOURCE_NOT_AVAILABLE` when it cannot be. Previously a failed
+  issuance left the object readable by `anonymous` with no token handed out.
+- Rejection of an over-long `description` for a persistent token on the NXCP surface as well, so that
+  both issuance surfaces answer the same request the same way instead of one truncating silently.
+
+**Deliberately out of scope — do not add without a new decision:**
+
+- nxmc UI (`IssueTokenDialog.java`, `TokenManagement.java`) — server and API only.
+- NXSL binding for token issuance.
+- Server console / nxadm issuance command (the token type display in `show authtokens` is not issuance).
+- Persistent single-use tokens and any accompanying schema change.

--- a/docs/plans/completed/20260804-single-use-token-type.md
+++ b/docs/plans/completed/20260804-single-use-token-type.md
@@ -1,0 +1,411 @@
+# Single-Use Authentication Token as a Token Type
+
+## Overview
+
+Single-use authentication tokens are currently modelled as a boolean flag (`singleUse`) that is
+orthogonal to `AuthenticationTokenType`. The flag is accepted for every token type, but only one
+combination is meaningful: two of the four possible pairings are either dead (`SERVICE` + single-use,
+which nothing asks for) or silently corrected by the descriptor constructor (`PERSISTENT` +
+single-use, forced off). Reviewers found this misleading — the API advertises a freedom of
+combination that does not exist.
+
+This change replaces the flag with a fourth `AuthenticationTokenType` value, `SINGLE_USE`. The
+invalid combinations become unrepresentable instead of being defensively corrected, and the four
+mutually exclusive kinds of token are described by one field instead of three booleans plus an enum.
+
+The change is confined to the server. The NXCP and REST representations both stay **byte-identical**:
+the wire has always carried a set of booleans rather than a type, so the server simply derives those
+booleans from the type. No client, schema, or protocol work is required.
+
+## Context (from discovery)
+
+Files/components involved:
+
+- `src/server/include/auth-token.h` — `AuthenticationTokenType` enum, `AuthenticationTokenDescriptor`
+  struct, `fillMessage()`, `toJson()`. Included only by `src/server/include/nms_objects.h`, so the
+  whole type is server-contained.
+- `src/server/include/nms_users.h` — declarations of `IssueAuthenticationToken()`,
+  `ValidateAuthenticationToken()`, `ConsumeAuthenticationToken()`.
+- `src/server/core/authtokens.cpp` — issuance, the shared `ProcessAuthenticationToken()`
+  implementation behind validate/consume, and `ShowAuthenticationTokens()`.
+- `src/server/core/session.cpp` — `authenticateUserByToken()` (the sole spend point),
+  `issueAuthToken()` (NXCP issuance boundary).
+- `src/server/webapi/users.cpp` — `H_UserTokenCreate()` (REST issuance boundary).
+- `tests/test-authtokens/test-authtokens.cpp` — unit harness; compiles the real `authtokens.cpp`.
+- `doc/Single_Use_Authentication_Tokens.md` — design/administration document.
+
+Related patterns found:
+
+- `ConsumeAuthenticationToken()` is deliberately **not** marked `NXCORE_EXPORTABLE`, so the linker
+  confines the spend primitive to server core. `src/server/CLAUDE.md` documents this as intentional.
+- Server code is Unicode-only: `L"..."` and `wchar_t`, never `_T()` / `TCHAR`. `auth-token.h` still
+  carries `TCHAR` remnants. Formatting into a `wchar_t` buffer uses `nx_swprintf`, not `_sntprintf`.
+- `tests/include/testtools.h` has `AssertEquals` overloads for int32/int64/uint/size_t/ssize_t and
+  `char*`/`wchar_t*` — **no `enum class` overload**.
+
+Dependencies identified:
+
+- No database schema dependency — token type is never persisted. `auth_tokens` rows are persistent
+  tokens by construction.
+- No NXCP protocol dependency — the enum value is never serialized. `VID_SINGLE_USE` stays as-is.
+- `ValidateAuthenticationToken()`'s callers outside tests are unaffected by the out-param change:
+  `webapi_router.cpp:306` passes `nullptr` explicitly, `session.cpp:4248` passes only two arguments
+  and relies on the default. Its only non-`nullptr` third-argument caller in the tree is
+  `test-authtokens.cpp:169`.
+- The five `IssueAuthenticationToken()` callers not listed below (`session.cpp:3021`,
+  `session.cpp:4262`, `reporting.cpp:369`, `reporting.cpp:430`, `webapi_auth.cpp:81`) all pass fewer
+  than six arguments, so dropping the trailing `bool singleUse` leaves them untouched.
+
+## Development Approach
+
+- **testing approach**: Regular (code first, then tests) — this is a mechanical refactor of existing
+  behaviour with an existing unit harness. No new behaviour is introduced, so there is nothing to
+  drive with a failing test first.
+- **CRITICAL — this refactor does not compile until Tasks 1-6 are all complete.** Removing three
+  fields from a struct breaks every reader of those fields simultaneously; there is no intermediate
+  state where the tree builds. Per-task test runs are therefore impossible, and the plan does not
+  pretend otherwise: Tasks 1-6 form **one compilable unit**, and the build-and-test gate lives at the
+  end of Task 6. Do not attempt `make` before then.
+- Test coverage must come out **neutral or better**, never negative. No new behaviour is introduced,
+  so no new scenarios are needed — but Task 6 must not quietly lose coverage while migrating. Two
+  specific traps, both called out in that task: the existing asserts rely on a poison-value pattern
+  that a naive enum rewrite makes vacuous, and the one test being deleted needs a replacement rather
+  than a pointer to a suite the build gate does not run.
+- Complete each task fully before moving to the next.
+- Behaviour must be preserved exactly. Any observable change other than the two intended ones (server
+  console `show authtokens` column, audit-log wording) is a bug.
+
+## Testing Strategy
+
+- **unit tests**: `tests/test-authtokens/` — migrated in Task 6, run in Task 6's final checkbox and
+  again in Task 8. Requires `./configure --with-tests`. This is the only suite the build gate runs, so
+  anything that must be verified before merge has to live here.
+- **integration tests**: `tests/integration/.../SingleUseTokenTest.java` — must pass **unchanged**.
+  This is the load-bearing verification that the wire format did not move: it exercises issuance,
+  single-use login, reuse rejection, ordinary-token reuse, and the persistent+single-use rejection
+  entirely through the Java client. If it needs edits, the refactor has leaked past the server.
+- **e2e tests**: not applicable — no UI change.
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+- update plan if implementation deviates from original scope
+
+## Solution Overview
+
+`AuthenticationTokenType` gains `SINGLE_USE = 3`. `AuthenticationTokenDescriptor` replaces its three
+booleans with a single `AuthenticationTokenType type` field, and everything that used to read a
+boolean now compares against the enum.
+
+Key design decisions:
+
+- **No `isPersistent()` / `isService()` / `isSingleUse()` accessors.** Call sites compare directly:
+  `descriptor->type == AuthenticationTokenType::PERSISTENT`. Three one-line predicates that exist
+  only to shorten a comparison are the kind of indirection the project's design principles reject.
+- **Validation stays at the protocol boundary.** `issueAuthToken()` and `H_UserTokenCreate()` keep
+  reading the request booleans and keep rejecting `persistent && singleUse`. That check is what makes
+  the combination unreachable now that the constructor no longer corrects it — it is not redundant,
+  it is the replacement.
+- **Wire compatibility by derivation, not by storage.** `fillMessage()` and `toJson()` compute the
+  three booleans from the type at serialization time.
+- **`SINGLE_USE` composes with nothing.** The previous model left room for a service token that is
+  also single-use. Nothing asked for it, and dropping the possibility is the point of the change.
+
+## Technical Details
+
+Enum:
+
+```cpp
+enum class AuthenticationTokenType
+{
+   EPHEMERAL = 0,    // Not saved to database, usually short-lived
+   PERSISTENT = 1,   // Saved to database, usually with long expiration time
+   SERVICE = 2,      // Similar to ephemeral but will not trigger existing session disconnect
+   SINGLE_USE = 3    // Memory-only, destroyed by the login that spends it
+};
+```
+
+Signatures after the change:
+
+```cpp
+shared_ptr<AuthenticationTokenDescriptor> NXCORE_EXPORTABLE IssueAuthenticationToken(uint32_t userId,
+   uint32_t validFor, AuthenticationTokenType type = AuthenticationTokenType::EPHEMERAL,
+   const wchar_t *description = nullptr, uint32_t maxLifetime = 0);
+
+// As shipped, the tokenType out-parameter was dropped entirely: no production caller reads it once
+// the spend point moves to ConsumeAuthenticationToken(), so the wrapper passes nullptr internally.
+bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId,
+   uint32_t validFor = 0, time_t *expiresAt = nullptr, time_t *maxExpiresAt = nullptr);
+
+bool ConsumeAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId,
+   AuthenticationTokenType *tokenType = nullptr);
+```
+
+Request-flag → type mapping, used identically at both issuance boundaries:
+
+```cpp
+   AuthenticationTokenType type = persistent ? AuthenticationTokenType::PERSISTENT :
+      (singleUse ? AuthenticationTokenType::SINGLE_USE : AuthenticationTokenType::EPHEMERAL);
+```
+
+Wire derivation in `fillMessage()` (`toJson()` mirrors it):
+
+```cpp
+   msg->setField(baseId + 2, type == AuthenticationTokenType::PERSISTENT);
+   msg->setField(baseId + 7, type == AuthenticationTokenType::SERVICE);
+   msg->setField(baseId + 8, type == AuthenticationTokenType::SINGLE_USE);
+```
+
+Intended observable changes (everything else must stay identical):
+
+| Surface | Before | After |
+|---|---|---|
+| `show authtokens` column | `Flags` — `PSUV` characters | `Type` — `ephemeral` / `persistent` / `service` / `single-use` |
+| `show authtokens` `V` flag | separate column position | dropped; `Token` column already prints `unavailable` |
+| Audit log on issuance | `single-use ephemeral` | `single-use` |
+
+## What Goes Where
+
+- **Implementation Steps**: all server C++ changes, unit-test migration, documentation rewrite.
+- **Post-Completion**: manual server-console verification, integration-test run against a live server.
+
+## Implementation Steps
+
+### Task 1: Add SINGLE_USE type and collapse descriptor flags
+
+**Files:**
+- Modify: `src/server/include/auth-token.h`
+
+- [x] add `SINGLE_USE = 3` to `enum class AuthenticationTokenType` with a comment noting it is
+      memory-only and destroyed by the login that spends it
+- [x] replace the `persistent` / `service` / `singleUse` members of `AuthenticationTokenDescriptor`
+      with a single `AuthenticationTokenType type` field, placed after `userId`; keep `claimed` and
+      `validClearText` as they are
+- [x] drop the `bool _singleUse` parameter from the main constructor, delete the
+      `singleUse = _singleUse && (type != AuthenticationTokenType::PERSISTENT);` line and its
+      comment, and assign `type = _type;` instead of the three boolean assignments
+      (the `type` parameter was renamed to `_type` to avoid shadowing the new member)
+- [x] collapse the DB-record constructor's `persistent`/`service`/`singleUse` assignments (and the
+      "Persistent tokens are never single-use" comment) into `type = AuthenticationTokenType::PERSISTENT;`
+- [x] derive the wire booleans in `fillMessage()` (baseId+2, +7, +8) and in `toJson()`
+      (`persistent`, `service`, `singleUse` keys) from `type` — field IDs and JSON key names unchanged
+- [x] sweep `TCHAR` / `_T()` to `wchar_t` / `L""` throughout the file: constructor parameter
+      `const TCHAR *_description`, `TCHAR buffer[64]` in `toString()` and `toMaskedString()`,
+      `TCHAR text[128]` in the DB constructor, and `_T("********")` / `_T("%.4s****%.4s")`
+- [x] replace `_sntprintf` in `toMaskedString()` with `nx_swprintf` per `src/server/CLAUDE.md`
+- [x] update the constructor doc comment: remove the `@param _singleUse` line, and reword `@param type`
+      from "ephemeral, persistent, or service" to cover all four
+- [x] call the Unicode sweep out separately in the commit message — it is convention-aligned per
+      `src/server/CLAUDE.md` and a strict no-op (server builds are Unicode-only), but it enlarges a
+      diff otherwise advertised as mechanical
+- [x] do NOT build yet — the tree does not compile until Task 6
+
+### Task 2: Update token issuance and validation API
+
+**Files:**
+- Modify: `src/server/core/authtokens.cpp`
+- Modify: `src/server/include/nms_users.h`
+
+- [x] add file-static `TokenTypeName(AuthenticationTokenType)` in `authtokens.cpp` returning
+      `L"persistent"` / `L"service"` / `L"single-use"` / `L"ephemeral"` (default branch)
+- [x] drop the trailing `bool singleUse` parameter from `IssueAuthenticationToken()` in both the
+      definition and the `nms_users.h` declaration; remove its `@param singleUse` doc line and reword
+      `@param type` to cover all four types
+- [x] replace the issuance debug log's 2-way ternary (`authtokens.cpp:188-189`) with `TokenTypeName(type)`
+- [x] change `ProcessAuthenticationToken()`'s `bool *serviceToken, bool *singleUseToken` parameters to
+      a single `AuthenticationTokenType *tokenType`; set it from `descriptor->type` and update the
+      `@param` block
+- [x] change the single-use gate inside `ProcessAuthenticationToken()` to
+      `descriptor->type == AuthenticationTokenType::SINGLE_USE`, leaving the `claimed`
+      `InterlockedIncrement` guard, `s_tokens.remove(hash)` and both debug messages untouched
+- [x] update the `ValidateAuthenticationToken()` and `ConsumeAuthenticationToken()` wrappers and their
+      `nms_users.h` declarations to the new out-param; keep `ConsumeAuthenticationToken()` undecorated
+      and keep the comment explaining why
+- [x] replace `descriptor->persistent` / `d->persistent` with
+      `... type == AuthenticationTokenType::PERSISTENT` at `authtokens.cpp` lines 217, 245, 269, 306,
+      315, 409
+- [x] do NOT build yet
+
+### Task 3: Replace flags column with type name in server console
+
+**Files:**
+- Modify: `src/server/core/authtokens.cpp`
+
+- [x] in `ShowAuthenticationTokens()`, replace the `Flags` header with a `Type` header 10 characters
+      wide and widen the separator row's second column to 12 dashes (10 + the two surrounding spaces)
+- [x] replace the four `%c` flag arguments with `TokenTypeName(descriptor->type)` under a `%-10s`;
+      `persistent` and `single-use` are both exactly 10 characters, so nothing truncates
+- [x] drop the `V` flag — `validClearText` is false only for descriptors built by the DB-record
+      constructor, and the `Token` column already prints `unavailable` in exactly that case
+- [x] convert the touched `printf` literals from `_T()` to `L""` and the lambda's
+      `TCHAR userName[MAX_USER_NAME]` to `wchar_t`, so the block is not left half-converted
+- [x] note in the commit message that this also fixes a pre-existing alignment bug: the header used
+      `%s` for a 5-character `"Flags"` while the data row emitted 6 characters
+- [x] do NOT build yet
+
+### Task 4: Map request flags to token type in NXCP session handler
+
+**Files:**
+- Modify: `src/server/core/session.cpp`
+
+- [x] in `authenticateUserByToken()`, replace the `bool serviceToken` / `bool singleUseToken` locals
+      with one `AuthenticationTokenType tokenType` passed to `ConsumeAuthenticationToken()`;
+      initialize it explicitly to `AuthenticationTokenType::EPHEMERAL` — `enum class` has no
+      zero-state and the variable is only read on the success path, so leaving it uninitialized
+      invites `-Wmaybe-uninitialized`
+- [x] gate the "single-use token consumed" debug message on
+      `tokenType == AuthenticationTokenType::SINGLE_USE`
+- [x] change the close-other-sessions suppression to
+      `(tokenType == AuthenticationTokenType::SERVICE) || (tokenType == AuthenticationTokenType::SINGLE_USE)`
+      and reword its comment to refer to handoff tokens
+- [x] in `issueAuthToken()`, keep the `VID_PERSISTENT` / `VID_SINGLE_USE` reads and the
+      `persistent && singleUse` → `RCC_INVALID_ARGUMENT` rejection; map the pair to an
+      `AuthenticationTokenType` local and pass it to `IssueAuthenticationToken()` without the trailing
+      boolean (the audit-log string local was renamed `tokenTypeName` to free `type` for the enum)
+- [x] change the audit-log type string from `L"single-use ephemeral"` to `L"single-use"`
+- [x] verify `ValidateAuthenticationToken()` at `session.cpp:4248` still compiles unchanged (it passes
+      only `&tokenUserId`)
+- [x] do NOT build yet
+
+### Task 5: Map request flags to token type in WebAPI handler
+
+**Files:**
+- Modify: `src/server/webapi/users.cpp`
+
+- [x] in `H_UserTokenCreate()`, keep the `singleUse` JSON read, the `persistent && singleUse` → HTTP
+      400 rejection and its error text unchanged
+- [x] map the pair to an `AuthenticationTokenType` local and pass it to `IssueAuthenticationToken()`
+      without the trailing boolean
+- [x] change the audit-log type string from `L"single-use ephemeral"` to `L"single-use"`
+- [x] verify `ValidateAuthenticationToken()` at `webapi_router.cpp:306` still compiles unchanged (it
+      passes `nullptr` for the out-param) — the file lives in `src/server/core/`, not `src/server/webapi/`
+- [x] do NOT build yet
+
+### Task 6: Update authentication token unit tests and build
+
+**Files:**
+- Modify: `tests/test-authtokens/test-authtokens.cpp`
+
+- [x] change the `IssueToken()` helper to
+      `IssueToken(uint32_t validFor, AuthenticationTokenType type = AuthenticationTokenType::EPHEMERAL, uint32_t maxLifetime = 0)`
+      and drop the `singleUse` argument it forwards
+- [x] translate the nine `IssueToken()` call sites (lines 82, 104, 130, 145, 162, 195, 235, 265, 266)
+      by pattern — drop the boolean, and where it was `true` pass `AuthenticationTokenType::SINGLE_USE`
+      instead of the type that followed it. Six distinct shapes: `(600, true)`, `(600, false)`,
+      `(600, false, SERVICE)`, `(60, false, EPHEMERAL, 3600)`, `(60, true, EPHEMERAL, 86400)`, `(0, true)`
+- [x] replace the paired `bool serviceToken` / `bool singleUseToken` locals with a single
+      `AuthenticationTokenType tokenType` at lines 89-91, 107-117, 133-150, 166-171, 221-222, 271-272
+- [x] assert with `AssertTrue(tokenType == AuthenticationTokenType::X)` — `testtools.h` has no
+      `enum class` `AssertEquals` overload, so a comparison avoids casting both sides
+- [x] **preserve the poison-value pattern.** The `bool` locals being replaced are pre-set to the
+      opposite of the expected result (`serviceToken = true` at line 107, `singleUseToken = true` at
+      133, 139 and 147, `= false` at 89) precisely so the assertion proves the out-param was *written*,
+      not merely left alone. Initialize each `tokenType` local to a value the call must overwrite —
+      e.g. `SERVICE` before consuming a single-use token, `SINGLE_USE` before validating an ephemeral
+      one. Initializing to the expected value would make every one of these assertions vacuous and
+      would pass against a `ProcessAuthenticationToken()` that never writes `*tokenType`
+- [x] delete `TestPersistentIsNeverSingleUse()` (lines 283-292) and its `main()` call: it asserted the
+      constructor's silent forcing, which no longer exists as state to check, and cannot be rewritten
+      because the `_singleUse` parameter is gone
+- [x] **replace it** with a `TestSingleUseIsMemoryOnly()` covering the half of that invariant which is
+      still a runtime property: issue via `IssueToken(600, AuthenticationTokenType::SINGLE_USE)` and
+      assert `descriptor->tokenId == 0` and `descriptor->type == AuthenticationTokenType::SINGLE_USE`.
+      Do not rely on `SingleUseTokenTest.testPersistentSingleUseTokenRejected()` to cover this — it
+      lives in the Maven integration suite, which `netxms-test-suite` does not run, so without this
+      test the build gate has no coverage of the exclusivity at all
+- [x] add the new test to `main()` in place of the deleted call
+- [x] verify `TestConcurrentConsume()`, `TestExpiredSingleUse()` and `TestPersistentExpirationClamp()`
+      keep their existing assertions — the claim race and the expiration clamp are unaffected
+- [x] build the tree (used the tree's existing configuration — `--with-server --with-agent --with-client
+      --with-tests` against the local prefix `/Users/alk/netxms/master` with the strict clang warning
+      set — rather than the generic line below, which would drop the macOS pgsql/openssl/microhttpd
+      paths this host needs): `make -j$(nproc) && make install`. Clean build; no warnings originate in
+      `authtokens.cpp` or `test-authtokens.cpp`
+- [x] run `./tests/suite/netxms-test-suite` — must pass before Task 7 (whole suite exits 0; all
+      `test-authtokens` cases OK; the binary had nine cases at this point, later review passes
+      brought it to fifteen)
+
+### Task 7: Rewrite single-use token documentation
+
+**Files:**
+- Modify: `doc/Single_Use_Authentication_Tokens.md`
+
+- [x] update the "Context" section (line 18): "three kinds" → four, and add a single-use bullet to the
+      list alongside ephemeral, persistent and service (the follow-on "All of them share one property"
+      sentence became "The first three share one property" — replayability is exactly what single-use
+      does not have, so listing it above that sentence required the qualifier)
+- [x] rewrite "Observing them" (lines 106-111): the `PSUV` flags column is now a `Type` column showing
+      the type name, and a consumed token still disappears from the listing (also noted that the
+      `Token` column reads `unavailable`, which is what replaced the dropped `V` flag)
+- [x] rewrite "Where this fits" (lines 118-136) to the opposite conclusion: single-use is a token type,
+      the four types are mutually exclusive, and the `SERVICE` + single-use composition is deliberately
+      gone because nothing asked for it. Lines 128-132 (no REST spend point) stay as they are; lines
+      133-136 need only "The flag defaults to false everywhere" reworded, since the request field is
+      still a boolean and still defaults to false — the statement remains true, the noun does not
+- [x] keep the "Memory only, and what that costs" section: the persistent+single-use rejection, its
+      `RCC_INVALID_ARGUMENT` / HTTP 400 codes and the `"persistent": false` note are all still accurate
+- [x] confirm the "Further reading" pointers still resolve (`openapi.yaml` schema fields, Java client
+      methods, debug tags) — none of them moved (`singleUse` at `openapi.yaml:11031`/`:11073`,
+      `NXCSession.requestAuthenticationToken()`, `AuthenticationToken.isSingleUse()`, `auth` tag)
+
+### Task 8: Verify acceptance criteria
+
+- [x] `grep -rn "singleUse\|_singleUse" src/server/` returns only the request-field reads at the two
+      issuance boundaries and the JSON/NXCP key names — no descriptor field, no function parameter
+      (hits: `session.cpp:3057-3112` and `users.cpp:364-400` request flags plus their audit strings,
+      `auth-token.h:223` JSON key, and `openapi.yaml` schema/doc text)
+- [x] `grep -rn -- "->persistent\|->singleUse" src/server/` returns nothing. Do **not** anchor the
+      pattern on `descriptor->` — two of the six live sites (`authtokens.cpp:269` and `:409`) spell it
+      `d->persistent` inside lambdas and would slip through a half-done refactor
+- [x] `grep -n -- "->service\b" src/server/core/authtokens.cpp src/server/include/auth-token.h` returns
+      nothing; scope it to those two files, since a tree-wide `->service` false-positives on
+      `record->serviceName` in `otellog.cpp` and `otlp/`
+- [x] confirm `include/nms_cscp.h`, `src/server/webapi/openapi.yaml`, the Java client and
+      `SingleUseTokenTest.java` are untouched in `git diff --stat` — compared against `d91e2931ce`
+      (the plan commit, i.e. the pre-refactor state), not `master`: the branch's earlier commit
+      `8e0769433b` introduced single-use tokens themselves and legitimately touches all four. The
+      refactor's own diff spans only `authtokens.cpp`, `session.cpp`, `auth-token.h`, `nms_users.h`,
+      `users.cpp`, `test-authtokens.cpp` and the two docs
+- [x] run the full suite: `./tests/suite/netxms-test-suite` — exits 0; all `test-authtokens`
+      cases OK (nine at the time of this run, fifteen after the review passes that followed). Note
+      the generated script lost its executable bit, so it was invoked as
+      `sh tests/suite/netxms-test-suite`
+- [x] start `netxmsd -D6`, run `show authtokens` on the server console and confirm the `Type` column
+      renders and aligns for at least an ephemeral and a persistent token — manual test (skipped, not
+      automatable: needs a live server and database). Alignment verified statically instead: header
+      and data rows both use `%-10s` for the type and the separator row's second column is 12 dashes
+- [x] confirm `ConsumeAuthenticationToken()` is still undecorated in `nms_users.h` and its rationale
+      comment survived (`nms_users.h:630-637`, both intact)
+
+### Task 9: [Final] Update documentation
+
+- [x] confirm `src/server/CLAUDE.md`'s `ConsumeAuthenticationToken()` paragraph is still accurate — it
+      is, unchanged: the symbol is still the sole spend point for single-use tokens, still undecorated
+      in `nms_users.h:637`, and its rationale comment (`nms_users.h:631-636`) survived the refactor.
+      Only the out-parameter type changed, which the paragraph does not mention
+- [x] confirm `doc/internal/debug_tags.txt` needs no change — no new debug tags introduced; the
+      refactor adds no `nxlog_debug_tag()` call, and every touched message keeps the existing `auth`
+      tag (`debug_tags.txt:18`)
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems — no checkboxes, informational only*
+
+**Manual verification:**
+
+- Run `tests/integration/.../SingleUseTokenTest.java` against a live server built from this branch.
+  It must pass **without modification** — that is the proof the wire format did not move. All four
+  cases matter: single-use login, reuse rejection, ordinary-token reuse, and persistent+single-use
+  rejection.
+- Confirm the management console still reconnects after a restart, exercising the ephemeral reconnect
+  token issued by `finalizeLogin()`.
+- Check a report execution end to end — `reporting.cpp` issues `SERVICE` tokens and is the only
+  in-tree consumer of that type.
+
+**External system updates:**
+
+- `nxmc-launcher` lives in its own repository and still does not request single-use tokens. Nothing
+  there needs updating; it is unaffected because the wire format is unchanged.

--- a/include/nms_cscp.h
+++ b/include/nms_cscp.h
@@ -1798,6 +1798,7 @@ __PACK_END__
 #define VID_MARKDOWN                ((uint32_t)1023)
 #define VID_AGENT_TLS_MODE          ((uint32_t)1024)
 #define VID_AGENT_CERT_FINGERPRINT  ((uint32_t)1025)
+#define VID_SINGLE_USE              ((uint32_t)1026)
 
 // Base values for EPP optimistic concurrency
 #define VID_DELETED_RULE_LIST_BASE  ((uint32_t)0x7A000000)

--- a/src/client/java/netxms-client/src/main/java/org/netxms/client/NXCSession.java
+++ b/src/client/java/netxms-client/src/main/java/org/netxms/client/NXCSession.java
@@ -2926,23 +2926,60 @@ public class NXCSession
     * Request new authentication token from server.
     *
     * @param persistent true to request persistent token
-    * @param validFor token validity time in seconds
-    * @param description optional token description (can be null)
+    * @param validFor token validity time in seconds; must be greater than 0. For a persistent token the resulting expiration
+    *           time must not be later than 2038-01-19T03:14:07Z, because server stores it in a 32-bit database column.
+    * @param description optional token description (can be null); limited to 127 characters, because server stores a persistent
+    *           token in a fixed size database column and applies the same limit to all token types
     * @param userId user ID to issue token for (0 to indicate currently logged in user)
-    * @return token ID for persistent tokens or 0 for ephemeral
+    * @return issued authentication token, including its clear-text value
     * @throws IOException if socket I/O error occurs
-    * @throws NXCException if NetXMS server returns an error or operation was timed out
+    * @throws NXCException if NetXMS server returns an error or operation was timed out (INVALID_ARGUMENT if validity time or
+    *            description is out of range, INVALID_USER_ID if token cannot be issued for given user)
     */
    public AuthenticationToken requestAuthenticationToken(boolean persistent, int validFor, String description, int userId) throws IOException, NXCException
+   {
+      return requestAuthenticationToken(persistent, validFor, description, userId, false);
+   }
+
+   /**
+    * Request new authentication token from server.
+    *
+    * @param persistent true to request persistent token
+    * @param validFor token validity time in seconds; must be greater than 0. For a persistent token the resulting expiration
+    *           time must not be later than 2038-01-19T03:14:07Z, because server stores it in a 32-bit database column.
+    * @param description optional token description (can be null); limited to 127 characters, because server stores a persistent
+    *           token in a fixed size database column and applies the same limit to all token types
+    * @param userId user ID to issue token for (0 to indicate currently logged in user)
+    * @param singleUse true to request single-use token, which is destroyed by the login it authenticates. Cannot be combined with
+    *           persistent token request.
+    * @return issued authentication token, including its clear-text value
+    * @throws IOException if socket I/O error occurs
+    * @throws NXCException if NetXMS server returns an error or operation was timed out (INVALID_ARGUMENT if validity time or
+    *            description is out of range or single-use token is requested together with persistent one, INVALID_USER_ID if
+    *            token cannot be issued for given user, NOT_IMPLEMENTED if single-use token was requested from a server that does
+    *            not support them)
+    */
+   public AuthenticationToken requestAuthenticationToken(boolean persistent, int validFor, String description, int userId,
+         boolean singleUse) throws IOException, NXCException
    {
       NXCPMessage request = newMessage(NXCPCodes.CMD_REQUEST_AUTH_TOKEN);
       request.setField(NXCPCodes.VID_PERSISTENT, persistent);
       request.setFieldInt32(NXCPCodes.VID_VALIDITY_TIME, validFor);
       request.setFieldInt32(NXCPCodes.VID_USER_ID, userId);
       request.setField(NXCPCodes.VID_DESCRIPTION, description);
+      request.setField(NXCPCodes.VID_SINGLE_USE, singleUse);
       sendMessage(request);
       NXCPMessage response = waitForRCC(request.getMessageId());
-      return new AuthenticationToken(response, NXCPCodes.VID_ELEMENT_LIST_BASE);
+      AuthenticationToken token = new AuthenticationToken(response, NXCPCodes.VID_ELEMENT_LIST_BASE);
+
+      // Server not supporting single-use tokens ignores the request and issues an ordinary reusable token,
+      // which would silently break the one-shot guarantee expected by the caller
+      if (singleUse && !token.isSingleUse())
+      {
+         logger.warn("Server issued reusable token in response to single-use token request");
+         throw new NXCException(RCC.NOT_IMPLEMENTED);
+      }
+      return token;
    }
 
    /**
@@ -2977,7 +3014,7 @@ public class NXCSession
       int count = response.getFieldAsInt32(NXCPCodes.VID_NUM_ELEMENTS);
       long fieldId = NXCPCodes.VID_ELEMENT_LIST_BASE;
       List<AuthenticationToken> tokens = new ArrayList<>(count);
-      for(int i = 0; i < count; i++)
+      for(int i = 0; i < count; i++, fieldId += 10)
          tokens.add(new AuthenticationToken(response, fieldId));
       return tokens;
    }

--- a/src/client/java/netxms-client/src/main/java/org/netxms/client/users/AuthenticationToken.java
+++ b/src/client/java/netxms-client/src/main/java/org/netxms/client/users/AuthenticationToken.java
@@ -33,6 +33,7 @@ public class AuthenticationToken
    private String value;
    private Date creationTime;
    private Date expirationTime;
+   private boolean singleUse;
 
    /**
     * Create token information object from NXCP message.
@@ -49,6 +50,7 @@ public class AuthenticationToken
       value = msg.getFieldAsString(baseId + 4);
       creationTime = msg.getFieldAsDate(baseId + 5);
       expirationTime = msg.getFieldAsDate(baseId + 6);
+      singleUse = msg.getFieldAsBoolean(baseId + 8);
    }
 
    /**
@@ -84,7 +86,9 @@ public class AuthenticationToken
    }
 
    /**
-    * Get token value. Normally it is available only for newly created tokens.
+    * Get token value. Available for as long as the server keeps the token in memory, which covers newly issued tokens and any
+    * live ephemeral, single-use or persistent token issued since the last server restart. Persistent tokens reloaded from the
+    * database no longer carry it.
     *
     * @return token value (can be null or empty string if unavailable)
     */
@@ -107,5 +111,16 @@ public class AuthenticationToken
    public Date getExpirationTime()
    {
       return expirationTime;
+   }
+
+   /**
+    * Check if this token is single-use. Such token is destroyed by the login it authenticates and cannot be presented as REST
+    * bearer credential.
+    *
+    * @return true if this token is single-use
+    */
+   public boolean isSingleUse()
+   {
+      return singleUse;
    }
 }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/dialogs/IssueTokenDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/dialogs/IssueTokenDialog.java
@@ -48,6 +48,16 @@ import org.xnap.commons.i18n.I18n;
  */
 public class IssueTokenDialog extends Dialog
 {
+   /**
+    * Latest expiration time server accepts for a persistent token - it is stored in a 32-bit database column.
+    */
+   private static final long MAX_EXPIRATION_TIME = 0x7FFFFFFFL;
+
+   /**
+    * Longest description server accepts - it is stored in a fixed size database column.
+    */
+   private static final int MAX_DESCRIPTION_LENGTH = 127;
+
    private I18n i18n = LocalizationHelper.getI18n(IssueTokenDialog.class);
 
    private int userId;
@@ -98,6 +108,7 @@ public class IssueTokenDialog extends Dialog
 
       description = new LabeledText(dialogArea, SWT.NONE);
       description.setLabel(i18n.tr("Description"));
+      description.setTextLimit(MAX_DESCRIPTION_LENGTH);
       GridData gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
       gd.horizontalAlignment = SWT.FILL;
@@ -143,9 +154,22 @@ public class IssueTokenDialog extends Dialog
    @Override
    protected void okPressed()
    {
+      final long expiration = expirationTime.getValue().getTime() / 1000;
+      final long validFor = expiration - System.currentTimeMillis() / 1000;
+      if (validFor <= 0)
+      {
+         MessageDialogHelper.openWarning(getShell(), i18n.tr("Warning"), i18n.tr("Expiration time must be in the future"));
+         return;
+      }
+      if (expiration > MAX_EXPIRATION_TIME)
+      {
+         MessageDialogHelper.openWarning(getShell(), i18n.tr("Warning"), i18n.tr("Expiration time cannot be later than 2038-01-19"));
+         return;
+      }
+
       final NXCSession session = Registry.getSession();
       final String d = description.getText().trim();
-      final int v = (int)((expirationTime.getValue().getTime() - System.currentTimeMillis()) / 1000);
+      final int v = (int)validFor;
       new Job("Issuing authentication token", null) {
          @Override
          protected void run(IProgressMonitor monitor) throws Exception

--- a/src/java-common/netxms-base/src/main/java/org/netxms/base/NXCPCodes.java
+++ b/src/java-common/netxms-base/src/main/java/org/netxms/base/NXCPCodes.java
@@ -1602,6 +1602,7 @@ public class NXCPCodes
    public static final long VID_MARKDOWN = 1023;
    public static final long VID_AGENT_TLS_MODE = 1024;
    public static final long VID_AGENT_CERT_FINGERPRINT = 1025;
+   public static final long VID_SINGLE_USE = 1026;
 
    public static final long VID_SKILL_LIST_BASE = 0x50000000L;
    public static final long VID_TRANSLATION_LIST_BASE = 0x68000000L;

--- a/src/server/CLAUDE.md
+++ b/src/server/CLAUDE.md
@@ -15,6 +15,8 @@ extern NXCORE_EXPORTABLE_VAR(int) g_myGlobal;
 
 When exporting a function for module use, also export the sibling functions declared alongside it in the same header group (unless clearly internal) — a module rarely calls exactly one function from a subsystem, and exporting the whole family up front avoids a churn of one-symbol export edits and rebuild/reinstall cycles later.
 
+The converse also matters: a missing `NXCORE_EXPORTABLE` on a function declared in a server header can be deliberate. Leaving it off keeps the symbol reachable only from within core, which is how a security-sensitive primitive is restricted to a single call site — the linker enforces the rule instead of a comment. `ConsumeAuthenticationToken()` (`include/nms_users.h`) is the reference case: it is the sole spend point for single-use authentication tokens and is undecorated on purpose. Before adding the decoration to an undecorated declaration, check for a comment explaining why it is absent.
+
 ## String Handling
 
 Server code is always built in Unicode mode. Use `L"..."` string literals and wide-character functions (`wcsncmp`, `wcslen`, etc.) directly. Do **not** use `_T()` / `TCHAR` / `_tcsncmp` wrappers in new server code — those are remnants from older versions that supported non-Unicode builds. The `_T()` abstraction is only needed in agent code and shared libraries that may be built in either mode.
@@ -261,6 +263,7 @@ nxlog_debug_tag(_T("session"), level, ...)    # Client sessions
 
 - SSH Interactive Sessions: `doc/SSH_Interactive_Sessions_Design.md`
 - AI Incident Management: `doc/AI_Incident_Management_Integration_Design.md`
+- Single-Use Authentication Tokens: `doc/Single_Use_Authentication_Tokens.md`
 
 ## Related Components
 

--- a/src/server/core/authtokens.cpp
+++ b/src/server/core/authtokens.cpp
@@ -117,13 +117,33 @@ void LoadAuthenticationTokens()
 }
 
 /**
+ * Get display name for authentication token type
+ */
+const wchar_t NXCORE_EXPORTABLE *AuthenticationTokenTypeName(AuthenticationTokenType type)
+{
+   switch(type)
+   {
+      case AuthenticationTokenType::PERSISTENT:
+         return L"persistent";
+      case AuthenticationTokenType::SERVICE:
+         return L"service";
+      case AuthenticationTokenType::SINGLE_USE:
+         return L"single-use";
+      default:
+         return L"ephemeral";
+   }
+}
+
+/**
  * Issue authentication token
  *
  * @param userId User ID for this token
  * @param validFor Initial validity period in seconds
- * @param type Token type (ephemeral, persistent, or service)
+ * @param type Token type (ephemeral, persistent, service, or single-use)
  * @param description Optional description
  * @param maxLifetime Maximum absolute lifetime in seconds (0 = use configured default for ephemeral, no limit for persistent)
+ * @return descriptor of the issued token, or nullptr if the token cannot be issued (user ID refers to a group or to an
+ *         unknown user, or a persistent token would be issued already expired). Callers must check the returned pointer.
  */
 shared_ptr<AuthenticationTokenDescriptor> NXCORE_EXPORTABLE IssueAuthenticationToken(uint32_t userId, uint32_t validFor, AuthenticationTokenType type, const wchar_t *description, uint32_t maxLifetime)
 {
@@ -142,6 +162,24 @@ shared_ptr<AuthenticationTokenDescriptor> NXCORE_EXPORTABLE IssueAuthenticationT
    }
 
    auto descriptor = make_shared<AuthenticationTokenDescriptor>(userId, validFor, type, description, effectiveMaxLifetime);
+
+   // Expiration time of a persistent token is stored in 32-bit database column and is clamped to
+   // MAX_PERSISTENT_TOKEN_EXPIRATION_TIME, so past that point any persistent token would be issued
+   // already expired. Check the constructed descriptor instead of the clock, so that clamping and
+   // validation always see the same issuing time. Both request handlers reject an out of range
+   // expiration time before reaching this point, so only internal callers can be clamped here.
+   if (type == AuthenticationTokenType::PERSISTENT)
+   {
+      if (static_cast<int64_t>(descriptor->issuingTime) + validFor > MAX_PERSISTENT_TOKEN_EXPIRATION_TIME)
+         nxlog_write_tag(NXLOG_WARNING, DEBUG_TAG, L"Expiration time of persistent authentication token for user %s [%u] clamped to 2038-01-19T03:14:07Z", userName, userId);
+
+      if (descriptor->expirationTime <= descriptor->issuingTime)
+      {
+         nxlog_write_tag(NXLOG_WARNING, DEBUG_TAG, L"Cannot issue persistent authentication token for user %s [%u]: token would be already expired", userName, userId);
+         return shared_ptr<AuthenticationTokenDescriptor>();
+      }
+   }
+
    s_tokens.set(descriptor->hash, descriptor);
 
    if (type == AuthenticationTokenType::PERSISTENT)
@@ -174,7 +212,7 @@ shared_ptr<AuthenticationTokenDescriptor> NXCORE_EXPORTABLE IssueAuthenticationT
    else
    {
       nxlog_debug_tag(DEBUG_TAG, 6, _T("New %s authentication token issued for user %s [%u]"),
-         (type == AuthenticationTokenType::SERVICE) ? L"service" : L"ephemeral", userName, userId);
+         AuthenticationTokenTypeName(type), userName, userId);
    }
 
    return descriptor;
@@ -202,7 +240,7 @@ void NXCORE_EXPORTABLE RevokeAuthenticationToken(const UserAuthenticationToken& 
    {
       s_tokens.remove(hash);
       nxlog_debug_tag(DEBUG_TAG, 4, _T("User authentication token \"%s\" was revoked"), token.toMaskedString().cstr());
-      if (descriptor->persistent)
+      if (descriptor->type == AuthenticationTokenType::PERSISTENT)
          DeleteAuthenticationTokenFromDB(descriptor->tokenId);
    }
 }
@@ -212,6 +250,11 @@ void NXCORE_EXPORTABLE RevokeAuthenticationToken(const UserAuthenticationToken& 
  */
 uint32_t NXCORE_EXPORTABLE RevokeAuthenticationToken(uint32_t tokenId, uint32_t userId)
 {
+   // Only persistent tokens are assigned an ID; ephemeral and service tokens all carry 0, so
+   // a lookup by ID 0 would match an arbitrary one of them instead of the intended token
+   if (tokenId == 0)
+      return RCC_INVALID_TOKEN_ID;
+
    shared_ptr<AuthenticationTokenDescriptor> descriptor = s_tokens.findElement(
       [tokenId] (const UserAuthenticationTokenHash& key, const AuthenticationTokenDescriptor& descriptor) -> bool
       {
@@ -225,7 +268,7 @@ uint32_t NXCORE_EXPORTABLE RevokeAuthenticationToken(uint32_t tokenId, uint32_t 
 
    s_tokens.remove(descriptor->hash);
    nxlog_debug_tag(DEBUG_TAG, 4, _T("User authentication token [%u] was revoked"), tokenId);
-   if (descriptor->persistent)
+   if (descriptor->type == AuthenticationTokenType::PERSISTENT)
       DeleteAuthenticationTokenFromDB(tokenId);
    return RCC_SUCCESS;
 }
@@ -249,24 +292,26 @@ void NXCORE_EXPORTABLE RevokeAuthenticationTokensForUser(uint32_t userId)
       AuthenticationTokenDescriptor *d = tokensToRevoke.get(i);
       s_tokens.remove(d->hash);
       nxlog_debug_tag(DEBUG_TAG, 4, _T("Revoked authentication token [%u] for deleted user [%u]"), d->tokenId, userId);
-      if (d->persistent)
+      if (d->type == AuthenticationTokenType::PERSISTENT)
          DeleteAuthenticationTokenFromDB(d->tokenId);
    }
 }
 
 /**
- * Authenticate user with token. If validFor is non-zero, token expiration time will be set to current time + provided value,
- * but not exceeding the maximum expiration time (absolute token lifetime cap).
+ * Common implementation for authentication token validation and consumption. If validFor is non-zero, token expiration time
+ * will be set to current time + provided value, but not exceeding the maximum expiration time (absolute token lifetime cap).
  *
  * @param token Authentication token to validate
+ * @param consuming true if called from the designated spend point, in which case a single-use token is accepted and destroyed
  * @param userId Output: user ID associated with the token
- * @param serviceToken Output: true if this is a service token
+ * @param tokenType Output: type of the token
  * @param validFor If non-zero, extend token expiration by this many seconds
  * @param expiresAt Output: token expiration time (for warning header calculation)
  * @param maxExpiresAt Output: maximum token expiration time (0 if no limit)
  * @return true if token is valid
  */
-bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId, bool *serviceToken, uint32_t validFor, time_t *expiresAt, time_t *maxExpiresAt)
+static bool ProcessAuthenticationToken(const UserAuthenticationToken& token, bool consuming, uint32_t *userId,
+   AuthenticationTokenType *tokenType, uint32_t validFor, time_t *expiresAt, time_t *maxExpiresAt)
 {
    UserAuthenticationTokenHash hash;
    CalculateSHA256Hash(token.value(), USER_AUTHENTICATION_TOKEN_LENGTH, hash);
@@ -283,7 +328,7 @@ bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken
    {
       s_tokens.remove(hash);
       nxlog_debug_tag(DEBUG_TAG, 4, _T("User authentication token [%u] \"%s\" has reached maximum lifetime"), descriptor->tokenId, token.toMaskedString().cstr());
-      if (descriptor->persistent)
+      if (descriptor->type == AuthenticationTokenType::PERSISTENT)
          DeleteAuthenticationTokenFromDB(descriptor->tokenId);
       return false;
    }
@@ -292,10 +337,32 @@ bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken
    {
       s_tokens.remove(hash);
       nxlog_debug_tag(DEBUG_TAG, 4, _T("User authentication token [%u] \"%s\" has expired"), descriptor->tokenId, token.toMaskedString().cstr());
-      if (descriptor->persistent)
+      if (descriptor->type == AuthenticationTokenType::PERSISTENT)
          DeleteAuthenticationTokenFromDB(descriptor->tokenId);
       return false;
    }
+
+   if (descriptor->type == AuthenticationTokenType::SINGLE_USE)
+   {
+      if (!consuming)
+      {
+         nxlog_debug_tag(DEBUG_TAG, 4, L"Single-use authentication token [%u] \"%s\" presented outside of login entry point",
+            descriptor->tokenId, token.toMaskedString().cstr());
+         return false;
+      }
+
+      // Token is burnt as soon as it is claimed, even if the login it was claimed for subsequently fails -
+      // a one-shot credential that survives a failed attempt would be a retry oracle.
+      if (InterlockedIncrement(&descriptor->claimed) != 1)
+      {
+         nxlog_debug_tag(DEBUG_TAG, 4, L"Single-use authentication token [%u] \"%s\" was already consumed",
+            descriptor->tokenId, token.toMaskedString().cstr());
+         return false;
+      }
+      s_tokens.remove(hash);
+      nxlog_debug_tag(DEBUG_TAG, 5, L"Single-use authentication token [%u] \"%s\" consumed", descriptor->tokenId, token.toMaskedString().cstr());
+   }
+
    if (validFor > 0)
    {
       // Extend expiration time but do not exceed maximum expiration time (if set) and never shorten existing expiration
@@ -306,13 +373,34 @@ bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken
          descriptor->expirationTime = newExpiration;
    }
    *userId = descriptor->userId;
-   if (serviceToken != nullptr)
-      *serviceToken = descriptor->service;
+   if (tokenType != nullptr)
+      *tokenType = descriptor->type;
    if (expiresAt != nullptr)
       *expiresAt = descriptor->expirationTime;
    if (maxExpiresAt != nullptr)
       *maxExpiresAt = descriptor->maxExpirationTime;
    return true;
+}
+
+/**
+ * Validate authentication token. Never consumes the token, and always rejects single-use tokens -
+ * those can only be spent by ConsumeAuthenticationToken().
+ */
+bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId, uint32_t validFor, time_t *expiresAt, time_t *maxExpiresAt)
+{
+   return ProcessAuthenticationToken(token, false, userId, nullptr, validFor, expiresAt, maxExpiresAt);
+}
+
+/**
+ * Validate authentication token and consume it if it is single-use. This is the single designated spend
+ * point for single-use tokens and must be called from client session login only.
+ *
+ * Deliberately not marked as NXCORE_EXPORTABLE: the only caller lives in the same shared library, and
+ * leaving the decoration off keeps the spend primitive out of reach of server modules.
+ */
+bool ConsumeAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId, AuthenticationTokenType *tokenType)
+{
+   return ProcessAuthenticationToken(token, true, userId, tokenType, 0, nullptr, nullptr);
 }
 
 /**
@@ -341,7 +429,7 @@ void CheckUserAuthenticationTokens(const shared_ptr<ScheduledTaskParameters>& pa
       AuthenticationTokenDescriptor *d = expiredTokens.get(i);
       const UserAuthenticationTokenHash& hash = d->hash;
       s_tokens.remove(hash);
-      if (d->persistent)
+      if (d->type == AuthenticationTokenType::PERSISTENT)
          DeleteAuthenticationTokenFromDB(d->tokenId);
    }
 }
@@ -388,18 +476,17 @@ json_t NXCORE_EXPORTABLE *AuthenticationTokensToJson(uint32_t userId)
  */
 void ShowAuthenticationTokens(ServerConsole *console)
 {
-   console->printf(_T(" %-10s | %s | %-32s | %-6s | %-24s | %s\n"), _T("ID"), _T("Flags"), _T("Token"), _T("UID"), _T("User name"), _T("Expires at"));
-   console->printf(_T("------------+-------+----------------------------------+--------+--------------------------+----------------------\n"));
+   console->printf(L" %-10s | %-10s | %-32s | %-6s | %-24s | %s\n", L"ID", L"Type", L"Token", L"UID", L"User name", L"Expires at");
+   console->printf(L"------------+------------+----------------------------------+--------+--------------------------+----------------------\n");
    s_tokens.forEach(
       [console] (const UserAuthenticationTokenHash& key, const shared_ptr<AuthenticationTokenDescriptor>& descriptor) -> EnumerationCallbackResult
       {
-         TCHAR userName[MAX_USER_NAME];
-         console->printf(_T(" %10u | %c%c%c   | %-32s | %6u | %-24s | %s\n"),
+         wchar_t userName[MAX_USER_NAME];
+         console->printf(L" %10u | %-10s | %-32s | %6u | %-24s | %s\n",
             descriptor->tokenId,
-            descriptor->persistent ? _T('P') : _T('-'), descriptor->service ? _T('S') : _T('-'),
-            descriptor->validClearText ? _T('V') : _T('-'),
-            descriptor->validClearText ? descriptor->token.toString().cstr() : _T("unavailable"),
-            descriptor->userId, ResolveUserId(descriptor->userId, userName),
+            AuthenticationTokenTypeName(descriptor->type),
+            descriptor->validClearText ? descriptor->token.toString().cstr() : L"unavailable",
+            descriptor->userId, ResolveUserId(descriptor->userId, userName, true),
             FormatTimestamp(descriptor->expirationTime).cstr());
          return _CONTINUE;
       });

--- a/src/server/core/reporting.cpp
+++ b/src/server/core/reporting.cpp
@@ -362,6 +362,24 @@ NXCPMessage *ForwardMessageToReportingServer(NXCPMessage *request, ClientSession
          s_fileRequestLock.unlock();
          break;
       case CMD_RS_EXECUTE_REPORT:
+         // Issue authentication token for reporting server (valid for 5 minutes). User could have been
+         // deleted while the session is still open, in which case no token can be issued for it. Token is
+         // issued before data view preparation so that this failure path has nothing to clean up.
+         {
+            shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(session->getUserId(), 300, AuthenticationTokenType::SERVICE);
+            if (token == nullptr)
+            {
+               nxlog_debug_tag(DEBUG_TAG, 3, L"Cannot execute report %s (cannot issue authentication token for user [%u])",
+                  request->getFieldAsGUID(VID_REPORT_DEFINITION).toString().cstr(), session->getUserId());
+               // Reported as invalid user ID rather than by returning nullptr, which the caller
+               // translates into RCC_COMM_FAILURE - the reporting server connection is intact here
+               auto response = new NXCPMessage(CMD_REQUEST_COMPLETED, originalId);
+               response->setField(VID_RCC, RCC_INVALID_USER_ID);
+               return response;
+            }
+            request->setField(VID_AUTH_TOKEN, token->token.toString());
+         }
+
          if (IsDataViewRequired(request->getFieldAsGUID(VID_REPORT_DEFINITION)) && PrepareReportingDataView(session->getUserId(), viewName))
          {
             request->setField(VID_VIEW_NAME, viewName);
@@ -370,17 +388,18 @@ NXCPMessage *ForwardMessageToReportingServer(NXCPMessage *request, ClientSession
          {
             nxlog_debug_tag(DEBUG_TAG, 5, _T("Data view is not required or cannot be prepared for report %s"), request->getFieldAsGUID(VID_REPORT_DEFINITION).toString().cstr());
          }
-
-         // Issue authentication token for reporting server (valid for 5 minutes)
-         request->setField(VID_AUTH_TOKEN, IssueAuthenticationToken(session->getUserId(), 300, AuthenticationTokenType::SERVICE)->token.toString());
          break;
    }
 
    NXCPMessage *reply = nullptr;
    if (s_connector->sendMessage(request))
    {
-      reply = s_connector->waitForMessage(CMD_REQUEST_COMPLETED, request->getId(), 600000);
+      reply = s_connector->waitForMessage(CMD_REQUEST_COMPLETED, rqId, 600000);
    }
+
+   // Restore original message ID, so that a response built by the caller after this function
+   // returns nullptr is matched with the client request instead of carrying the internal ID
+   request->setId(originalId);
 
    if (reply != nullptr)
    {
@@ -413,15 +432,24 @@ void ExecuteReport(const shared_ptr<ScheduledTaskParameters>& parameters)
    uuid reportId = jobConfig.getValueAsUUID(L"/reportId");
    nxlog_debug_tag(DEBUG_TAG, 3, L"Preparing execution of report %s (%s)", reportId.toString().cstr(), parameters->m_comments);
 
+   // Issue authentication token for reporting server (valid for 5 minutes). User could have been
+   // deleted after the task was scheduled, in which case no token can be issued for it. Token is
+   // issued before data view preparation so that this failure path has nothing to clean up.
+   shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(parameters->m_userId, 300, AuthenticationTokenType::SERVICE);
+   if (token == nullptr)
+   {
+      nxlog_debug_tag(DEBUG_TAG, 3, L"Cannot execute scheduled report \"%s\" (cannot issue authentication token for user [%u])",
+         parameters->m_comments, parameters->m_userId);
+      return;
+   }
+   request.setField(VID_AUTH_TOKEN, token->token.toString());
+
    // Prepare data view if needed
    wchar_t viewName[MAX_OBJECT_NAME] = L"";
    if (IsDataViewRequired(reportId) && PrepareReportingDataView(parameters->m_userId, viewName))
       request.setField(VID_VIEW_NAME, viewName);
    else
       nxlog_debug_tag(DEBUG_TAG, 5, _T("Data view is not required or cannot be prepared for report %s"), reportId.toString().cstr());
-
-   // Issue authentication token for reporting server (valid for 5 minutes)
-   request.setField(VID_AUTH_TOKEN, IssueAuthenticationToken(parameters->m_userId, 300, AuthenticationTokenType::SERVICE)->token.toString());
 
    if (s_connector->sendMessage(&request))
    {

--- a/src/server/core/session.cpp
+++ b/src/server/core/session.cpp
@@ -2567,17 +2567,20 @@ uint32_t ClientSession::authenticateUserByToken(const NXCPMessage& request, Logi
    if (!token.isNull())
    {
       uint32_t userId;
-      bool serviceToken;
-      if (ValidateAuthenticationToken(token, &userId, &serviceToken))
+      AuthenticationTokenType tokenType = AuthenticationTokenType::EPHEMERAL;
+      if (ConsumeAuthenticationToken(token, &userId, &tokenType))
       {
+         if (tokenType == AuthenticationTokenType::SINGLE_USE)
+            debugPrintf(5, L"Single-use authentication token consumed");
+
          if (ResolveUserId(userId, loginInfo->loginName) != nullptr)
          {
             debugPrintf(5, _T("Authentication token is valid, login name %s"), loginInfo->loginName);
             rcc = AuthenticateUser(loginInfo->loginName, nullptr, 0, nullptr, nullptr, &m_userId, &m_systemAccessRights,
                   &loginInfo->changePassword, &loginInfo->intruderLockout, &loginInfo->closeOtherSessions, true, &loginInfo->graceLogins);
 
-            // Cancel "close other session" if authenticated with service token
-            if (serviceToken)
+            // Cancel "close other session" if authenticated with handoff token
+            if ((tokenType == AuthenticationTokenType::SERVICE) || (tokenType == AuthenticationTokenType::SINGLE_USE))
                loginInfo->closeOtherSessions = false;
          }
          else
@@ -3012,9 +3015,13 @@ uint32_t ClientSession::finalizeLogin(const NXCPMessage& request, NXCPMessage *r
       debugPrintf(3, _T("User %s authenticated (language=%s clientInfo=\"%s\")"), m_sessionName, m_language, m_clientInfo);
       writeAuditLog(AUDIT_SECURITY, true, 0, _T("User \"%s\" logged in (language: %s; client info: %s)"), m_loginInfo->loginName, m_language, m_clientInfo);
 
-      // Issue authentication token that client can use for re-login without re-authentication
+      // Issue authentication token that client can use for re-login without re-authentication.
+      // Absence of the token is not fatal for the session - client will have to re-authenticate.
       shared_ptr<AuthenticationTokenDescriptor> td = IssueAuthenticationToken(m_userId, 300);
-      response->setField(VID_AUTH_TOKEN, td->token.toString());
+      if (td != nullptr)
+         response->setField(VID_AUTH_TOKEN, td->token.toString());
+      else
+         debugPrintf(4, _T("Cannot issue reconnect authentication token for user [%u]"), m_userId);
 
       if (m_loginInfo->closeOtherSessions)
       {
@@ -3047,25 +3054,72 @@ void ClientSession::issueAuthToken(const NXCPMessage& request)
    if ((userId == m_userId) || checkSystemAccessRights(SYSTEM_ACCESS_MANAGE_USERS))
    {
       bool persistent = request.getFieldAsBoolean(VID_PERSISTENT);
-      TCHAR description[128] = _T("");
-      request.getFieldAsString(VID_DESCRIPTION, description, 128);
-      shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(userId, request.getFieldAsUInt32(VID_VALIDITY_TIME),
-         persistent ? AuthenticationTokenType::PERSISTENT : AuthenticationTokenType::EPHEMERAL, description);
-      token->fillMessage(&response, VID_ELEMENT_LIST_BASE);
-      response.setField(VID_RCC, RCC_SUCCESS);
+      bool singleUse = request.getFieldAsBoolean(VID_SINGLE_USE);
+      uint32_t validityTime = request.getFieldAsUInt32(VID_VALIDITY_TIME);
+      wchar_t *description = request.getFieldAsString(VID_DESCRIPTION);
 
-      // Do not write audit log for ephemeral tokens for current user,
-      // because management console request them often to implement reconnects
-      if (userId != m_userId)
+      uint32_t rcc;
+      if (persistent && singleUse)
       {
-         TCHAR buffer[MAX_USER_NAME];
-         writeAuditLog(AUDIT_SECURITY, true, 0, _T("Issued %s authentication token for user %s [%u] (description: %s)"),
-            persistent ? _T("persistent") : _T("ephemeral"), ResolveUserId(userId, buffer, true), userId, description);
+         // Single-use tokens are kept in memory only and cannot be persistent
+         debugPrintf(4, L"issueAuthToken: rejected request for user [%u] (single-use token cannot be persistent)", userId);
+         rcc = RCC_INVALID_ARGUMENT;
       }
-      else if (persistent)
+      else if (validityTime == 0)
       {
-         writeAuditLog(AUDIT_SECURITY, true, 0, _T("Issued persistent authentication token for itself (description: %s)"), description);
+         // Token with zero validity time expires at the moment it is issued and can never authenticate
+         debugPrintf(4, L"issueAuthToken: rejected request for user [%u] (validity time is zero)", userId);
+         rcc = RCC_INVALID_ARGUMENT;
       }
+      else if (persistent && (static_cast<int64_t>(time(nullptr)) + validityTime > MAX_PERSISTENT_TOKEN_EXPIRATION_TIME))
+      {
+         // Such token would be stored with truncated expiration time and become unusable after server restart
+         debugPrintf(4, L"issueAuthToken: rejected request for user [%u] (persistent token expiration time is beyond 2038-01-19T03:14:07Z)", userId);
+         rcc = RCC_INVALID_ARGUMENT;
+      }
+      else if ((description != nullptr) && (wcslen(description) >= MAX_TOKEN_DESCRIPTION_LENGTH))
+      {
+         // Description of a persistent token is stored in a fixed size database column, and an
+         // oversized value would fail the INSERT, leaving a token that disappears on server restart.
+         // Memory-only tokens hold the description in the descriptor until they expire, so the same
+         // limit keeps a client from parking arbitrary amounts of data on the server.
+         debugPrintf(4, L"issueAuthToken: rejected request for user [%u] (description is longer than %d characters)", userId, MAX_TOKEN_DESCRIPTION_LENGTH - 1);
+         rcc = RCC_INVALID_ARGUMENT;
+      }
+      else
+      {
+         AuthenticationTokenType type = persistent ? AuthenticationTokenType::PERSISTENT :
+            (singleUse ? AuthenticationTokenType::SINGLE_USE : AuthenticationTokenType::EPHEMERAL);
+         shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(userId, validityTime, type, CHECK_NULL_EX(description), 0);
+         if (token != nullptr)
+         {
+            token->fillMessage(&response, VID_ELEMENT_LIST_BASE);
+            rcc = RCC_SUCCESS;
+
+            const wchar_t *tokenTypeName = AuthenticationTokenTypeName(type);
+
+            // Do not write audit log for ordinary ephemeral tokens for current user,
+            // because management console request them often to implement reconnects.
+            // Single-use tokens are handoff credentials and are always audited.
+            if (userId != m_userId)
+            {
+               TCHAR buffer[MAX_USER_NAME];
+               writeAuditLog(AUDIT_SECURITY, true, 0, L"Issued %s authentication token for user %s [%u] (description: %s)",
+                  tokenTypeName, ResolveUserId(userId, buffer, true), userId, CHECK_NULL_EX(description));
+            }
+            else if (persistent || singleUse)
+            {
+               writeAuditLog(AUDIT_SECURITY, true, 0, L"Issued %s authentication token for itself (description: %s)", tokenTypeName, CHECK_NULL_EX(description));
+            }
+         }
+         else
+         {
+            // Token cannot be issued for a group or for an unknown user
+            rcc = RCC_INVALID_USER_ID;
+         }
+      }
+      MemFree(description);
+      response.setField(VID_RCC, rcc);
    }
    else
    {
@@ -4191,8 +4245,6 @@ void ClientSession::enableAnonymousObjectAccess(const NXCPMessage& request)
          uint32_t uid = ResolveUserName(_T("anonymous"));
          if (uid != INVALID_UID)
          {
-            object->setUserAccess(uid, OBJECT_ACCESS_READ);
-
             bool validToken = false;
 
             TCHAR tokenText[64];
@@ -4214,9 +4266,21 @@ void ClientSession::enableAnonymousObjectAccess(const NXCPMessage& request)
                StringBuffer description(L"Anonymous access token for object \"");
                description.append(object->getName());
                description.append(L"\"");
-               IssueAuthenticationToken(uid, 3650 * 86400, AuthenticationTokenType::PERSISTENT, description)->token.toString(tokenText);
+               shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(uid, 3650 * 86400, AuthenticationTokenType::PERSISTENT, description);
+               if (token == nullptr)
+               {
+                  debugPrintf(4, L"Cannot enable anonymous access for object \"%s\" [%u] (access token cannot be issued)", object->getName(), object->getId());
+                  response.setField(VID_RCC, RCC_RESOURCE_NOT_AVAILABLE);
+                  sendMessage(response);
+                  return;
+               }
+               token->token.toString(tokenText);
                object->setCustomAttribute(L"$anonymousAccessToken", tokenText, StateChange::CLEAR);
             }
+
+            // Access rights are granted only after a usable token is available, so that a failed
+            // request does not leave the object readable by anonymous user
+            object->setUserAccess(uid, OBJECT_ACCESS_READ);
 
             debugPrintf(4, L"Enabled anonymous access for object \"%s\" [%u]", object->getName(), object->getId());
             writeAuditLog(AUDIT_OBJECTS, true, objectId, L"Enabled anonymous access");

--- a/src/server/core/webapi_auth.cpp
+++ b/src/server/core/webapi_auth.cpp
@@ -73,17 +73,25 @@ void CheckPendingLoginRequests(const shared_ptr<ScheduledTaskParameters>& parame
 }
 
 /**
- * Complete login
+ * Complete login. Returns false if access token cannot be issued (user was deleted after
+ * authentication had started), in which case response document is left untouched.
  */
-static inline void CompleteLogin(json_t *response, const LoginRequest& loginRequest)
+static inline bool CompleteLogin(json_t *response, const LoginRequest& loginRequest)
 {
-   UserAuthenticationToken token = IssueAuthenticationToken(loginRequest.userId, AUTH_TOKEN_VALIDITY_TIME, AuthenticationTokenType::EPHEMERAL, _T("Web access token"))->token;
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueAuthenticationToken(loginRequest.userId, AUTH_TOKEN_VALIDITY_TIME, AuthenticationTokenType::EPHEMERAL, L"Web access token");
+   if (descriptor == nullptr)
+   {
+      nxlog_debug_tag(DEBUG_TAG_WEBAPI, 4, L"Cannot issue web access token for user [%u]", loginRequest.userId);
+      return false;
+   }
+
    char encodedToken[64];
-   json_object_set_new(response, "token", json_string(token.toStringA(encodedToken)));
+   json_object_set_new(response, "token", json_string(descriptor->token.toStringA(encodedToken)));
    json_object_set_new(response, "userId", json_integer(loginRequest.userId));
    json_object_set_new(response, "systemAccessRights", json_integer(loginRequest.systemAccessRights));
    json_object_set_new(response, "changePassword", json_boolean(loginRequest.changePassword));
    json_object_set_new(response, "graceLogins", json_integer(loginRequest.graceLogins));
+   return true;
 }
 
 /**
@@ -111,8 +119,7 @@ static int Process2FAResponse(Context *context)
       if (Validate2FAResponse(loginRequest->token, userResponse, loginRequest->userId, nullptr, nullptr))
       {
          nxlog_debug_tag(DEBUG_TAG_WEBAPI, 6, _T("Two-factor authentication user response validation successful"));
-         CompleteLogin(response, *loginRequest);
-         responseCode = 201;
+         responseCode = CompleteLogin(response, *loginRequest) ? 201 : 500;
       }
       else
       {
@@ -251,10 +258,16 @@ int H_Login(Context *context)
          {
             Decrease2FAGraceLogins(loginRequest.userId);
             nxlog_debug_tag(DEBUG_TAG_WEBAPI, 4, _T("Two-factor authentication enforcement active but not configured, allowing grace login (%d remaining)"), graceLogins - 1);
-            CompleteLogin(response, loginRequest);
-            json_object_set_new(response, "twoFASetupRequired", json_true());
-            json_object_set_new(response, "twoFAGraceLogins", json_integer(graceLogins - 1));
-            responseCode = 201;
+            if (CompleteLogin(response, loginRequest))
+            {
+               json_object_set_new(response, "twoFASetupRequired", json_true());
+               json_object_set_new(response, "twoFAGraceLogins", json_integer(graceLogins - 1));
+               responseCode = 201;
+            }
+            else
+            {
+               responseCode = 500;
+            }
          }
          else
          {
@@ -266,8 +279,7 @@ int H_Login(Context *context)
       else
       {
          nxlog_debug_tag(DEBUG_TAG_WEBAPI, 4, _T("Two-factor authentication is not required (not configured)"));
-         CompleteLogin(response, loginRequest);
-         responseCode = 201;
+         responseCode = CompleteLogin(response, loginRequest) ? 201 : 500;
       }
    }
    else

--- a/src/server/core/webapi_router.cpp
+++ b/src/server/core/webapi_router.cpp
@@ -303,7 +303,7 @@ Context *RouteRequest(MHD_Connection *connection, const char *path, const char *
       }
 
       time_t tokenExpiresAt = 0;
-      if (!ValidateAuthenticationToken(token, &userId, nullptr, AUTH_TOKEN_VALIDITY_TIME, &tokenExpiresAt, &tokenMaxExpiresAt /* updates outer scope var */))
+      if (!ValidateAuthenticationToken(token, &userId, AUTH_TOKEN_VALIDITY_TIME, &tokenExpiresAt, &tokenMaxExpiresAt /* updates outer scope var */))
       {
          char masked[32];
          MaskToken(encodedToken, masked, sizeof(masked));

--- a/src/server/include/auth-token.h
+++ b/src/server/include/auth-token.h
@@ -31,13 +31,27 @@
 #define USER_AUTHENTICATION_TOKEN_LENGTH  20
 
 /**
+ * Latest expiration time that can be assigned to a persistent authentication token. Expiration time
+ * of a persistent token is stored in a 32-bit integer database column, so a token expiring beyond
+ * this point cannot be written back and read as issued.
+ */
+#define MAX_PERSISTENT_TOKEN_EXPIRATION_TIME  _LL(0x7FFFFFFF)
+
+/**
+ * Size of authentication token description buffer, including terminating null character.
+ * Matches width of auth_tokens.description database column.
+ */
+#define MAX_TOKEN_DESCRIPTION_LENGTH  128
+
+/**
  * Authentication token types
  */
 enum class AuthenticationTokenType
 {
    EPHEMERAL = 0,    // Not saved to database, usually short-lived
    PERSISTENT = 1,   // Saved to database, usually with long expiration time
-   SERVICE = 2       // Similar to ephemeral but will not trigger existing session disconnect
+   SERVICE = 2,      // Similar to ephemeral but will not trigger existing session disconnect
+   SINGLE_USE = 3    // Memory-only, destroyed by the login that spends it
 };
 
 /**
@@ -73,7 +87,7 @@ public:
    }
    String toString() const
    {
-      TCHAR buffer[64];
+      wchar_t buffer[64];
       return String(toString(buffer));
    }
 
@@ -81,9 +95,9 @@ public:
    {
       String full = toString();
       if (full.length() <= 8)
-         return String(_T("********"));
-      TCHAR buffer[64];
-      _sntprintf(buffer, 64, _T("%.4s****%.4s"), full.cstr(), full.cstr() + full.length() - 4);
+         return String(L"********");
+      wchar_t buffer[64];
+      nx_swprintf(buffer, 64, L"%.4s****%.4s", full.cstr(), full.cstr() + full.length() - 4);
       return String(buffer);
    }
 
@@ -109,12 +123,12 @@ struct NXCORE_EXPORTABLE AuthenticationTokenDescriptor
    UserAuthenticationTokenHash hash;
    uint32_t tokenId;
    uint32_t userId;
+   AuthenticationTokenType type;
    time_t issuingTime;
    time_t expirationTime;
    time_t maxExpirationTime;  // Absolute maximum expiration time (cannot be extended beyond this)
-   bool persistent;
-   bool service;
-   bool validClearText;
+   VolatileCounter claimed;   // Atomic claim guard for single-use tokens, 0 until consumed
+   bool validClearText;       // Clear-text value is known (false for tokens restored from database)
    String description;
 
    /**
@@ -122,30 +136,42 @@ struct NXCORE_EXPORTABLE AuthenticationTokenDescriptor
     *
     * @param uid User ID for this token
     * @param validFor Initial validity period in seconds
-    * @param type Token type (ephemeral, persistent, or service)
+    * @param _type Token type (ephemeral, persistent, service, or single-use)
     * @param _description Optional description
-    * @param maxLifetime Maximum absolute lifetime in seconds (0 = no limit, only for ephemeral/service tokens)
+    * @param maxLifetime Maximum absolute lifetime in seconds (0 = no limit, only for non-persistent tokens)
     */
-   AuthenticationTokenDescriptor(uint32_t uid, uint32_t validFor, AuthenticationTokenType type, const TCHAR *_description, uint32_t maxLifetime = 0) : description(_description)
+   AuthenticationTokenDescriptor(uint32_t uid, uint32_t validFor, AuthenticationTokenType _type, const wchar_t *_description, uint32_t maxLifetime = 0) : description(_description)
    {
       BYTE bytes[USER_AUTHENTICATION_TOKEN_LENGTH];
       GenerateRandomBytes(bytes, USER_AUTHENTICATION_TOKEN_LENGTH);
       token = UserAuthenticationToken(bytes);
       CalculateSHA256Hash(bytes, USER_AUTHENTICATION_TOKEN_LENGTH, hash);
-      tokenId = (type == AuthenticationTokenType::PERSISTENT) ? CreateUniqueId(IDG_AUTHTOKEN) : 0;
+      tokenId = (_type == AuthenticationTokenType::PERSISTENT) ? CreateUniqueId(IDG_AUTHTOKEN) : 0;
       userId = uid;
+      type = _type;
       issuingTime = time(nullptr);
       expirationTime = issuingTime + validFor;
       // For persistent tokens, max expiration is the original expiration (no refresh extension allowed)
-      // For ephemeral/service tokens, max expiration is configurable (0 = no limit)
-      if (type == AuthenticationTokenType::PERSISTENT)
+      // For other token types, max expiration is configurable (0 = no limit)
+      if (_type == AuthenticationTokenType::PERSISTENT)
+      {
+         // Clamp to what the database column can hold, so that the token is always stored
+         // and read back exactly as reported to the caller
+         if (expirationTime > MAX_PERSISTENT_TOKEN_EXPIRATION_TIME)
+            expirationTime = MAX_PERSISTENT_TOKEN_EXPIRATION_TIME;
          maxExpirationTime = expirationTime;
+      }
       else if (maxLifetime > 0)
+      {
          maxExpirationTime = issuingTime + maxLifetime;
+         // Token stops authenticating at the absolute cap, so reporting a later expiration
+         // time to the caller would promise validity the token will never have
+         if (expirationTime > maxExpirationTime)
+            expirationTime = maxExpirationTime;
+      }
       else
          maxExpirationTime = 0;  // No absolute limit
-      persistent = (type == AuthenticationTokenType::PERSISTENT);
-      service = (type == AuthenticationTokenType::SERVICE);
+      claimed = 0;
       validClearText = true;
    }
 
@@ -156,16 +182,16 @@ struct NXCORE_EXPORTABLE AuthenticationTokenDescriptor
    {
       tokenId = DBGetFieldUInt32(hResult, row, 0);
       userId = DBGetFieldUInt32(hResult, row, 1);
+      type = AuthenticationTokenType::PERSISTENT;
       issuingTime = static_cast<time_t>(DBGetFieldInt64(hResult, row, 2));
       expirationTime = static_cast<time_t>(DBGetFieldInt64(hResult, row, 3));
       maxExpirationTime = expirationTime;  // Persistent tokens cannot be extended beyond original expiration
 
-      TCHAR text[128];
+      wchar_t text[128];
       DBGetField(hResult, row, 5, text, 128);
       StrToBin(text, hash, SHA256_DIGEST_SIZE);
 
-      persistent = true;
-      service = false;
+      claimed = 0;
       validClearText = false;
    }
 
@@ -176,7 +202,7 @@ struct NXCORE_EXPORTABLE AuthenticationTokenDescriptor
    {
       msg->setField(baseId, tokenId);
       msg->setField(baseId + 1, userId);
-      msg->setField(baseId + 2, persistent);
+      msg->setField(baseId + 2, type == AuthenticationTokenType::PERSISTENT);
       msg->setField(baseId + 3, description);
       if (validClearText)
       {
@@ -184,20 +210,23 @@ struct NXCORE_EXPORTABLE AuthenticationTokenDescriptor
       }
       msg->setFieldFromTime(baseId + 5, issuingTime);
       msg->setFieldFromTime(baseId + 6, expirationTime);
-      msg->setField(baseId + 7, service);
+      msg->setField(baseId + 7, type == AuthenticationTokenType::SERVICE);
+      msg->setField(baseId + 8, type == AuthenticationTokenType::SINGLE_USE);
    }
 
    /**
-    * Serialize to JSON. The clear-text token value is included only when it is
-    * available (i.e. immediately after the token was issued).
+    * Serialize to JSON. The clear-text token value is included for as long as the descriptor
+    * is held in memory, and is therefore returned by listings as well as by the issue response.
+    * Persistent tokens reloaded from the database after a restart no longer carry it.
     */
    json_t *toJson() const
    {
       json_t *root = json_object();
       json_object_set_new(root, "id", json_integer(tokenId));
       json_object_set_new(root, "userId", json_integer(userId));
-      json_object_set_new(root, "persistent", json_boolean(persistent));
-      json_object_set_new(root, "service", json_boolean(service));
+      json_object_set_new(root, "persistent", json_boolean(type == AuthenticationTokenType::PERSISTENT));
+      json_object_set_new(root, "service", json_boolean(type == AuthenticationTokenType::SERVICE));
+      json_object_set_new(root, "singleUse", json_boolean(type == AuthenticationTokenType::SINGLE_USE));
       json_object_set_new(root, "description", json_string_t(description.cstr()));
       json_object_set_new(root, "issuingTime", json_integer(static_cast<json_int_t>(issuingTime)));
       json_object_set_new(root, "expirationTime", json_integer(static_cast<json_int_t>(expirationTime)));

--- a/src/server/include/nms_users.h
+++ b/src/server/include/nms_users.h
@@ -614,13 +614,33 @@ unique_ptr<ObjectArray<UserDatabaseObject>> NXCORE_EXPORTABLE FindUserDBObjects(
 unique_ptr<ObjectArray<UserDatabaseObject>> NXCORE_EXPORTABLE FindUserDBObjects(const StructArray<ResponsibleUser>& ids);
 NXSL_Value *GetUserDBObjectForNXSL(uint32_t id, NXSL_VM *vm);
 
+const wchar_t NXCORE_EXPORTABLE *AuthenticationTokenTypeName(AuthenticationTokenType type);
+
+/**
+ * Issue authentication token. Returns nullptr if token cannot be issued for given user.
+ */
 shared_ptr<AuthenticationTokenDescriptor> NXCORE_EXPORTABLE IssueAuthenticationToken(uint32_t userId, uint32_t validFor,
    AuthenticationTokenType type = AuthenticationTokenType::EPHEMERAL, const wchar_t *description = nullptr, uint32_t maxLifetime = 0);
 void NXCORE_EXPORTABLE RevokeAuthenticationToken(const UserAuthenticationToken& token);
 uint32_t NXCORE_EXPORTABLE RevokeAuthenticationToken(uint32_t tokenId, uint32_t userId = 0);
 void NXCORE_EXPORTABLE RevokeAuthenticationTokensForUser(uint32_t userId);
-bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId, bool *serviceToken = nullptr,
+
+/**
+ * Validate authentication token. Never consumes the token, and always rejects single-use tokens -
+ * those can only be spent by ConsumeAuthenticationToken().
+ */
+bool NXCORE_EXPORTABLE ValidateAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId,
    uint32_t validFor = 0, time_t *expiresAt = nullptr, time_t *maxExpiresAt = nullptr);
+
+/**
+ * Validate authentication token and consume it if it is single-use. This is the single designated spend
+ * point for single-use tokens and must be called from client session login only.
+ *
+ * Deliberately not marked as NXCORE_EXPORTABLE: the only caller lives in the same shared library, and
+ * leaving the decoration off keeps the spend primitive out of reach of server modules.
+ */
+bool ConsumeAuthenticationToken(const UserAuthenticationToken& token, uint32_t *userId,
+   AuthenticationTokenType *tokenType = nullptr);
 void AuthenticationTokensToMessage(uint32_t userId, NXCPMessage *msg);
 json_t NXCORE_EXPORTABLE *AuthenticationTokensToJson(uint32_t userId);
 

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -3389,6 +3389,11 @@ paths:
                   errorCode:
                     type: integer
                     description: Error code that can provide additional information on login failure reasons.
+        '500':
+          description: |
+            Internal error - credentials were accepted but the access token could not be issued
+            (for example, the user account was deleted while authentication was in progress).
+            No token is returned and the login has to be repeated.
       security: []
       tags:
         - Authentication
@@ -9578,9 +9583,11 @@ paths:
       summary: List user authentication tokens
       description: |
         List active authentication tokens issued for the user. The clear-text token
-        value is never returned here — it is only available in the response to the
-        create operation. A user may list their own tokens; listing another user's
-        tokens requires MANAGE_USERS access right.
+        value is included for tokens still held in memory, which covers live ephemeral
+        tokens (including unspent single-use ones) and persistent tokens issued since
+        the last server restart. Persistent tokens reloaded from the database no longer
+        carry it. A user may list their own tokens; listing another user's tokens
+        requires MANAGE_USERS access right.
       parameters:
         - name: user-id
           in: path
@@ -9612,9 +9619,10 @@ paths:
       summary: Issue user authentication token
       description: |
         Issue a new authentication token for the user. The clear-text token value is
-        returned only in this response and cannot be retrieved afterwards. A user may
-        issue tokens for themselves; issuing tokens for another user requires
-        MANAGE_USERS access right.
+        returned in this response and, while the token is still held in memory, in
+        subsequent listings; persistent tokens reloaded from the database after a server
+        restart no longer carry it. A user may issue tokens for themselves; issuing
+        tokens for another user requires MANAGE_USERS access right.
       parameters:
         - name: user-id
           in: path
@@ -9636,7 +9644,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuthenticationToken'
         '400':
-          description: Invalid user ID or missing/invalid validFor
+          description: |
+            Invalid user ID, missing/invalid validFor, singleUse requested together with
+            persistent (single-use tokens are memory-only and require "persistent": false),
+            a description longer than 127 characters, or a persistent token with an expiration
+            time beyond 2038-01-19T03:14:07Z (neither fits the database columns)
         '401':
           description: Unauthorized
         '403':
@@ -9654,6 +9666,11 @@ paths:
       description: |
         Revoke an authentication token belonging to the user. A user may revoke their
         own tokens; revoking another user's token requires MANAGE_USERS access right.
+
+        Only persistent tokens can be revoked this way, because only they are assigned an ID;
+        a token-id of 0 is rejected with 400. Ephemeral, service and single-use tokens are not
+        revocable individually - they expire, or, for a single-use token, are consumed by the
+        login that spends it.
       parameters:
         - name: user-id
           in: path
@@ -11615,7 +11632,9 @@ components:
       properties:
         id:
           type: integer
-          description: Token ID (0 for ephemeral tokens).
+          description: |
+            Token ID. Assigned only to persistent tokens; ephemeral, service and single-use tokens
+            are always reported with 0 and therefore cannot be revoked by ID.
         userId:
           type: integer
           description: ID of the user the token was issued for.
@@ -11625,6 +11644,13 @@ components:
         service:
           type: boolean
           description: True if this is a service token.
+        singleUse:
+          type: boolean
+          description: |
+            True if the token is single-use. Such a token is destroyed by the login that
+            spends it, so it authenticates exactly one session. It can only be spent on an
+            NXCP login (management console or other NXCP client) and is rejected with 401
+            if presented as a REST bearer credential.
         description:
           type: string
           description: Human-readable token description.
@@ -11636,7 +11662,11 @@ components:
           description: Token expiration time (UNIX timestamp, seconds).
         value:
           type: string
-          description: Clear-text token value. Present only in the response to the create operation; never returned when listing tokens.
+          description: |
+            Clear-text token value. Available only while the token is held in memory, which
+            covers the response to the create operation and any listing of still-live tokens
+            (ephemeral, service or unspent single-use). Persistent tokens reloaded from the
+            database after a server restart no longer carry it.
     AuthenticationTokenCreateInput:
       type: object
       description: Request body for issuing a new authentication token.
@@ -11645,14 +11675,44 @@ components:
       properties:
         validFor:
           type: integer
-          description: Validity period in seconds from now. Must be a positive value.
+          format: int64
+          minimum: 1
+          maximum: 4294967295
+          description: |
+            Validity period in seconds from now. For a persistent token the resulting expiration
+            time is additionally required to be not later than 2038-01-19T03:14:07Z, because it is
+            stored in a 32-bit database column; a longer period is rejected with 400.
+
+            A non-persistent token (ephemeral, service or single-use) is additionally bound by the
+            absolute lifetime cap "WebAPI.AuthTokenMaxLifetime" (24 hours by default). A longer
+            validity period is accepted but silently reduced to the cap, so the returned
+            expirationTime can be earlier than the requested one.
         persistent:
           type: boolean
           default: true
           description: True to issue a persistent (database-backed) token, false for an ephemeral one.
+        singleUse:
+          type: boolean
+          default: false
+          description: |
+            True to issue a single-use token, which is destroyed by the login that spends it
+            and therefore authenticates exactly one session. Intended for handing a session
+            over to another process (for example a launcher spawning the management console).
+
+            A single-use token can only be spent on an NXCP login; presenting it as a REST
+            bearer credential is rejected with 401 and does not consume it.
+
+            Single-use tokens are kept in memory only and do not survive a server restart, so
+            this option requires "persistent" to be false. Because "persistent" defaults to
+            true, a request body containing only "singleUse": true is rejected with 400 -
+            "persistent": false must be sent explicitly.
         description:
           type: string
-          description: Optional human-readable token description.
+          maxLength: 127
+          description: |
+            Optional human-readable token description, limited to 127 characters; a longer value
+            is rejected with 400. The limit is the width of the database column a persistent token
+            is stored in, and is applied to all token types.
     EventProcessingPolicy:
       type: object
       description: Event processing policy - an ordered list of rules plus a version for optimistic concurrency control

--- a/src/server/webapi/users.cpp
+++ b/src/server/webapi/users.cpp
@@ -306,7 +306,8 @@ static bool CheckTokenAccess(Context *context, uint32_t userId)
 /**
  * Handler for GET /v1/users/:user-id/tokens
  * Returns the user's active authentication tokens. Clear-text token values are
- * never returned here (only at creation time).
+ * included only for tokens still held in memory; persistent tokens reloaded from
+ * the database after a restart no longer carry them.
  */
 int H_UserTokens(Context *context)
 {
@@ -328,8 +329,9 @@ int H_UserTokens(Context *context)
 /**
  * Handler for POST /v1/users/:user-id/tokens
  * Issues a new authentication token for the user. Body:
- * { "validFor": <seconds>, "persistent": bool, "description": "..." }.
- * The clear-text token value is returned only in this response.
+ * { "validFor": <seconds>, "persistent": bool, "singleUse": bool, "description": "..." }.
+ * The clear-text token value is returned in this response and, while the token is
+ * still held in memory, in subsequent listings.
  */
 int H_UserTokenCreate(Context *context)
 {
@@ -350,18 +352,45 @@ int H_UserTokenCreate(Context *context)
    }
 
    json_t *jsonValidFor = json_object_get(request, "validFor");
-   if (!json_is_integer(jsonValidFor) || (json_integer_value(jsonValidFor) <= 0))
+   json_int_t validityTime = json_is_integer(jsonValidFor) ? json_integer_value(jsonValidFor) : 0;
+   if ((validityTime <= 0) || (validityTime > UINT32_MAX))
    {
-      context->setErrorResponse("Field \"validFor\" is required and must be a positive number of seconds");
+      context->setErrorResponse("Field \"validFor\" is required and must be a number of seconds in range 1..4294967295");
       return 400;
    }
-   uint32_t validFor = static_cast<uint32_t>(json_integer_value(jsonValidFor));
+   uint32_t validFor = static_cast<uint32_t>(validityTime);
 
    bool persistent = json_object_get_boolean(request, "persistent", true);
-   wchar_t *description = json_object_get_string_t(request, "description", L"");
+   bool singleUse = json_object_get_boolean(request, "singleUse", false);
+   if (persistent && singleUse)
+   {
+      // Single-use tokens are kept in memory only and cannot be persistent. Note that
+      // "persistent" defaults to true, so a body containing only "singleUse" lands here.
+      context->setErrorResponse("Field \"singleUse\" requires \"persistent\" to be set to false");
+      return 400;
+   }
+   if (persistent && (static_cast<int64_t>(time(nullptr)) + validFor > MAX_PERSISTENT_TOKEN_EXPIRATION_TIME))
+   {
+      // Such token would be stored with truncated expiration time and become unusable after server restart
+      context->setErrorResponse("Field \"validFor\" is too large for a persistent token: expiration time must not be later than 2038-01-19T03:14:07Z");
+      return 400;
+   }
 
-   shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(userId, validFor,
-      persistent ? AuthenticationTokenType::PERSISTENT : AuthenticationTokenType::EPHEMERAL, description);
+   wchar_t *description = json_object_get_string_t(request, "description", L"");
+   if (wcslen(description) >= MAX_TOKEN_DESCRIPTION_LENGTH)
+   {
+      // Description of a persistent token is stored in a fixed size database column, and an
+      // oversized value would fail the INSERT, leaving a token that disappears on server restart.
+      // Memory-only tokens hold the description in the descriptor until they expire, so the same
+      // limit keeps a client from parking arbitrary amounts of data on the server.
+      MemFree(description);
+      context->setErrorResponse("Field \"description\" is too long: maximum length is 127 characters");
+      return 400;
+   }
+
+   AuthenticationTokenType type = persistent ? AuthenticationTokenType::PERSISTENT :
+      (singleUse ? AuthenticationTokenType::SINGLE_USE : AuthenticationTokenType::EPHEMERAL);
+   shared_ptr<AuthenticationTokenDescriptor> token = IssueAuthenticationToken(userId, validFor, type, description, 0);
    MemFree(description);
    if (token == nullptr)
    {
@@ -370,7 +399,7 @@ int H_UserTokenCreate(Context *context)
    }
 
    context->writeAuditLog(AUDIT_SECURITY, true, 0, L"Issued %s authentication token [%u] for user [%u]",
-      persistent ? L"persistent" : L"ephemeral", token->tokenId, userId);
+      AuthenticationTokenTypeName(type), token->tokenId, userId);
 
    json_t *output = token->toJson();
    context->setResponseData(output);

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -27,10 +27,11 @@ column below.
 | `test-libnxsnmp/` | SNMP library tests | via `@TEST_MODULES@` |
 | `test-libnxsl/` | NXSL interpreter tests | via `@TEST_MODULES@` |
 | `test-libnxsrv/` | Server library tests (NObject hierarchy, drivers, mock SNMP transport, …) | via `@TEST_MODULES@` |
+| `test-authtokens/` | Authentication token tests — compiles the real `src/server/core/authtokens.cpp` and stubs four core symbols; covers the validate/consume split and the single-use claim race | via `@TEST_MODULES@` |
 | `test-ncd-webhook/` | Webhook notification-channel driver tests | via `@TEST_MODULES@` |
 | `agent/unit/*` | Per-subagent unit tests: `entsoe`, `openmeteo`, `linux-cpu-usage-collector` | via `@AGENT_UNIT_TESTS@` |
 | `ha/` | `ha-node-sim` + Python `harness.py` — adversarial HA lease-manager harness (issue #3364). Compiles the real `src/server/core/halease.cpp` against a shared DB. | via `@TEST_MODULES@` |
-| `integration/` | Java/Maven integration tests (`EppScriptTest`, NXSL resource scripts) against a running server | Maven (separate) |
+| `integration/` | Java/Maven integration tests (`EppScriptTest`, `SingleUseTokenTest`, NXSL resource scripts) against a running server | Maven (separate) |
 | `nx-2488/` | Manual web-service caching repro (SQL patch, NXSL scripts, trivial web server) | manual (not in build) |
 | `tools/` | Standalone Python helpers: `otlp-log-sender`, `otlp-mock-collector` (for OTLP ingestion testing, issue #3292) | manual (not in build) |
 
@@ -118,6 +119,15 @@ Makefile alone is not enough:
 4. Create `tests/<name>/Makefile.w32` (see "Windows build" above) and add the
    directory to `TESTS_DIRS` in the top-level `Makefile.w32`.
 5. Add a `call :RunTest <binary>` line to `suite/netxms-test-suite.cmd`.
+
+A test that compiles a **server core** source directly instead of linking a
+library needs two extra flags in both Makefiles, and missing either one breaks
+only the Windows build: `-DNXCORE_EXPORTS`, without which `NXCORE_EXPORTABLE`
+expands to `__declspec(dllimport)` (`src/server/include/nms_core.h`) and
+defining those symbols is a hard error on MinGW; and `@MICROHTTPD_CPPFLAGS@` /
+`-I$(MICROHTTPD_ROOT)/include` if the source reaches `netxms-webapi.h`, which
+includes `<microhttpd.h>`. Link `libnxsrv` for `ServerConsole` and stub only the
+few remaining core symbols. `test-authtokens/` is the reference example.
 
 For a **new test case in an existing binary**: add the `Test*()` function (new
 `.cpp` if substantial, listed in that dir's `_SOURCES`), declare it in the

--- a/tests/integration/src/test/java/org/netxms/tests/SingleUseTokenTest.java
+++ b/tests/integration/src/test/java/org/netxms/tests/SingleUseTokenTest.java
@@ -1,0 +1,267 @@
+/**
+ * NetXMS - open source network management system
+ * Copyright (C) 2003-2026 Raden Solutions
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.netxms.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.netxms.client.NXCException;
+import org.netxms.client.NXCSession;
+import org.netxms.client.ProtocolVersion;
+import org.netxms.client.constants.RCC;
+import org.netxms.client.users.AbstractUserObject;
+import org.netxms.client.users.AuthenticationToken;
+import org.netxms.client.users.User;
+import org.netxms.utilities.TestHelper;
+
+/**
+ * Tests for single-use authentication tokens.
+ */
+public class SingleUseTokenTest extends AbstractSessionTest
+{
+   private static final int TOKEN_VALIDITY_TIME = 600;
+   private static final String HANDOFF_USER_NAME = "single-use-handoff-test";
+   private static final String HANDOFF_USER_PASSWORD = "Handoff.Test.1";
+
+   /**
+    * Login to server with given authentication token. Caller is responsible for disconnecting returned session.
+    *
+    * @param token token value
+    * @return logged in session
+    */
+   private NXCSession loginWithToken(String token) throws Exception
+   {
+      NXCSession session = new NXCSession(TestConstants.SERVER_ADDRESS, TestConstants.SERVER_PORT_CLIENT, true);
+      session.connect(new int[] { ProtocolVersion.INDEX_FULL });
+      try
+      {
+         session.login(token);
+      }
+      catch(Exception e)
+      {
+         session.disconnect();
+         throw e;
+      }
+      return session;
+   }
+
+   /**
+    * Login to server with given credentials. Caller is responsible for disconnecting returned session.
+    *
+    * @param login login name
+    * @param password password
+    * @return logged in session
+    */
+   private NXCSession loginWithPassword(String login, String password) throws Exception
+   {
+      NXCSession session = new NXCSession(TestConstants.SERVER_ADDRESS, TestConstants.SERVER_PORT_CLIENT, true);
+      session.connect(new int[] { ProtocolVersion.INDEX_FULL });
+      try
+      {
+         session.login(login, password);
+      }
+      catch(Exception e)
+      {
+         session.disconnect();
+         throw e;
+      }
+      return session;
+   }
+
+   /**
+    * Wait for session to be disconnected by the server.
+    *
+    * @param session session to watch
+    * @return true if session was disconnected within the timeout
+    */
+   private boolean waitForDisconnect(NXCSession session) throws Exception
+   {
+      for(int i = 0; (i < 50) && session.isConnected(); i++)
+         Thread.sleep(100);
+      return !session.isConnected();
+   }
+
+   /**
+    * Create (or reuse) a test user with CLOSE_OTHER_SESSIONS flag set - the flag single-use login has to ignore.
+    *
+    * @param admin session with MANAGE_USERS access right
+    * @return test user
+    */
+   private User prepareHandoffUser(NXCSession admin) throws Exception
+   {
+      User user = TestHelper.findOrCreateUser(admin, HANDOFF_USER_NAME, HANDOFF_USER_PASSWORD);
+      user.setFlags((user.getFlags() | AbstractUserObject.CLOSE_OTHER_SESSIONS)
+            & ~(AbstractUserObject.DISABLED | AbstractUserObject.CHANGE_PASSWORD | AbstractUserObject.INTRUDER_LOCKOUT));
+      admin.modifyUserDBObject(user, AbstractUserObject.MODIFY_FLAGS);
+      admin.setUserPassword(user.getId(), HANDOFF_USER_PASSWORD, null);
+      return user;
+   }
+
+   @Test
+   public void testLoginWithSingleUseToken() throws Exception
+   {
+      NXCSession issuer = connectAndLogin();
+      AuthenticationToken token = issuer.requestAuthenticationToken(false, TOKEN_VALIDITY_TIME, "single-use token test", 0, true);
+      assertNotNull(token.getValue());
+      assertFalse(token.getValue().isEmpty());
+      assertTrue(token.isSingleUse());
+      assertFalse(token.isPersistent());
+
+      NXCSession session = loginWithToken(token.getValue());
+      try
+      {
+         assertEquals(issuer.getUserId(), session.getUserId());
+      }
+      finally
+      {
+         session.disconnect();
+      }
+   }
+
+   @Test
+   public void testSingleUseTokenCannotBeReused() throws Exception
+   {
+      NXCSession issuer = connectAndLogin();
+      AuthenticationToken token = issuer.requestAuthenticationToken(false, TOKEN_VALIDITY_TIME, "single-use token test", 0, true);
+
+      NXCSession session = loginWithToken(token.getValue());
+      session.disconnect();
+
+      try
+      {
+         loginWithToken(token.getValue()).disconnect();
+         fail("Second login with single-use token succeeded");
+      }
+      catch(NXCException e)
+      {
+         assertEquals(RCC.ACCESS_DENIED, e.getErrorCode());
+      }
+   }
+
+   @Test
+   public void testOrdinaryTokenIsNotConsumed() throws Exception
+   {
+      NXCSession issuer = connectAndLogin();
+      AuthenticationToken token = issuer.requestAuthenticationToken(false, TOKEN_VALIDITY_TIME, "reusable token test", 0);
+      assertFalse(token.isSingleUse());
+
+      for(int i = 0; i < 3; i++)
+      {
+         NXCSession session = loginWithToken(token.getValue());
+         assertEquals(issuer.getUserId(), session.getUserId());
+         session.disconnect();
+      }
+   }
+
+   /**
+    * Handing a session over must not disconnect the issuer, even for a user whose sessions are normally
+    * closed by a new login. This is the primary use case - a launcher spawning the console must survive it.
+    */
+   @Test
+   public void testSingleUseLoginKeepsOtherSessions() throws Exception
+   {
+      NXCSession admin = connectAndLogin();
+      User user = prepareHandoffUser(admin);
+
+      NXCSession issuer = loginWithPassword(HANDOFF_USER_NAME, HANDOFF_USER_PASSWORD);
+      try
+      {
+         AuthenticationToken token = issuer.requestAuthenticationToken(false, TOKEN_VALIDITY_TIME, "handoff test", 0, true);
+         NXCSession session = loginWithToken(token.getValue());
+         try
+         {
+            // Round trip request, because isConnected() alone does not prove the server kept the session
+            assertNotNull(issuer.getAlarms());
+            assertTrue(issuer.isConnected());
+            assertEquals(user.getId(), session.getUserId());
+         }
+         finally
+         {
+            session.disconnect();
+         }
+
+         // Control check - an ordinary login for the same user must close the issuer session,
+         // otherwise the assertion above would hold even without the single-use exception
+         NXCSession replacement = loginWithPassword(HANDOFF_USER_NAME, HANDOFF_USER_PASSWORD);
+         try
+         {
+            assertTrue(waitForDisconnect(issuer), "CLOSE_OTHER_SESSIONS is not in effect for test user");
+         }
+         finally
+         {
+            replacement.disconnect();
+         }
+      }
+      finally
+      {
+         if (issuer.isConnected())
+            issuer.disconnect();
+      }
+   }
+
+   /**
+    * Every token in a listing must be decoded from its own set of fields
+    */
+   @Test
+   public void testTokenListingReportsEachTokenSeparately() throws Exception
+   {
+      NXCSession issuer = connectAndLogin();
+      AuthenticationToken singleUseToken = issuer.requestAuthenticationToken(false, TOKEN_VALIDITY_TIME, "listing test (single-use)", 0, true);
+      AuthenticationToken ephemeralToken = issuer.requestAuthenticationToken(false, TOKEN_VALIDITY_TIME, "listing test (ephemeral)", 0);
+
+      List<AuthenticationToken> tokens = issuer.getAuthenticationTokens(issuer.getUserId());
+      AuthenticationToken listedSingleUse = null;
+      AuthenticationToken listedEphemeral = null;
+      for(AuthenticationToken t : tokens)
+      {
+         if (singleUseToken.getValue().equals(t.getValue()))
+            listedSingleUse = t;
+         else if (ephemeralToken.getValue().equals(t.getValue()))
+            listedEphemeral = t;
+      }
+
+      assertNotNull(listedSingleUse, "Single-use token is missing from listing");
+      assertNotNull(listedEphemeral, "Ephemeral token is missing from listing");
+      assertTrue(listedSingleUse.isSingleUse());
+      assertFalse(listedSingleUse.isPersistent());
+      assertFalse(listedEphemeral.isSingleUse());
+      assertFalse(listedEphemeral.isPersistent());
+      assertEquals("listing test (single-use)", listedSingleUse.getDescription());
+      assertEquals("listing test (ephemeral)", listedEphemeral.getDescription());
+   }
+
+   @Test
+   public void testPersistentSingleUseTokenRejected() throws Exception
+   {
+      NXCSession issuer = connectAndLogin();
+      try
+      {
+         issuer.requestAuthenticationToken(true, TOKEN_VALIDITY_TIME, "invalid combination test", 0, true);
+         fail("Request for persistent single-use token was accepted");
+      }
+      catch(NXCException e)
+      {
+         assertEquals(RCC.INVALID_ARGUMENT, e.getErrorCode());
+      }
+   }
+}

--- a/tests/suite/netxms-test-suite.cmd
+++ b/tests/suite/netxms-test-suite.cmd
@@ -35,6 +35,7 @@ if not exist "%BinDir%" (
 echo *** Running NetXMS test suite from %BinDir% ***
 
 call :RunTest test-libnetxms || goto failure
+call :RunTest test-authtokens || goto failure
 call :RunTest test-libethernetip || goto failure
 call :RunTest test-libnxnetconf || goto failure
 call :RunTest test-libnxsnmp || goto failure

--- a/tests/suite/netxms-test-suite.in
+++ b/tests/suite/netxms-test-suite.in
@@ -20,6 +20,12 @@ echo ""
 echo "********** test-libnetxms **********"
 $BINDIR/test-libnetxms || exit 1
 
+if [ -x $BINDIR/test-authtokens ]; then
+	echo ""
+	echo "********** test-authtokens **********"
+	$BINDIR/test-authtokens || exit 1
+fi
+
 if [ -x $BINDIR/test-libethernetip ]; then
 	echo ""
 	echo "********** test-libethernetip **********"

--- a/tests/test-authtokens/Makefile.am
+++ b/tests/test-authtokens/Makefile.am
@@ -1,0 +1,30 @@
+# Copyright (C) 2004 NetXMS Team <bugs@netxms.org>
+#
+# This file is free software; as a special exception the author gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+bin_PROGRAMS = test-authtokens
+test_authtokens_SOURCES = test-authtokens.cpp ../../src/server/core/authtokens.cpp
+test_authtokens_CPPFLAGS = -I@top_srcdir@/include -I@top_srcdir@/src/server/include -I../include -I@top_srcdir@/build -DNXCORE_EXPORTS @MICROHTTPD_CPPFLAGS@
+test_authtokens_LDFLAGS = @EXEC_LDFLAGS@
+test_authtokens_LDADD = \
+	@top_srcdir@/src/server/libnxsrv/libnxsrv.la \
+	@top_srcdir@/src/snmp/libnxsnmp/libnxsnmp.la \
+	@top_srcdir@/src/libnxsl/libnxsl.la \
+	@top_srcdir@/src/db/libnxdb/libnxdb.la \
+	@top_srcdir@/src/agent/libnxagent/libnxagent.la \
+	@top_srcdir@/src/libnetxms/libnetxms.la \
+	@EXEC_LIBS@
+
+if USE_INTERNAL_JANSSON
+test_authtokens_LDADD += @top_srcdir@/src/jansson/libnxjansson.la
+else
+test_authtokens_LDADD += -ljansson
+endif
+
+EXTRA_DIST = Makefile.w32

--- a/tests/test-authtokens/Makefile.w32
+++ b/tests/test-authtokens/Makefile.w32
@@ -1,0 +1,14 @@
+#
+# Makefile.w32 - test-authtokens (authentication token unit tests) for Windows/MinGW
+# Part of NetXMS project
+#
+
+TOOL = test-authtokens
+SOURCES = test-authtokens.cpp authtokens.cpp
+# authtokens.cpp includes netxms-webapi.h, which pulls in <microhttpd.h>
+TOOL_CPPFLAGS = -I$(TOPDIR)/src/server/include -I$(TOPDIR)/tests/include -I$(MICROHTTPD_ROOT)/include -DNXCORE_EXPORTS
+TOOL_LIBS = -lnxsrv -lnxsnmp -lnxsl -lnxdb -lnxagent -lnetxms -lnxjansson
+
+vpath %.cpp $(TOPDIR)/src/server/core
+
+include $(TOPDIR)/build/tool-common.mk

--- a/tests/test-authtokens/test-authtokens.cpp
+++ b/tests/test-authtokens/test-authtokens.cpp
@@ -1,0 +1,506 @@
+/*
+** NetXMS - Network Management System
+** Copyright (C) 2003-2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+** File: test-authtokens.cpp
+**
+** Unit tests for authentication token validation and consumption. Only ephemeral,
+** service and single-use tokens are issued so that the persistent token code paths,
+** which require a database connection, are never entered.
+**
+**/
+
+#include <nms_common.h>
+#include <nms_util.h>
+#include <nxcpapi.h>
+#include <nms_core.h>
+#include <nms_users.h>
+#include <testtools.h>
+
+#define TEST_USER_ID    1
+
+/**
+ * Stubs for server core symbols referenced by authtokens.cpp. The token code
+ * under test never reaches the database, so the query stub only has to exist.
+ */
+uint32_t NXCORE_EXPORTABLE ConfigReadULong(const wchar_t *variable, uint32_t defaultValue)
+{
+   return defaultValue;
+}
+
+uint32_t NXCORE_EXPORTABLE CreateUniqueId(int group)
+{
+   static VolatileCounter id = 0;
+   return static_cast<uint32_t>(InterlockedIncrement(&id));
+}
+
+bool NXCORE_EXPORTABLE ExecuteQueryOnObject(DB_HANDLE hdb, uint32_t objectId, const wchar_t *query)
+{
+   return true;
+}
+
+wchar_t NXCORE_EXPORTABLE *ResolveUserId(uint32_t id, wchar_t *buffer, bool noFail)
+{
+   if (id & GROUP_FLAG)
+      return noFail ? wcscpy(buffer, L"[unknown]") : nullptr;
+   nx_swprintf(buffer, MAX_USER_NAME, L"user-%u", id);
+   return buffer;
+}
+
+/**
+ * Issue token and check that it was created
+ */
+static shared_ptr<AuthenticationTokenDescriptor> IssueToken(uint32_t validFor,
+   AuthenticationTokenType type = AuthenticationTokenType::EPHEMERAL, uint32_t maxLifetime = 0)
+{
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueAuthenticationToken(TEST_USER_ID, validFor, type, nullptr, maxLifetime);
+   AssertNotNull(descriptor.get());
+   return descriptor;
+}
+
+/**
+ * Validation must reject a single-use token without destroying it
+ */
+static void TestValidateRejectsSingleUse()
+{
+   StartTest(_T("Validate rejects single-use token and leaves it valid"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600, AuthenticationTokenType::SINGLE_USE);
+
+   uint32_t userId = 0;
+   AssertFalse(ValidateAuthenticationToken(descriptor->token, &userId));
+   AssertEquals(userId, static_cast<uint32_t>(0));
+
+   // Rejection must not consume the token - it is still spendable at the designated spend point
+   AuthenticationTokenType tokenType = AuthenticationTokenType::EPHEMERAL;
+   AssertTrue(ConsumeAuthenticationToken(descriptor->token, &userId, &tokenType));
+   AssertTrue(tokenType == AuthenticationTokenType::SINGLE_USE);
+   AssertEquals(userId, static_cast<uint32_t>(TEST_USER_ID));
+
+   EndTest();
+}
+
+/**
+ * Single-use token can be consumed exactly once
+ */
+static void TestConsumeSingleUseOnce()
+{
+   StartTest(_T("Consume single-use token exactly once"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600, AuthenticationTokenType::SINGLE_USE);
+
+   uint32_t userId = 0;
+   AuthenticationTokenType tokenType = AuthenticationTokenType::SERVICE;
+   AssertTrue(ConsumeAuthenticationToken(descriptor->token, &userId, &tokenType));
+   AssertEquals(userId, static_cast<uint32_t>(TEST_USER_ID));
+   AssertTrue(tokenType == AuthenticationTokenType::SINGLE_USE);
+
+   userId = 0;
+   tokenType = AuthenticationTokenType::SERVICE;
+   AssertFalse(ConsumeAuthenticationToken(descriptor->token, &userId, &tokenType));
+   AssertFalse(ConsumeAuthenticationToken(descriptor->token, &userId, &tokenType));
+   AssertFalse(ValidateAuthenticationToken(descriptor->token, &userId));
+
+   EndTest();
+}
+
+/**
+ * Ordinary token must survive consumption - this is the reconnect token path
+ */
+static void TestConsumeNonSingleUse()
+{
+   StartTest(_T("Consume does not destroy ordinary token"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600);
+
+   uint32_t userId = 0;
+   AuthenticationTokenType tokenType = AuthenticationTokenType::SINGLE_USE;
+   AssertTrue(ConsumeAuthenticationToken(descriptor->token, &userId, &tokenType));
+   AssertEquals(userId, static_cast<uint32_t>(TEST_USER_ID));
+   AssertTrue(tokenType == AuthenticationTokenType::EPHEMERAL);
+
+   // Repeated logins with the same reconnect token must keep working
+   tokenType = AuthenticationTokenType::SINGLE_USE;
+   AssertTrue(ConsumeAuthenticationToken(descriptor->token, &userId, &tokenType));
+   AssertTrue(tokenType == AuthenticationTokenType::EPHEMERAL);
+   AssertTrue(ValidateAuthenticationToken(descriptor->token, &userId));
+
+   // Service token type must still be reported correctly
+   shared_ptr<AuthenticationTokenDescriptor> serviceDescriptor = IssueToken(600, AuthenticationTokenType::SERVICE);
+   tokenType = AuthenticationTokenType::SINGLE_USE;
+   AssertTrue(ConsumeAuthenticationToken(serviceDescriptor->token, &userId, &tokenType));
+   AssertTrue(tokenType == AuthenticationTokenType::SERVICE);
+
+   EndTest();
+}
+
+/**
+ * Validation of an ordinary token, including expiration extension
+ */
+static void TestValidateNonSingleUse()
+{
+   StartTest(_T("Validate ordinary token with expiration extension"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(60, AuthenticationTokenType::EPHEMERAL, 3600);
+   time_t originalExpiration = descriptor->expirationTime;
+
+   uint32_t userId = 0;
+   time_t expiresAt = 0;
+   time_t maxExpiresAt = 0;
+   AssertTrue(ValidateAuthenticationToken(descriptor->token, &userId, 0, &expiresAt, &maxExpiresAt));
+   AssertEquals(userId, static_cast<uint32_t>(TEST_USER_ID));
+   AssertTrue(expiresAt == originalExpiration);
+   AssertTrue(maxExpiresAt == descriptor->maxExpirationTime);
+   AssertTrue(descriptor->expirationTime == originalExpiration);
+
+   // Extension moves expiration forward but never past the absolute lifetime cap
+   AssertTrue(ValidateAuthenticationToken(descriptor->token, &userId, 600, &expiresAt, nullptr));
+   AssertTrue(descriptor->expirationTime > originalExpiration);
+   AssertTrue(expiresAt == descriptor->expirationTime);
+   AssertTrue(descriptor->expirationTime <= descriptor->maxExpirationTime);
+
+   AssertTrue(ValidateAuthenticationToken(descriptor->token, &userId, 86400, nullptr, nullptr));
+   AssertTrue(descriptor->expirationTime == descriptor->maxExpirationTime);
+
+   EndTest();
+}
+
+/**
+ * Single-use rejection must happen before the expiration extension block
+ */
+static void TestRejectionBeforeExtension()
+{
+   StartTest(_T("Single-use rejection happens before expiration extension"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(60, AuthenticationTokenType::SINGLE_USE, 86400);
+   time_t originalExpiration = descriptor->expirationTime;
+
+   uint32_t userId = 0;
+   AssertFalse(ValidateAuthenticationToken(descriptor->token, &userId, 14400));
+   AssertTrue(descriptor->expirationTime == originalExpiration);
+
+   EndTest();
+}
+
+/**
+ * Concurrent consumption of a single-use token
+ */
+#define RACE_THREADS    16
+#define RACE_ROUNDS     50
+
+static Condition s_raceStartGate(true);
+static VolatileCounter s_raceSuccessCount = 0;
+static VolatileCounter s_raceGateFailures = 0;
+static UserAuthenticationToken s_raceToken;
+
+static void RaceWorkerThread()
+{
+   if (!s_raceStartGate.wait(10000))
+      InterlockedIncrement(&s_raceGateFailures);
+   uint32_t userId = 0;
+   AuthenticationTokenType tokenType = AuthenticationTokenType::EPHEMERAL;
+   if (ConsumeAuthenticationToken(s_raceToken, &userId, &tokenType) && (tokenType == AuthenticationTokenType::SINGLE_USE) && (userId == TEST_USER_ID))
+      InterlockedIncrement(&s_raceSuccessCount);
+}
+
+static void TestConcurrentConsume()
+{
+   StartTest(_T("Concurrent consumption yields exactly one winner"));
+
+   // Repeated rounds because the contention window is only a few microseconds wide -
+   // a single round can miss the claim race entirely and still pass
+   s_raceGateFailures = 0;
+   for(int round = 0; round < RACE_ROUNDS; round++)
+   {
+      shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600, AuthenticationTokenType::SINGLE_USE);
+      s_raceToken = descriptor->token;
+      s_raceSuccessCount = 0;
+      s_raceStartGate.reset();
+
+      THREAD threads[RACE_THREADS];
+      for(int i = 0; i < RACE_THREADS; i++)
+         threads[i] = ThreadCreateEx(RaceWorkerThread);
+      ThreadSleepMs(5);
+      s_raceStartGate.set();
+      for(int i = 0; i < RACE_THREADS; i++)
+         ThreadJoin(threads[i]);
+
+      AssertEquals(static_cast<int32_t>(s_raceSuccessCount), 1);
+   }
+
+   // A gate timeout would silently degrade this into sequential consumption
+   AssertEquals(static_cast<int32_t>(s_raceGateFailures), 0);
+
+   EndTest();
+}
+
+/**
+ * Expired single-use token is rejected by both entry points. Two separate tokens
+ * are used because the first call removes the descriptor from the token map.
+ */
+static void TestExpiredSingleUse()
+{
+   StartTest(_T("Expired single-use token is rejected"));
+
+   shared_ptr<AuthenticationTokenDescriptor> validationTarget = IssueToken(0, AuthenticationTokenType::SINGLE_USE);
+   shared_ptr<AuthenticationTokenDescriptor> consumeTarget = IssueToken(0, AuthenticationTokenType::SINGLE_USE);
+
+   uint32_t userId = 0;
+   AssertFalse(ValidateAuthenticationToken(validationTarget->token, &userId));
+
+   AuthenticationTokenType tokenType = AuthenticationTokenType::EPHEMERAL;
+   AssertFalse(ConsumeAuthenticationToken(consumeTarget->token, &userId, &tokenType));
+   AssertEquals(static_cast<int32_t>(consumeTarget->claimed), 0);
+
+   EndTest();
+}
+
+/**
+ * Single-use tokens exist in memory only - they never get a database identifier, which is
+ * what makes them mutually exclusive with persistent tokens. A single-use token surviving
+ * a restart would be indistinguishable from an unspent one.
+ */
+static void TestSingleUseIsMemoryOnly()
+{
+   StartTest(_T("Single-use token is memory only"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600, AuthenticationTokenType::SINGLE_USE);
+   AssertEquals(descriptor->tokenId, static_cast<uint32_t>(0));
+   AssertTrue(descriptor->type == AuthenticationTokenType::SINGLE_USE);
+
+   EndTest();
+}
+
+/**
+ * Token cannot be issued for a group or for an unknown user, and a persistent token that would be
+ * born already expired is refused as well. Every caller depends on this null return to reject the
+ * request instead of dereferencing the descriptor.
+ */
+static void TestIssueFailures()
+{
+   StartTest(_T("Token issuing failures (invalid user, already expired persistent token)"));
+
+   AssertNull(IssueAuthenticationToken(GROUP_FLAG | TEST_USER_ID, 600).get());
+   AssertNull(IssueAuthenticationToken(TEST_USER_ID, 0, AuthenticationTokenType::PERSISTENT).get());
+
+   // Zero validity period is refused only for persistent tokens - an already expired ephemeral
+   // token is harmless and is cleaned up by the expiration check
+   AssertNotNull(IssueAuthenticationToken(TEST_USER_ID, 0).get());
+
+   EndTest();
+}
+
+/**
+ * Only persistent tokens are assigned an ID, so revocation by ID 0 must not match one of the
+ * memory-only tokens that all carry 0
+ */
+static void TestRevokeByIdRejectsZero()
+{
+   StartTest(_T("Revocation by token ID 0 is rejected"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600);
+   AssertEquals(descriptor->tokenId, static_cast<uint32_t>(0));
+
+   AssertEquals(RevokeAuthenticationToken(static_cast<uint32_t>(0), static_cast<uint32_t>(0)), static_cast<uint32_t>(RCC_INVALID_TOKEN_ID));
+
+   uint32_t userId = 0;
+   AssertTrue(ValidateAuthenticationToken(descriptor->token, &userId));
+   AssertEquals(userId, static_cast<uint32_t>(TEST_USER_ID));
+
+   EndTest();
+}
+
+/**
+ * Expiration time of a persistent token is stored in a 32-bit database column, so a
+ * descriptor with an oversized validity period must be clamped at construction time -
+ * otherwise the token would be written back and read as a different (or negative) time.
+ *
+ * MAX_PERSISTENT_TOKEN_EXPIRATION_TIME is also the largest representable time_t on platforms
+ * with a 32-bit time_t, where an oversized validity period overflows the type instead of
+ * exceeding the cap. Clamping cannot be observed there, so the check only runs on 64-bit time_t.
+ */
+static void TestPersistentExpirationClamp()
+{
+   StartTest(_T("Persistent token expiration time is clamped"));
+
+   if (sizeof(time_t) > 4)
+   {
+      AuthenticationTokenDescriptor descriptor(TEST_USER_ID, UINT32_MAX, AuthenticationTokenType::PERSISTENT, nullptr);
+      AssertEquals(static_cast<int64_t>(descriptor.expirationTime), MAX_PERSISTENT_TOKEN_EXPIRATION_TIME);
+      AssertEquals(static_cast<int64_t>(descriptor.maxExpirationTime), MAX_PERSISTENT_TOKEN_EXPIRATION_TIME);
+
+      AuthenticationTokenDescriptor ephemeral(TEST_USER_ID, UINT32_MAX, AuthenticationTokenType::EPHEMERAL, nullptr);
+      AssertTrue(static_cast<int64_t>(ephemeral.expirationTime) > MAX_PERSISTENT_TOKEN_EXPIRATION_TIME);
+   }
+   else
+   {
+      _tprintf(_T("(skipped on 32-bit time_t) "));
+   }
+
+   EndTest();
+}
+
+/**
+ * A memory-only token stops authenticating at its absolute lifetime cap, so a validity period
+ * longer than the cap must be reduced at construction time - otherwise the descriptor (and the
+ * expiration time reported to the client) would promise validity the token will never have.
+ */
+static void TestLifetimeCapClamp()
+{
+   StartTest(_T("Expiration time is clamped to absolute lifetime cap"));
+
+   shared_ptr<AuthenticationTokenDescriptor> capped = IssueToken(86400, AuthenticationTokenType::EPHEMERAL, 3600);
+   AssertTrue(capped->expirationTime == capped->maxExpirationTime);
+   AssertEquals(static_cast<int64_t>(capped->expirationTime - capped->issuingTime), static_cast<int64_t>(3600));
+
+   // A validity period within the cap is left alone
+   shared_ptr<AuthenticationTokenDescriptor> uncapped = IssueToken(600, AuthenticationTokenType::SINGLE_USE, 3600);
+   AssertTrue(uncapped->expirationTime < uncapped->maxExpirationTime);
+   AssertEquals(static_cast<int64_t>(uncapped->expirationTime - uncapped->issuingTime), static_cast<int64_t>(600));
+
+   EndTest();
+}
+
+/**
+ * A token that reached its absolute lifetime cap must be rejected and evicted by both entry
+ * points even though its nominal expiration time is still in the future
+ */
+static void TestMaxLifetimeReached()
+{
+   StartTest(_T("Token that reached maximum lifetime is rejected"));
+
+   shared_ptr<AuthenticationTokenDescriptor> validationTarget = IssueToken(3600, AuthenticationTokenType::EPHEMERAL, 3600);
+   shared_ptr<AuthenticationTokenDescriptor> consumeTarget = IssueToken(3600, AuthenticationTokenType::SINGLE_USE, 3600);
+
+   time_t now = time(nullptr);
+   validationTarget->maxExpirationTime = now - 1;
+   consumeTarget->maxExpirationTime = now - 1;
+
+   uint32_t userId = 0;
+   AssertFalse(ValidateAuthenticationToken(validationTarget->token, &userId));
+   AssertTrue(validationTarget->expirationTime > now);
+
+   AssertFalse(ConsumeAuthenticationToken(consumeTarget->token, &userId));
+   AssertEquals(static_cast<int32_t>(consumeTarget->claimed), 0);
+
+   EndTest();
+}
+
+/**
+ * Revocation by token value works for memory-only tokens, which cannot be revoked by ID
+ */
+static void TestRevokeByTokenValue()
+{
+   StartTest(_T("Revocation by token value"));
+
+   shared_ptr<AuthenticationTokenDescriptor> descriptor = IssueToken(600);
+   uint32_t userId = 0;
+   AssertTrue(ValidateAuthenticationToken(descriptor->token, &userId));
+
+   RevokeAuthenticationToken(descriptor->token);
+   AssertFalse(ValidateAuthenticationToken(descriptor->token, &userId));
+
+   // Revocation of already revoked token must be a no-op
+   RevokeAuthenticationToken(descriptor->token);
+   AssertFalse(ValidateAuthenticationToken(descriptor->token, &userId));
+
+   EndTest();
+}
+
+/**
+ * Token type name is what audit log entries and the server console listing show
+ */
+static void TestTokenTypeNames()
+{
+   StartTest(_T("Token type names"));
+
+   AssertEquals(AuthenticationTokenTypeName(AuthenticationTokenType::EPHEMERAL), L"ephemeral");
+   AssertEquals(AuthenticationTokenTypeName(AuthenticationTokenType::PERSISTENT), L"persistent");
+   AssertEquals(AuthenticationTokenTypeName(AuthenticationTokenType::SERVICE), L"service");
+   AssertEquals(AuthenticationTokenTypeName(AuthenticationTokenType::SINGLE_USE), L"single-use");
+
+   EndTest();
+}
+
+/**
+ * Neither protocol carries the token type - both derive three mutually exclusive booleans
+ * from it, and a client reading them back must see exactly one set (or none, for ephemeral)
+ */
+static void TestSerializedTokenType()
+{
+   StartTest(_T("Token type is serialized as mutually exclusive flags"));
+
+   static const AuthenticationTokenType types[] =
+   {
+      AuthenticationTokenType::EPHEMERAL,
+      AuthenticationTokenType::PERSISTENT,
+      AuthenticationTokenType::SERVICE,
+      AuthenticationTokenType::SINGLE_USE
+   };
+
+   for(size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++)
+   {
+      // Descriptor is constructed directly instead of being issued, so that a persistent
+      // token is not written to the database
+      AuthenticationTokenDescriptor descriptor(TEST_USER_ID, 600, types[i], L"serialization test");
+      bool persistent = (types[i] == AuthenticationTokenType::PERSISTENT);
+      bool service = (types[i] == AuthenticationTokenType::SERVICE);
+      bool singleUse = (types[i] == AuthenticationTokenType::SINGLE_USE);
+
+      NXCPMessage msg(CMD_REQUEST_COMPLETED, 1);
+      descriptor.fillMessage(&msg, VID_ELEMENT_LIST_BASE);
+      AssertTrue(msg.getFieldAsBoolean(VID_ELEMENT_LIST_BASE + 2) == persistent);
+      AssertTrue(msg.getFieldAsBoolean(VID_ELEMENT_LIST_BASE + 7) == service);
+      AssertTrue(msg.getFieldAsBoolean(VID_ELEMENT_LIST_BASE + 8) == singleUse);
+
+      json_t *json = descriptor.toJson();
+      AssertTrue((json_is_true(json_object_get(json, "persistent")) != 0) == persistent);
+      AssertTrue((json_is_true(json_object_get(json, "service")) != 0) == service);
+      AssertTrue((json_is_true(json_object_get(json, "singleUse")) != 0) == singleUse);
+      AssertNotNull(json_object_get(json, "value"));
+      json_decref(json);
+   }
+
+   EndTest();
+}
+
+/**
+ * main()
+ */
+int main(int argc, char *argv[])
+{
+   InitNetXMSProcess(true);
+
+   TestValidateRejectsSingleUse();
+   TestConsumeSingleUseOnce();
+   TestConsumeNonSingleUse();
+   TestValidateNonSingleUse();
+   TestRejectionBeforeExtension();
+   TestConcurrentConsume();
+   TestExpiredSingleUse();
+   TestSingleUseIsMemoryOnly();
+   TestIssueFailures();
+   TestRevokeByIdRejectsZero();
+   TestPersistentExpirationClamp();
+   TestLifetimeCapClamp();
+   TestMaxLifetimeReached();
+   TestRevokeByTokenValue();
+   TestTokenTypeNames();
+   TestSerializedTokenType();
+
+   return 0;
+}


### PR DESCRIPTION
Refs #3493.

Authentication tokens can now be issued as single-use: consumed on first successful NXCP login, which is the only spend point. An observed token value becomes worthless once it has been used, which bounds the `ps`-visible exposure window in the `nxmc-launcher` handoff.

## Design

- Single-use is orthogonal to `AuthenticationTokenType` (EPHEMERAL / PERSISTENT / SERVICE), not a fourth enum value.
- Single-use implies ephemeral. The `DB_RESULT` constructor forces the flag off, so a persistent token can never be single-use.
- `ValidateAuthenticationToken()` is split from consumption. The REST path validates on every request and never consumes; only NXCP login calls `ConsumeAuthenticationToken()`.
- `ConsumeAuthenticationToken()` is deliberately **not** `NXCORE_EXPORTABLE` — the linker keeps the sole spend point unreachable from modules. Noted in `src/server/CLAUDE.md` so it doesn't get "fixed" later.
- Consumption claims via `VolatileCounter`, so concurrent logins with the same token produce exactly one winner.

Memory-only: no schema change, no `nxdbmgr` upgrade procedure, no DB backport.

## Also in here

- `getAuthenticationTokens()` in the Java client advanced field IDs incorrectly and returned N copies of the first token. Fixed.
- Null-descriptor checks on all issuance call sites.
- `RevokeAuthenticationToken()` now rejects token ID 0.

## Protocol

New `VID_SINGLE_USE` = 1026, mirrored into `NXCPCodes.java`. Issuance via `CMD_REQUEST_AUTH_TOKEN` and `POST /v1/users/:user-id/tokens` (`openapi.yaml` updated).

## Tests

- `tests/test-authtokens` — new unit harness, including a concurrent-consumption race test.
- `SingleUseTokenTest` — end-to-end integration test.

## Verified

`make -C src/server/core`, `netxms-base`, and `netxms-client` all build clean. Recompiled the touched core files and checked every warning against the changed line ranges — all pre-existing `-Wsign-conversion` noise, nothing new.

The integration test and `test-authtokens` have not been run here; they need a live server.

Implementation plan is in `docs/plans/completed/20260731-single-use-auth-tokens.md`, user-facing docs in `doc/Single_Use_Authentication_Tokens.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-use authentication tokens for NXCP login.
  * Added single-use status visibility and creation support in client listings and APIs.
  * Added validation for token lifetime, persistence, descriptions, and incompatible settings.
  * Added audit logging and documentation covering token storage, expiration, and reuse.

* **Bug Fixes**
  * Improved handling of authentication-token issuance failures.
  * Prevented invalid persistent-token expiration values and token reuse.

* **Tests**
  * Added coverage for consumption, reuse prevention, expiration, concurrency, and persistence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->