### PR TITLE
WebAPI: added ARP cache, routing table, and switch forwarding database endpoints

### DIFF
--- a/src/server/core/macdb.cpp
+++ b/src/server/core/macdb.cpp
@@ -276,6 +276,10 @@ shared_ptr<NetObj> NXCORE_EXPORTABLE MacDbFind(const MacAddress& macAddr)
  */
 static std::pair<const TCHAR*, uint32_t> FindVendorByMacInternal(const MacAddress& macAddr)
 {
+   // Lookups below read up to 5 bytes from the address, so reject anything shorter than a full MAC
+   if (macAddr.length() != MAC_ADDR_LENGTH)
+      return std::pair<const TCHAR *, uint32_t>(nullptr, 0);
+
    uint32_t numBytes;
    oui24_t bytes;
    memcpy(bytes, macAddr.value(), 3);

--- a/src/server/include/nms_objects.h
+++ b/src/server/include/nms_objects.h
@@ -6634,7 +6634,7 @@ void NXCORE_EXPORTABLE MacDbRemoveInterface(const Interface& iface);
 void NXCORE_EXPORTABLE MacDbRemoveObject(const MacAddress& macAddr, const uint32_t objectId);
 shared_ptr<NetObj> NXCORE_EXPORTABLE MacDbFind(const BYTE *macAddr);
 shared_ptr<NetObj> NXCORE_EXPORTABLE MacDbFind(const MacAddress& macAddr);
-const TCHAR *FindVendorByMac(const MacAddress& macAddr);
+const TCHAR NXCORE_EXPORTABLE *FindVendorByMac(const MacAddress& macAddr);
 void FindVendorByMacList(const NXCPMessage& request, NXCPMessage* response);
 
 const wchar_t NXCORE_EXPORTABLE *GetObjectName(uint32_t id, const wchar_t *defaultName);

--- a/src/server/webapi/main.cpp
+++ b/src/server/webapi/main.cpp
@@ -279,6 +279,9 @@ int H_TopologyL2(Context *context);
 int H_TopologyIP(Context *context);
 int H_TopologyOSPF(Context *context);
 int H_TopologyInternal(Context *context);
+int H_ArpCache(Context *context);
+int H_RoutingTable(Context *context);
+int H_SwitchForwardingDatabase(Context *context);
 int H_Users(Context *context);
 int H_UserDetails(Context *context);
 int H_UserCreate(Context *context);
@@ -806,6 +809,15 @@ static bool InitModule(Config *config)
       .build();
    RouteBuilder("v1/objects/:object-id/topology/ospf")
       .GET(H_TopologyOSPF)
+      .build();
+   RouteBuilder("v1/objects/:object-id/arp-cache")
+      .GET(H_ArpCache)
+      .build();
+   RouteBuilder("v1/objects/:object-id/routing-table")
+      .GET(H_RoutingTable)
+      .build();
+   RouteBuilder("v1/objects/:object-id/switch-forwarding-database")
+      .GET(H_SwitchForwardingDatabase)
       .build();
    RouteBuilder("v1/objects/query")
       .POST(H_ObjectQuery)

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -6256,6 +6256,117 @@ paths:
           description: Unable to build internal communication topology
       security:
         - BearerAuth: []
+  /v1/objects/{object-id}/arp-cache:
+    get:
+      operationId: getArpCache
+      summary: Get node ARP cache
+      description: >-
+        Read the ARP cache of the given node. Entries are resolved against the object database where possible -
+        the interface the entry was seen on and the node owning the IP address are reported by name when the
+        caller has read access to them. Returns an empty entry list with a null timestamp when the ARP cache has
+        never been collected for this node.
+      tags:
+        - Objects
+      parameters:
+        - name: object-id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Node object ID
+        - name: forceRead
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            Force a live read from the device instead of using the server's cached copy. A live read blocks for
+            the duration of the agent or SNMP request and may time out on an unreachable node.
+      responses:
+        '200':
+          description: ARP cache retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArpCache'
+        '400':
+          description: Invalid object ID or object is not a node
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to given object
+        '404':
+          description: Object with given ID does not exist
+      security:
+        - BearerAuth: []
+  /v1/objects/{object-id}/routing-table:
+    get:
+      operationId: getRoutingTable
+      summary: Get node routing table
+      description: >-
+        Read the IP routing table of the given node. Returns an empty entry list with a null timestamp when the
+        routing table has never been collected for this node.
+      tags:
+        - Objects
+      parameters:
+        - name: object-id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Node object ID
+      responses:
+        '200':
+          description: Routing table retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutingTable'
+        '400':
+          description: Invalid object ID or object is not a node
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to given object
+        '404':
+          description: Object with given ID does not exist
+      security:
+        - BearerAuth: []
+  /v1/objects/{object-id}/switch-forwarding-database:
+    get:
+      operationId: getSwitchForwardingDatabase
+      summary: Get switch forwarding database
+      description: >-
+        Read the switch forwarding database (FDB) of the given node. Applicable to bridge-capable nodes.
+        Returns an empty entry list with a null timestamp when the forwarding database has never been collected
+        for this node.
+      tags:
+        - Objects
+      parameters:
+        - name: object-id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Node object ID
+      responses:
+        '200':
+          description: Switch forwarding database retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwitchForwardingDatabase'
+        '400':
+          description: Invalid object ID or object is not a node
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to given object
+        '404':
+          description: Object with given ID does not exist
+      security:
+        - BearerAuth: []
   /v1/objects/{object-id}/status-explanation:
     get:
       operationId: getObjectStatusExplanation
@@ -10590,8 +10701,8 @@ components:
           type: integer
           description: IP address family
         address:
-          type: integer
-          description: IP address
+          type: string
+          description: IP address in text form. Omitted entirely for unset (AF_UNSPEC) addresses.
         prefixLength:
           type: integer
           description: IP address prefix length
@@ -13986,6 +14097,146 @@ components:
         flags:
           type: integer
           description: Link flags
+    ArpCache:
+      type: object
+      description: ARP cache of a node
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the cache was collected. Null when it has never been collected for this node.
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArpCacheEntry'
+    ArpCacheEntry:
+      type: object
+      description: Single ARP cache entry
+      properties:
+        ipAddress:
+          $ref: '#/components/schemas/InetAddress'
+        macAddress:
+          type: string
+          description: MAC address in colon-separated notation
+        vendor:
+          type: string
+          nullable: true
+          description: NIC vendor resolved from the OUI database. Null when the prefix is not known.
+        interfaceIndex:
+          type: integer
+          description: Interface index the entry was seen on (0 if unknown)
+        interfaceName:
+          type: string
+          nullable: true
+          description: Name of the matching interface object. Null when no interface object matches the index.
+        nodeId:
+          type: integer
+          description: >-
+            ID of the node owning this IP address, or 0 when no node matches or the caller has no read access
+            to it.
+        nodeName:
+          type: string
+          nullable: true
+          description: Name of the node owning this IP address. Null when nodeId is 0.
+    RoutingTable:
+      type: object
+      description: IP routing table of a node
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the table was collected. Null when it has never been collected for this node.
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/Route'
+    Route:
+      type: object
+      description: Single IP routing table entry
+      properties:
+        destination:
+          $ref: '#/components/schemas/InetAddress'
+        nextHop:
+          $ref: '#/components/schemas/InetAddress'
+        interfaceIndex:
+          type: integer
+          description: Outgoing interface index (0 if unknown)
+        interfaceName:
+          type: string
+          nullable: true
+          description: Name of the matching interface object. Null when no interface object matches the index.
+        type:
+          type: integer
+          description: "Route type, RFC1213 ipRouteType (1=other, 2=invalid, 3=direct, 4=indirect)"
+        typeText:
+          type: string
+          description: Textual representation of the route type
+        metric:
+          type: integer
+          description: Route metric
+        protocol:
+          type: integer
+          description: "Routing protocol, RFC1213 ipRouteProto (2=local, 8=RIP, 13=OSPF, 14=BGP, ...)"
+        protocolText:
+          type: string
+          description: Textual representation of the routing protocol
+    SwitchForwardingDatabase:
+      type: object
+      description: Switch forwarding database (FDB) of a node
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            When the forwarding database was collected. Null when it has never been collected for this node.
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ForwardingDatabaseEntry'
+    ForwardingDatabaseEntry:
+      type: object
+      description: Single switch forwarding database entry
+      properties:
+        macAddress:
+          type: string
+          description: MAC address in colon-separated notation
+        vendor:
+          type: string
+          nullable: true
+          description: NIC vendor resolved from the OUI database. Null when the prefix is not known.
+        bridgePort:
+          type: integer
+          description: Bridge port number (0 if unknown)
+        interfaceIndex:
+          type: integer
+          description: Interface index (0 if unknown)
+        interfaceName:
+          type: string
+          nullable: true
+          description: >-
+            Name of the matching interface object. Members of an Ethernet or LAG parent interface are reported
+            under the parent's name. Null when no interface object matches the index.
+        vlanId:
+          type: integer
+          description: VLAN ID (0 if unknown)
+        nodeId:
+          type: integer
+          description: >-
+            ID of the node owning this MAC address, or 0 when no node matches or the caller has no read access
+            to it.
+        nodeName:
+          type: string
+          nullable: true
+          description: Name of the node owning this MAC address. Null when nodeId is 0.
+        type:
+          type: integer
+          description: "Entry type, dot1dTpFdbStatus (3=dynamic, 5=static, 6=secure)"
+        typeText:
+          type: string
+          description: Textual representation of the entry type
     ObjectQueryResult:
       type: object
       properties:

--- a/src/server/webapi/topology.cpp
+++ b/src/server/webapi/topology.cpp
@@ -211,3 +211,283 @@ int H_TopologyInternal(Context *context)
    json_decref(output);
    return 200;
 }
+
+/**
+ * Load node object for a node-scoped table request. Sets *httpCode and returns nullptr on failure.
+ */
+static shared_ptr<Node> LoadNodeForTableRequest(Context *context, int *httpCode)
+{
+   uint32_t objectId = context->getPlaceholderValueAsUInt32(_T("object-id"));
+   if (objectId == 0)
+   {
+      *httpCode = 400;
+      return shared_ptr<Node>();
+   }
+
+   shared_ptr<NetObj> object = FindObjectById(objectId);
+   if (object == nullptr)
+   {
+      *httpCode = 404;
+      return shared_ptr<Node>();
+   }
+
+   if (!object->checkAccessRights(context->getUserId(), OBJECT_ACCESS_READ))
+   {
+      *httpCode = 403;
+      return shared_ptr<Node>();
+   }
+
+   if (object->getObjectClass() != OBJECT_NODE)
+   {
+      context->setErrorResponse("Object is not a node");
+      *httpCode = 400;
+      return shared_ptr<Node>();
+   }
+
+   return static_pointer_cast<Node>(object);
+}
+
+/**
+ * Resolve NIC vendor from OUI database. Returns JSON null if unknown.
+ */
+static json_t *VendorToJson(const MacAddress& macAddr)
+{
+   const wchar_t *vendor = FindVendorByMac(macAddr);
+   return (vendor != nullptr) ? json_string_t(vendor) : json_null();
+}
+
+/**
+ * Resolve interface name by index. Returns JSON null if there is no matching interface object.
+ * When preferParent is set, an interface that is a member of an Ethernet or LAG parent interface
+ * is reported under the parent's name (same rule as ForwardingDatabase::interfaceIndexToName).
+ */
+static json_t *InterfaceNameToJson(const Node& node, uint32_t ifIndex, bool preferParent)
+{
+   shared_ptr<Interface> iface = node.findInterfaceByIndex(ifIndex);
+   if (iface == nullptr)
+      return json_null();
+
+   if (preferParent && (iface->getParentInterfaceId() != 0))
+   {
+      shared_ptr<Interface> parent = static_pointer_cast<Interface>(FindObjectById(iface->getParentInterfaceId(), OBJECT_INTERFACE));
+      if ((parent != nullptr) &&
+          ((parent->getIfType() == IFTYPE_ETHERNET_CSMACD) || (parent->getIfType() == IFTYPE_IEEE8023ADLAG)))
+         return json_string_t(parent->getName());
+   }
+
+   return json_string_t(iface->getName());
+}
+
+/**
+ * Add "nodeId" and "nodeName" fields for a referenced node, honouring the caller's access rights.
+ * Unknown or inaccessible nodes are reported as id 0 with a null name.
+ */
+static void SetNodeReference(json_t *entry, const shared_ptr<Node>& node, uint32_t userId)
+{
+   if ((node != nullptr) && node->checkAccessRights(userId, OBJECT_ACCESS_READ))
+   {
+      json_object_set_new(entry, "nodeId", json_integer(node->getId()));
+      json_object_set_new(entry, "nodeName", json_string_t(node->getName()));
+   }
+   else
+   {
+      json_object_set_new(entry, "nodeId", json_integer(0));
+      json_object_set_new(entry, "nodeName", json_null());
+   }
+}
+
+/**
+ * Textual representation of IP routing protocol (RFC1213 ipRouteProto)
+ */
+static const char *RoutingProtocolToText(RoutingProtocol protocol)
+{
+   switch(protocol)
+   {
+      case ROUTING_PROTOCOL_OTHER:
+         return "Other";
+      case ROUTING_PROTOCOL_LOCAL:
+         return "Local";
+      case ROUTING_PROTOCOL_NETMGMT:
+         return "Network Management";
+      case ROUTING_PROTOCOL_ICMP:
+         return "ICMP";
+      case ROUTING_PROTOCOL_EGP:
+         return "EGP";
+      case ROUTING_PROTOCOL_GGP:
+         return "GGP";
+      case ROUTING_PROTOCOL_HELLO:
+         return "HELLO";
+      case ROUTING_PROTOCOL_RIP:
+         return "RIP";
+      case ROUTING_PROTOCOL_IS_IS:
+         return "IS-IS";
+      case ROUTING_PROTOCOL_ES_IS:
+         return "ES-IS";
+      case ROUTING_PROTOCOL_IGRP:
+         return "IGRP";
+      case ROUTING_PROTOCOL_BBN_SPF_IGP:
+         return "BBN SPF IGP";
+      case ROUTING_PROTOCOL_OSPF:
+         return "OSPF";
+      case ROUTING_PROTOCOL_BGP:
+         return "BGP";
+      case ROUTING_PROTOCOL_IDPR:
+         return "IDPR";
+      case ROUTING_PROTOCOL_EIGRP:
+         return "EIGRP";
+      case ROUTING_PROTOCOL_DVMRP:
+         return "DVMRP";
+      case ROUTING_PROTOCOL_RPL:
+         return "RPL";
+      case ROUTING_PROTOCOL_DHCP:
+         return "DHCP";
+      default:
+         return "Unknown";
+   }
+}
+
+/**
+ * Textual representation of IP route type (RFC1213 ipRouteType)
+ */
+static const char *RouteTypeToText(uint32_t type)
+{
+   switch(type)
+   {
+      case 1:
+         return "Other";
+      case 2:
+         return "Invalid";
+      case 3:
+         return "Direct";
+      case 4:
+         return "Indirect";
+      default:
+         return "Unknown";
+   }
+}
+
+/**
+ * Textual representation of switch forwarding database entry type (dot1dTpFdbStatus)
+ */
+static const char *FdbEntryTypeToText(uint16_t type)
+{
+   switch(type)
+   {
+      case 3:
+         return "Dynamic";
+      case 5:
+         return "Static";
+      case 6:
+         return "Secure";
+      default:
+         return "Unknown";
+   }
+}
+
+/**
+ * Handler for GET /v1/objects/:object-id/arp-cache
+ */
+int H_ArpCache(Context *context)
+{
+   int httpCode;
+   shared_ptr<Node> node = LoadNodeForTableRequest(context, &httpCode);
+   if (node == nullptr)
+      return httpCode;
+
+   json_t *entries = json_array();
+   shared_ptr<ArpCache> arpCache = node->getArpCache(context->getQueryParameterAsBoolean("forceRead", false));
+   for(int i = 0; (arpCache != nullptr) && (i < arpCache->size()); i++)
+   {
+      const ArpEntry *e = arpCache->get(i);
+
+      json_t *entry = json_object();
+      json_object_set_new(entry, "ipAddress", e->ipAddr.toJson());
+      json_object_set_new(entry, "macAddress", json_string_t(e->macAddr.toString()));
+      json_object_set_new(entry, "vendor", VendorToJson(e->macAddr));
+      json_object_set_new(entry, "interfaceIndex", json_integer(e->ifIndex));
+      json_object_set_new(entry, "interfaceName", InterfaceNameToJson(*node, e->ifIndex, false));
+      SetNodeReference(entry, FindNodeByIP(node->getZoneUIN(), e->ipAddr), context->getUserId());
+      json_array_append_new(entries, entry);
+   }
+
+   json_t *output = json_object();
+   json_object_set_new(output, "timestamp", (arpCache != nullptr) ? json_time_string(arpCache->timestamp()) : json_null());
+   json_object_set_new(output, "entries", entries);
+   context->setResponseData(output);
+   json_decref(output);
+   return 200;
+}
+
+/**
+ * Handler for GET /v1/objects/:object-id/routing-table
+ */
+int H_RoutingTable(Context *context)
+{
+   int httpCode;
+   shared_ptr<Node> node = LoadNodeForTableRequest(context, &httpCode);
+   if (node == nullptr)
+      return httpCode;
+
+   json_t *entries = json_array();
+   shared_ptr<RoutingTable> routingTable = node->getRoutingTable();
+   for(int i = 0; (routingTable != nullptr) && (i < routingTable->size()); i++)
+   {
+      const ROUTE *route = routingTable->get(i);
+
+      json_t *entry = json_object();
+      json_object_set_new(entry, "destination", route->destination.toJson());
+      json_object_set_new(entry, "nextHop", route->nextHop.toJson());
+      json_object_set_new(entry, "interfaceIndex", json_integer(route->ifIndex));
+      json_object_set_new(entry, "interfaceName", InterfaceNameToJson(*node, route->ifIndex, false));
+      json_object_set_new(entry, "type", json_integer(route->routeType));
+      json_object_set_new(entry, "typeText", json_string(RouteTypeToText(route->routeType)));
+      json_object_set_new(entry, "metric", json_integer(route->metric));
+      json_object_set_new(entry, "protocol", json_integer(route->protocol));
+      json_object_set_new(entry, "protocolText", json_string(RoutingProtocolToText(route->protocol)));
+      json_array_append_new(entries, entry);
+   }
+
+   json_t *output = json_object();
+   json_object_set_new(output, "timestamp", (routingTable != nullptr) ? json_time_string(routingTable->timestamp()) : json_null());
+   json_object_set_new(output, "entries", entries);
+   context->setResponseData(output);
+   json_decref(output);
+   return 200;
+}
+
+/**
+ * Handler for GET /v1/objects/:object-id/switch-forwarding-database
+ */
+int H_SwitchForwardingDatabase(Context *context)
+{
+   int httpCode;
+   shared_ptr<Node> node = LoadNodeForTableRequest(context, &httpCode);
+   if (node == nullptr)
+      return httpCode;
+
+   json_t *entries = json_array();
+   shared_ptr<ForwardingDatabase> fdb = node->getSwitchForwardingDatabase();
+   for(int i = 0; (fdb != nullptr) && (i < fdb->getSize()); i++)
+   {
+      const ForwardingDatabaseEntry *e = fdb->getEntry(i);
+
+      json_t *entry = json_object();
+      json_object_set_new(entry, "macAddress", json_string_t(e->macAddr.toString()));
+      json_object_set_new(entry, "vendor", VendorToJson(e->macAddr));
+      json_object_set_new(entry, "bridgePort", json_integer(e->bridgePort));
+      json_object_set_new(entry, "interfaceIndex", json_integer(e->ifIndex));
+      json_object_set_new(entry, "interfaceName", InterfaceNameToJson(*node, e->ifIndex, true));
+      json_object_set_new(entry, "vlanId", json_integer(e->vlanId));
+      SetNodeReference(entry, static_pointer_cast<Node>(FindObjectById(e->nodeObject, OBJECT_NODE)), context->getUserId());
+      json_object_set_new(entry, "type", json_integer(e->type));
+      json_object_set_new(entry, "typeText", json_string(FdbEntryTypeToText(e->type)));
+      json_array_append_new(entries, entry);
+   }
+
+   json_t *output = json_object();
+   json_object_set_new(output, "timestamp", (fdb != nullptr) ? json_time_string(fdb->getTimeStamp()) : json_null());
+   json_object_set_new(output, "entries", entries);
+   context->setResponseData(output);
+   json_decref(output);
+   return 200;
+}


### PR DESCRIPTION
New read-only node object views:

  GET /v1/objects/{object-id}/arp-cache (supports forceRead query parameter)
  GET /v1/objects/{object-id}/routing-table
  GET /v1/objects/{object-id}/switch-forwarding-database

All three resolve raw table data against the object database the same way the management console does: interface index to interface name, MAC OUI to NIC vendor, and IP/MAC to the owning node. Referenced nodes are reported as id 0 with a null name when the caller has no read access to them. FDB entries belonging to a member of an Ethernet or LAG interface are reported under the parent interface name.

FindVendorByMac() is exported from libnxsrv so webapi module can use it, and now rejects addresses shorter than 6 bytes - it reads up to 5 bytes from the address, and ARP/FDB entries are not guaranteed to carry a full MAC.

Corrected InetAddress.address schema in openapi.yaml - it was documented as integer while InetAddress::toJson() has always emitted text form.