### PR TITLE
WebAPI: object deletion and business service availability endpoints

### DIFF
--- a/include/nms_util.h
+++ b/include/nms_util.h
@@ -413,9 +413,11 @@ std::string LIBNETXMS_EXPORTABLE FormatISO8601TimestampMs(int64_t t);
 
 /**
  * Parse timestamp from string. Supports absolute timestamps in ISO 8601 format or as UNIX timestamp,
- * as well as relative timestamps in format [+|-]<number>[s|m|h|d]
+ * as well as relative timestamps in format [+|-]<number>[s|m|h|d]. Returns defaultValue if string
+ * cannot be parsed. Valid representations of epoch (like "0") are parsed into 0, so caller that has
+ * to tell parsing errors from epoch should pass non-zero default value.
  */
-time_t LIBNETXMS_EXPORTABLE ParseTimestamp(const char *ts);
+time_t LIBNETXMS_EXPORTABLE ParseTimestamp(const char *ts, time_t defaultValue = 0);
 
 /**
  * Parse time duration string with optional unit suffix. Recognized suffixes (case-insensitive):

--- a/src/libnetxms/tools.cpp
+++ b/src/libnetxms/tools.cpp
@@ -1137,15 +1137,18 @@ std::string LIBNETXMS_EXPORTABLE FormatISO8601TimestampMs(int64_t t)
 
 /**
  * Parse timestamp from string. Supports absolute timestamps in ISO 8601 format or as UNIX timestamp,
- * as well as relative timestamps in format [+|-]<number>[s|m|h|d] or word "now".
+ * as well as relative timestamps in format [+|-]<number>[s|m|h|d] or word "now". Returns defaultValue
+ * if string cannot be parsed, including empty string and a sign without a number.
  */
-time_t LIBNETXMS_EXPORTABLE ParseTimestamp(const char *ts)
+time_t LIBNETXMS_EXPORTABLE ParseTimestamp(const char *ts, time_t defaultValue)
 {
    char *eptr;
    if ((ts[0] == '-') || (ts[0] == '+'))
    {
       // Offset from now
       int64_t offset = strtoll(&ts[1], &eptr, 10);
+      if (eptr == &ts[1])
+         return defaultValue;  // sign not followed by a number
       if (*eptr != 0)
       {
          // check for suffix
@@ -1156,7 +1159,7 @@ time_t LIBNETXMS_EXPORTABLE ParseTimestamp(const char *ts)
          else if (stricmp(eptr, "d") == 0)
             offset *= 86400;
          else if (stricmp(eptr, "s") != 0)
-            return 0;  // invalid format
+            return defaultValue;  // invalid format
       }
       else
       {
@@ -1171,12 +1174,12 @@ time_t LIBNETXMS_EXPORTABLE ParseTimestamp(const char *ts)
       return time(nullptr);
 
    int64_t n = strtoll(ts, &eptr, 10);
-   if (*eptr == 0)
+   if ((eptr != ts) && (*eptr == 0))
       return static_cast<time_t>(n);   // Assume UNIX timestamp
 
    struct tm t;
    if (strptime(ts, "%Y-%m-%dT%H:%M:%SZ", &t) == nullptr)
-      return 0;
+      return defaultValue;
 
    return timegm(&t);
 }

--- a/src/server/core/bizservice.cpp
+++ b/src/server/core/bizservice.cpp
@@ -808,28 +808,25 @@ NXSL_Value *BusinessService::createNXSLObject(NXSL_VM *vm)
 }
 
 /**
- * Get business service uptime in percents
+ * Get business service uptime in percents. Returns negative value if downtime records cannot
+ * be read from database.
  */
 double GetServiceUptime(uint32_t serviceId, time_t from, time_t to)
 {
    if ((to - from) <= 0)  // prevent division by zero (or negative value)
       return 100.0;
 
-   double uptimePercentage = 0;
+   double uptimePercentage = -1;
    DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
    DB_STATEMENT hStmt = DBPrepare(hdb,
             _T("SELECT from_timestamp,to_timestamp FROM business_service_downtime ")
-            _T("WHERE service_id=? AND ((from_timestamp BETWEEN ? AND ? OR to_timestamp BETWEEN ? and ?) OR (from_timestamp<=? AND (to_timestamp=0 OR to_timestamp>=?))) ")
+            _T("WHERE service_id=? AND from_timestamp<=? AND (to_timestamp=0 OR to_timestamp>=?) ")
             _T("ORDER BY from_timestamp"));
    if (hStmt != nullptr)
    {
       DBBind(hStmt, 1, DB_SQLTYPE_INTEGER, serviceId);
-      DBBind(hStmt, 2, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(from));
-      DBBind(hStmt, 3, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(to));
-      DBBind(hStmt, 4, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(from));
-      DBBind(hStmt, 5, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(to));
-      DBBind(hStmt, 6, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(from));
-      DBBind(hStmt, 7, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(to));
+      DBBind(hStmt, 2, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(to));
+      DBBind(hStmt, 3, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(from));
       DB_RESULT hResult = DBSelectPrepared(hStmt);
       if (hResult != nullptr)
       {
@@ -894,16 +891,12 @@ void GetServiceTickets(uint32_t serviceId, time_t from, time_t to, NXCPMessage *
    DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
    DB_STATEMENT hStmt = DBPrepare(hdb,
             _T("SELECT ticket_id,original_ticket_id,original_service_id,check_id,create_timestamp,close_timestamp,reason,check_description FROM business_service_tickets ")
-            _T("WHERE service_id=? AND ((create_timestamp BETWEEN ? AND ? OR close_timestamp BETWEEN ? and ?) OR (create_timestamp<? AND (close_timestamp=0 OR close_timestamp>?)))"));
+            _T("WHERE service_id=? AND create_timestamp<=? AND (close_timestamp=0 OR close_timestamp>=?)"));
    if (hStmt != nullptr)
    {
       DBBind(hStmt, 1, DB_SQLTYPE_INTEGER, serviceId);
-      DBBind(hStmt, 2, DB_SQLTYPE_INTEGER, (uint32_t)from);
-      DBBind(hStmt, 3, DB_SQLTYPE_INTEGER, (uint32_t)to);
-      DBBind(hStmt, 4, DB_SQLTYPE_INTEGER, (uint32_t)from);
-      DBBind(hStmt, 5, DB_SQLTYPE_INTEGER, (uint32_t)to);
-      DBBind(hStmt, 6, DB_SQLTYPE_INTEGER, (uint32_t)from);
-      DBBind(hStmt, 7, DB_SQLTYPE_INTEGER, (uint32_t)to);
+      DBBind(hStmt, 2, DB_SQLTYPE_INTEGER, (uint32_t)to);
+      DBBind(hStmt, 3, DB_SQLTYPE_INTEGER, (uint32_t)from);
       DB_RESULT hResult = DBSelectPrepared(hStmt);
       if (hResult != nullptr)
       {
@@ -937,4 +930,65 @@ void GetServiceTickets(uint32_t serviceId, time_t from, time_t to, NXCPMessage *
       DBFreeStatement(hStmt);
    }
    DBConnectionPoolReleaseConnection(hdb);
+}
+
+/**
+ * Get business service tickets as JSON array, newest first. Closure time of still open
+ * ticket is reported as null. Returns nullptr if tickets cannot be read from database.
+ */
+json_t *GetServiceTicketsAsJson(uint32_t serviceId, time_t from, time_t to)
+{
+   DB_HANDLE hdb = DBConnectionPoolAcquireConnection();
+   DB_STATEMENT hStmt = DBPrepare(hdb,
+            _T("SELECT ticket_id,original_ticket_id,original_service_id,check_id,create_timestamp,close_timestamp,reason,check_description FROM business_service_tickets ")
+            _T("WHERE service_id=? AND create_timestamp<=? AND (close_timestamp=0 OR close_timestamp>=?) ")
+            _T("ORDER BY create_timestamp DESC"));
+   if (hStmt == nullptr)
+   {
+      DBConnectionPoolReleaseConnection(hdb);
+      return nullptr;
+   }
+
+   DBBind(hStmt, 1, DB_SQLTYPE_INTEGER, serviceId);
+   DBBind(hStmt, 2, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(to));
+   DBBind(hStmt, 3, DB_SQLTYPE_INTEGER, static_cast<uint32_t>(from));
+   DB_RESULT hResult = DBSelectPrepared(hStmt);
+   if (hResult == nullptr)
+   {
+      DBFreeStatement(hStmt);
+      DBConnectionPoolReleaseConnection(hdb);
+      return nullptr;
+   }
+
+   json_t *tickets = json_array();
+   int count = DBGetNumRows(hResult);
+   for (int i = 0; i < count; i++)
+   {
+      uint32_t ticketId = DBGetFieldULong(hResult, i, 0);
+      uint32_t originalTicketId = DBGetFieldULong(hResult, i, 1);
+      uint32_t originalServiceId = DBGetFieldULong(hResult, i, 2);
+      uint32_t checkId = DBGetFieldULong(hResult, i, 3);
+      time_t creationTimestamp = static_cast<time_t>(DBGetFieldULong(hResult, i, 4));
+      time_t closureTimestamp = static_cast<time_t>(DBGetFieldULong(hResult, i, 5));
+      wchar_t reason[256];
+      DBGetField(hResult, i, 6, reason, 256);
+      wchar_t checkDescription[1024];
+      DBGetField(hResult, i, 7, checkDescription, 1024);
+
+      json_t *ticket = json_object();
+      json_object_set_new(ticket, "id", json_integer(originalTicketId != 0 ? originalTicketId : ticketId));
+      json_object_set_new(ticket, "serviceId", json_integer(originalTicketId != 0 ? originalServiceId : serviceId));
+      json_object_set_new(ticket, "checkId", json_integer(checkId));
+      json_object_set_new(ticket, "creationTime", json_time_string(creationTimestamp));
+      json_object_set_new(ticket, "closureTime", json_time_string(closureTimestamp));
+      json_object_set_new(ticket, "reason", json_string_t(reason));
+      json_object_set_new(ticket, "checkDescription", json_string_t(checkDescription));
+      json_array_append_new(tickets, ticket);
+   }
+
+   DBFreeResult(hResult);
+   DBFreeStatement(hStmt);
+   DBConnectionPoolReleaseConnection(hdb);
+
+   return tickets;
 }

--- a/src/server/core/session.cpp
+++ b/src/server/core/session.cpp
@@ -19161,7 +19161,8 @@ void ClientSession::getBusinessServiceUptime(const NXCPMessage& request)
             to = request.getFieldAsUInt64(VID_TIME_TO);
          }
 
-         response.setField(VID_BUSINESS_SERVICE_UPTIME, GetServiceUptime(object->getId(), from, to));
+         double uptime = GetServiceUptime(object->getId(), from, to);
+         response.setField(VID_BUSINESS_SERVICE_UPTIME, (uptime >= 0) ? uptime : 0.0);
          response.setField(VID_RCC, RCC_SUCCESS);
       }
       else

--- a/src/server/include/nms_objects.h
+++ b/src/server/include/nms_objects.h
@@ -6744,8 +6744,9 @@ void FindSshKeyById(uint32_t id, NXCPMessage *msg);
 json_t NXCORE_EXPORTABLE *GetSshKeysAsJson(bool includePublicKey);
 json_t NXCORE_EXPORTABLE *GetSshKeyByIdAsJson(uint32_t id);
 
-double GetServiceUptime(uint32_t serviceId, time_t from, time_t to);
+double NXCORE_EXPORTABLE GetServiceUptime(uint32_t serviceId, time_t from, time_t to);
 void GetServiceTickets(uint32_t serviceId, time_t from, time_t to, NXCPMessage* msg);
+json_t NXCORE_EXPORTABLE *GetServiceTicketsAsJson(uint32_t serviceId, time_t from, time_t to);
 
 void CheckNodeCountRestrictions();
 int GetMaxAllowedNodeCount();

--- a/src/server/webapi/CLAUDE.md
+++ b/src/server/webapi/CLAUDE.md
@@ -87,7 +87,7 @@ The JSON interface is becoming the primary interface to the system; a JSON→NXC
 
 ## Request Parsing Conventions
 
-- **Point-in-time values:** parse string values with `ParseTimestamp()` from libnetxms (`nms_util.h`) at the use site — it accepts ISO 8601, UNIX timestamps as strings, relative offsets (`[+|-]<number>[s|m|h|d]`), and `now`; 0 means parse failure → return 400. JSON integers are UNIX timestamps directly. Do not add new shared time-parse helpers to webapi headers.
+- **Point-in-time values:** parse string values with `ParseTimestamp()` from libnetxms (`nms_util.h`) at the use site — it accepts ISO 8601, UNIX timestamps as strings, relative offsets (`[+|-]<number>[s|m|h|d]`), and `now`. Detect a parse failure by passing an out-of-band `defaultValue` (`-1`) and testing for it; do not treat a returned 0 as failure, epoch is valid input. Range-check the result where it matters — timestamps are stored in the database as 32 bit values, so a millisecond timestamp or a max-date sentinel from a generated client wraps silently. JSON integers are UNIX timestamps directly. Do not add new shared time-parse helpers to webapi headers.
 - **Content types:** `RouteBuilder` accepts `application/json` on every POST/PUT/PATCH route by default; `.acceptProtobuf()` / `.acceptImage()` only widen the accepted set. A binary-only route (protobuf, raw image body) must call `.acceptJson(false)`, otherwise it silently accepts a JSON-labeled body and the handler parses it blindly. Anything not accepted gets 415.
 
 ## API Documentation

--- a/src/server/webapi/Makefile.am
+++ b/src/server/webapi/Makefile.am
@@ -1,7 +1,7 @@
 MODULE = webapi
 
 pkglib_LTLIBRARIES = webapi.la
-webapi_la_SOURCES = 2fa.cpp actions.cpp ai.cpp ai_operators.cpp alarm_categories.cpp alarms.cpp asset_management.cpp chassis.cpp chat_bots.cpp cloud_connectors.cpp conn_history.cpp datacoll.cpp dcst.cpp epp.cpp event_forwarders.cpp events.cpp find.cpp geoareas.cpp grafana.cpp images.cpp incidents.cpp info.cpp log_parsers.cpp logs.cpp main.cpp notifications.cpp object_categories.cpp object_collections.cpp object_dashboard.cpp object_dci.cpp object_helpers.cpp object_networkmap.cpp object_node_config.cpp object_properties.cpp objects.cpp objtools.cpp racks.cpp schedules.cpp scripts.cpp snmp_mib.cpp sshkeys.cpp tcpproxy.cpp topology.cpp users.cpp websvc.cpp
+webapi_la_SOURCES = 2fa.cpp actions.cpp ai.cpp ai_operators.cpp alarm_categories.cpp alarms.cpp asset_management.cpp business_services.cpp chassis.cpp chat_bots.cpp cloud_connectors.cpp conn_history.cpp datacoll.cpp dcst.cpp epp.cpp event_forwarders.cpp events.cpp find.cpp geoareas.cpp grafana.cpp images.cpp incidents.cpp info.cpp log_parsers.cpp logs.cpp main.cpp notifications.cpp object_categories.cpp object_collections.cpp object_dashboard.cpp object_dci.cpp object_helpers.cpp object_networkmap.cpp object_node_config.cpp object_properties.cpp objects.cpp objtools.cpp racks.cpp schedules.cpp scripts.cpp snmp_mib.cpp sshkeys.cpp tcpproxy.cpp topology.cpp users.cpp websvc.cpp
 webapi_la_CPPFLAGS = -I@top_srcdir@/include -I@top_srcdir@/src/server/include -I@top_srcdir@/build @MICROHTTPD_CPPFLAGS@
 webapi_la_LDFLAGS = -module -avoid-version @MICROHTTPD_LDFLAGS@
 webapi_la_LIBADD = ../../libnetxms/libnetxms.la ../libnxsrv/libnxsrv.la ../core/libnxcore.la @MICROHTTPD_LIBS@

--- a/src/server/webapi/business_services.cpp
+++ b/src/server/webapi/business_services.cpp
@@ -1,0 +1,107 @@
+/*
+** NetXMS - Network Management System
+** Copyright (C) 2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+** File: business_services.cpp
+**
+**/
+
+#include "webapi.h"
+
+/**
+ * Upper bound for period boundaries (2038-01-19T03:14:07Z). Downtime and ticket timestamps are
+ * stored as 32 bit values, so anything above this cannot be represented in the database.
+ */
+#define MAX_PERIOD_TIMESTAMP  _LL(0x7FFFFFFF)
+
+/**
+ * Handler for GET /v1/objects/:object-id/availability
+ *
+ * Time period defaults to epoch .. now.
+ */
+int H_BusinessServiceAvailability(Context *context)
+{
+   uint32_t objectId = context->getPlaceholderValueAsUInt32(L"object-id");
+   if (objectId == 0)
+      return 400;
+
+   shared_ptr<NetObj> object = FindObjectById(objectId, OBJECT_BUSINESSSERVICE);
+   if (object == nullptr)
+      return 404;
+
+   if (!object->checkAccessRights(context->getUserId(), OBJECT_ACCESS_READ))
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, false, objectId, L"Access denied on reading business service uptime");
+      return 403;
+   }
+
+   // Parsing error is reported as -1 so that it cannot be confused with epoch, which is a valid
+   // input and also the default for "from". Boundaries outside of [epoch, MAX_PERIOD_TIMESTAMP]
+   // are rejected as well - such timestamps cannot be stored in the database and would break
+   // uptime calculation (a millisecond timestamp passed as "to" is the typical case).
+   time_t from = 0;
+   const char *fromText = context->getQueryParameter("from");
+   if (fromText != nullptr)
+   {
+      from = ParseTimestamp(fromText, -1);
+      if ((from < 0) || (static_cast<int64_t>(from) > MAX_PERIOD_TIMESTAMP))
+      {
+         context->setErrorResponse("Invalid \"from\" parameter");
+         return 400;
+      }
+   }
+
+   time_t to = time(nullptr);
+   const char *toText = context->getQueryParameter("to");
+   if (toText != nullptr)
+   {
+      to = ParseTimestamp(toText, -1);
+      if ((to < 0) || (static_cast<int64_t>(to) > MAX_PERIOD_TIMESTAMP))
+      {
+         context->setErrorResponse("Invalid \"to\" parameter");
+         return 400;
+      }
+   }
+
+   if (to < from)
+   {
+      context->setErrorResponse("\"to\" must not be earlier than \"from\"");
+      return 400;
+   }
+
+   double uptime = GetServiceUptime(objectId, from, to);
+   if (uptime < 0)
+      return 500;
+
+   json_t *tickets = nullptr;
+   if (context->getQueryParameterAsBoolean("includeTickets", false))
+   {
+      tickets = GetServiceTicketsAsJson(objectId, from, to);
+      if (tickets == nullptr)
+         return 500;
+   }
+
+   json_t *output = json_object();
+   json_object_set_new(output, "uptime", json_real(uptime));
+   json_object_set_new(output, "from", json_string(FormatISO8601Timestamp(from).c_str()));
+   json_object_set_new(output, "to", json_string(FormatISO8601Timestamp(to).c_str()));
+   if (tickets != nullptr)
+      json_object_set_new(output, "tickets", tickets);
+   context->setResponseData(output);
+   json_decref(output);
+   return 200;
+}

--- a/src/server/webapi/main.cpp
+++ b/src/server/webapi/main.cpp
@@ -95,6 +95,7 @@ int H_AssetAttributeDetails(Context *context);
 int H_AssetAttributeCreate(Context *context);
 int H_AssetAttributeUpdate(Context *context);
 int H_AssetAttributeDelete(Context *context);
+int H_BusinessServiceAvailability(Context *context);
 int H_CloudConnectors(Context *context);
 int H_GetConnectionHistory(Context *context);
 int H_DataCollectionCurrentValues(Context *context);
@@ -165,6 +166,7 @@ int H_ObjectAgentGet(Context *context);
 int H_ObjectAgentUpdate(Context *context);
 int H_ObjectAutoBindUpdate(Context *context);
 int H_ObjectCreate(Context *context);
+int H_ObjectDelete(Context *context);
 int H_ObjectAccessRights(Context *context);
 int H_ObjectAccessRightsUpdate(Context *context);
 int H_ObjectDashboard(Context *context);
@@ -652,6 +654,10 @@ static bool InitModule(Config *config)
    RouteBuilder("v1/objects/:object-id")
       .GET(H_ObjectDetails)
       .PATCH(H_ObjectPropertiesUpdate)
+      .DELETE(H_ObjectDelete)
+      .build();
+   RouteBuilder("v1/objects/:object-id/availability")
+      .GET(H_BusinessServiceAvailability)
       .build();
    RouteBuilder("v1/objects/:object-id/rack-layout")
       .GET(H_RackLayout)

--- a/src/server/webapi/objects.cpp
+++ b/src/server/webapi/objects.cpp
@@ -342,6 +342,70 @@ int H_ObjectCreate(Context *context)
 }
 
 /**
+ * Worker for asynchronous object deletion
+ */
+static void DeleteObjectWorker(const shared_ptr<NetObj>& object)
+{
+   object->deleteObject();
+}
+
+/**
+ * Handler for DELETE /v1/objects/:object-id
+ *
+ * Object and its children are deleted on a worker thread, so 204 means that deletion request
+ * is accepted. Requests are serialized to prevent interleaved deletion of related objects.
+ */
+int H_ObjectDelete(Context *context)
+{
+   uint32_t objectId = context->getPlaceholderValueAsUInt32(L"object-id");
+   if (objectId == 0)
+      return 400;
+
+   shared_ptr<NetObj> object = FindObjectById(objectId);
+   if ((object == nullptr) || object->isDeleted())
+      return 404;
+
+   // Check if it is a built-in object, like "Entire Network"
+   if (object->getId() < 10)
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, false, objectId, L"Access denied on delete object %s", object->getName());
+      context->setErrorResponse("Built-in objects cannot be deleted");
+      return 403;
+   }
+
+   if (!object->checkAccessRights(context->getUserId(), OBJECT_ACCESS_DELETE))
+   {
+      context->writeAuditLog(AUDIT_OBJECTS, false, objectId, L"Access denied on delete object %s", object->getName());
+      return 403;
+   }
+
+   if ((object->getObjectClass() == OBJECT_ZONE) && !object->isEmpty())
+   {
+      context->setErrorResponse("Zone is not empty");
+      return 409;
+   }
+
+   if ((object->getObjectClass() == OBJECT_ASSET) &&
+       !ConfigReadBoolean(L"Objects.Assets.AllowDeleteIfLinked", false) &&
+       (static_cast<Asset&>(*object).getLinkedObjectId() != 0))
+   {
+      context->setErrorResponse("Asset is linked to an object");
+      return 409;
+   }
+
+   // For templates and clusters, set the DCI removal option before deletion
+   bool removeDCI = context->getQueryParameterAsBoolean("removeDCI", true);
+   if (object->getObjectClass() == OBJECT_TEMPLATE)
+      static_cast<Template&>(*object).setRemoveDCIOnDelete(removeDCI);
+   else if (object->getObjectClass() == OBJECT_CLUSTER)
+      static_cast<Cluster&>(*object).setRemoveDCIOnDelete(removeDCI);
+
+   context->writeAuditLog(AUDIT_OBJECTS, true, objectId, L"Object %s deleted", object->getName());
+   ThreadPoolExecuteSerialized(g_clientThreadPool, L"DeleteObject", DeleteObjectWorker, object);
+   return 204;
+}
+
+/**
  * Handler for /v1/objects/:object-id
  */
 int H_ObjectDetails(Context *context)

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -3615,6 +3615,58 @@ paths:
         - BearerAuth: []
       tags:
         - Objects
+    delete:
+      operationId: deleteObject
+      summary: Delete object
+      description: |
+        Delete an object. A child object is deleted along with it only when this object is
+        its last remaining parent; a child that is also reachable through another parent is
+        detached instead. A node normally belongs to both a subnet and a container, so
+        deleting a container usually leaves its nodes in place.
+
+        Deletion is **asynchronous**: the request is validated and queued, and `204` means
+        the deletion was accepted, not that the object is already gone. Clients should
+        re-read the tree rather than assume the object disappears immediately.
+
+        Built-in objects (ID below 10, such as "Entire Network" and the class roots) cannot
+        be deleted.
+      parameters:
+        - name: object-id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: removeDCI
+          in: query
+          required: false
+          description: >-
+            Templates and clusters only. Whether to also remove the data collection items
+            this object pushed onto its members. Ignored for every other object class.
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '204':
+          description: Deletion accepted. The object is removed asynchronously.
+        '400':
+          description: Invalid object ID
+        '401':
+          description: Unauthorized
+        '403':
+          description: >-
+            User does not have delete access to the object, or the object is a built-in
+            object that cannot be deleted.
+        '404':
+          description: Object with given ID does not exist
+        '409':
+          description: >-
+            Object cannot be deleted in its current state — the zone still contains
+            objects, or the asset is linked to an object and
+            `Objects.Assets.AllowDeleteIfLinked` is disabled.
+      security:
+        - BearerAuth: []
+      tags:
+        - Objects
   /v1/objects/{object-id}/location:
     patch:
       operationId: updateObjectLocation
@@ -6271,6 +6323,97 @@ paths:
           description: Object with given ID does not exist
         '500':
           description: Unable to build internal communication topology
+      security:
+        - BearerAuth: []
+  /v1/objects/{object-id}/availability:
+    get:
+      operationId: getBusinessServiceAvailability
+      summary: Get business service availability
+      description: >-
+        Percentage of the requested period during which the business service was not in
+        CRITICAL state. Downtime is recorded only on transitions into and out of CRITICAL,
+        so a service whose failing checks never take it past DEGRADED reports 100% even
+        when `includeTickets` returns open tickets for the same period. Applies to objects
+        of class BusinessService only; any other class is reported as not found.
+      tags:
+        - Objects
+      parameters:
+        - name: object-id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: from
+          in: query
+          required: false
+          description: >-
+            Start of the period. ISO 8601, a UNIX timestamp, a relative offset such as
+            `-30d`, or `now`. Must resolve to a moment between the epoch and
+            `2038-01-19T03:14:07Z`; timestamps are stored as 32 bit values, so anything
+            outside that range is rejected. Defaults to the epoch. Note that the percentage
+            is computed over the whole requested period while the housekeeper purges
+            downtime records older than `BusinessServices.History.RetentionTime` (90 days
+            by default), so a period reaching further back than the retention time counts
+            the purged part as uptime.
+          schema:
+            type: string
+        - name: to
+          in: query
+          required: false
+          description: >-
+            End of the period, same formats and same accepted range as `from`. Defaults to
+            now.
+          schema:
+            type: string
+        - name: includeTickets
+          in: query
+          required: false
+          description: >-
+            Also return the service tickets overlapping the period, newest first. Omitted
+            from the response entirely when false, so a caller that only needs the
+            percentage does not pay for the second query.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Availability for the requested period.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uptime:
+                    type: number
+                    format: double
+                    description: Percentage of the period the service was up, 0 to 100.
+                  from:
+                    type: string
+                    format: date-time
+                    description: >-
+                      Start of the period actually used. `1970-01-01T00:00:00Z` when `from`
+                      was not supplied.
+                  to:
+                    type: string
+                    format: date-time
+                    description: End of the period actually used.
+                  tickets:
+                    type: array
+                    description: Present only when `includeTickets` is true.
+                    items:
+                      $ref: '#/components/schemas/BusinessServiceTicket'
+        '400':
+          description: >-
+            Unparseable `from` / `to`, a bound outside the accepted range, or `to` earlier
+            than `from`.
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have read access to the business service
+        '404':
+          description: No business service with given ID
+        '500':
+          description: Unable to read business service history from database
       security:
         - BearerAuth: []
   /v1/objects/{object-id}/arp-cache:
@@ -14256,6 +14399,40 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ArpCacheEntry'
+    BusinessServiceTicket:
+      type: object
+      description: >-
+        One period during which a business service check was failing. A ticket raised on a
+        child service is propagated to every parent service, and the propagated copy reports
+        the id of the original ticket and of the service the check belongs to.
+      properties:
+        id:
+          type: integer
+          description: Ticket ID.
+        serviceId:
+          type: integer
+          description: >-
+            ID of the business service the check that raised the ticket belongs to. For a
+            ticket propagated from a child service this is the child, not the service that
+            was queried.
+        checkId:
+          type: integer
+          description: ID of the check that raised the ticket.
+        creationTime:
+          type: string
+          format: date-time
+          description: When the check started failing.
+        closureTime:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the check recovered. Null while the ticket is still open.
+        reason:
+          type: string
+          description: Failure reason recorded when the ticket was raised.
+        checkDescription:
+          type: string
+          description: Description of the check, as it read at the time.
     ArpCacheEntry:
       type: object
       description: Single ARP cache entry

--- a/tests/test-libnetxms/test-libnetxms.cpp
+++ b/tests/test-libnetxms/test-libnetxms.cpp
@@ -1600,6 +1600,43 @@ static void TestParseDuration()
 }
 
 /**
+ * Test ParseTimestamp
+ */
+static void TestParseTimestamp()
+{
+   StartTest(_T("ParseTimestamp"));
+
+   // Absolute timestamps
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("0")), static_cast<int64_t>(0));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("1700000000")), static_cast<int64_t>(1700000000));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("1970-01-01T00:00:00Z")), static_cast<int64_t>(0));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("2023-11-14T22:13:20Z")), static_cast<int64_t>(1700000000));
+
+   // Relative timestamps (clock may move by a second between the calls)
+   time_t now = time(nullptr);
+   time_t t = ParseTimestamp("now");
+   AssertTrue((t >= now) && (t <= now + 1));
+   t = ParseTimestamp("-1h");
+   AssertTrue((t >= now - 3600) && (t <= now - 3599));
+   t = ParseTimestamp("+30");   // no suffix means minutes
+   AssertTrue((t >= now + 1800) && (t <= now + 1801));
+
+   // Invalid input returns default value
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("abc")), static_cast<int64_t>(0));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("abc", -1)), static_cast<int64_t>(-1));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("-10x", -1)), static_cast<int64_t>(-1));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("", -1)), static_cast<int64_t>(-1));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("-", -1)), static_cast<int64_t>(-1));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("+", -1)), static_cast<int64_t>(-1));
+
+   // Epoch is a valid input and is not affected by default value
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("0", -1)), static_cast<int64_t>(0));
+   AssertEquals(static_cast<int64_t>(ParseTimestamp("1970-01-01T00:00:00Z", -1)), static_cast<int64_t>(0));
+
+   EndTest();
+}
+
+/**
  * Keys for hash map
  */
 typedef char HASH_KEY[6];
@@ -3712,6 +3749,7 @@ int main(int argc, char *argv[])
    TestInetAddress();
    TestIntegerToString();
    TestParseDuration();
+   TestParseTimestamp();
    TestQueue();
    TestSharedObjectQueue();
    TestSQueue();


### PR DESCRIPTION
## WebAPI: object deletion and business service availability endpoints

Adds two endpoints that the REST API was missing relative to NXCP.

### `DELETE /v1/objects/{object-id}`

Deletes an object and everything below it in the tree. Validation mirrors
`ClientSession::deleteObject`:

- built-in objects (ID below 10 — "Entire Network", the class roots) → `403`
- caller without `OBJECT_ACCESS_DELETE` → `403` (audited as access denied)
- zone that still contains objects → `409`
- asset linked to an object while `Objects.Assets.AllowDeleteIfLinked` is off → `409`
- `?removeDCI=` (default `true`) controls whether templates and clusters drop the DCIs
  they pushed onto their members; ignored for every other class

Deletion is queued on the client thread pool, serialized, exactly as the NXCP path does.
**`204` therefore means "accepted", not "already gone"** — clients must re-read rather than
assume the object is immediately absent. This is called out in the OpenAPI description.

### `GET /v1/objects/{object-id}/availability`

Uptime percentage for a business service over a period. Any non-`BusinessService` class is
reported as `404`, matching the NXCP lookup.

- `from` / `to` accept ISO 8601, UNIX timestamps, relative offsets (`-30d`), and `now`;
  they default to the epoch and now respectively
- unparseable bounds, or `to` before `from`, → `400`
- `?includeTickets=true` additionally returns the tickets overlapping the period, newest
  first, so an SLA view can be built from one request. Omitted entirely when false, so
  callers that only want the percentage do not pay for the second query.

### Server core

- `GetServiceTicketsAsJson()` added next to the existing `GetServiceTickets()`, following
  the established `*AsJson` pattern in core. Open tickets (`close_timestamp = 0`) are
  reported as `closureTime: null` rather than as 1970.
- `GetServiceUptime()` marked `NXCORE_EXPORTABLE` — webapi is a separate module.

### Documentation

`openapi.yaml` updated with both operations plus a `BusinessServiceTicket` schema.