### PR TITLE
Wrap remaining hardcoded UI strings in i18n.tr()

### DIFF
--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/dialogs/ThemeElementEditDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/dialogs/ThemeElementEditDialog.java
@@ -24,13 +24,17 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.nxmc.base.widgets.ExtendedColorSelector;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.ThemeElement;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for editing theme elements
  */
 public class ThemeElementEditDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ThemeElementEditDialog.class);
+
    private ThemeElement element;
    private ExtendedColorSelector foreground;
    private ExtendedColorSelector background;
@@ -51,7 +55,7 @@ public class ThemeElementEditDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Edit Theme Element");
+      newShell.setText(i18n.tr("Edit Theme Element"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/login/TwoFactorResponseDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/login/TwoFactorResponseDialog.java
@@ -106,7 +106,7 @@ public class TwoFactorResponseDialog extends Dialog
          qrLabel.setLayoutData(gd);
 
          PasswordInputField secretText = new PasswordInputField(dialogArea, SWT.NONE, true);
-         secretText.setLabel("Secret as text");
+         secretText.setLabel(i18n.tr("Secret as text"));
          secretText.setText(qrText);
          secretText.setEditable(false);
          gd = new GridData(SWT.FILL, SWT.CENTER, true, false);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/widgets/KeyValueSetEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/widgets/KeyValueSetEditor.java
@@ -41,14 +41,18 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.netxms.nxmc.base.dialogs.KeyValuePairEditDialog;
 import org.netxms.nxmc.base.widgets.helpers.KeyValuePairLabelProvider;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.ElementLabelComparator;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Editor for generic set of key/value pairs
  */
 public class KeyValueSetEditor extends Composite
 {
+   private final I18n i18n = LocalizationHelper.getI18n(KeyValueSetEditor.class);
+
    private SortableTableViewer viewer;
    private Button buttonAdd;
    private Button buttonEdit;
@@ -118,7 +122,7 @@ public class KeyValueSetEditor extends Composite
       buttons.setLayoutData(gd);
 
       buttonAdd = new Button(buttons, SWT.PUSH);
-      buttonAdd.setText("&Add...");
+      buttonAdd.setText(i18n.tr("&Add..."));
       buttonAdd.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)
@@ -131,7 +135,7 @@ public class KeyValueSetEditor extends Composite
       buttonAdd.setLayoutData(rd);
 
       buttonEdit = new Button(buttons, SWT.PUSH);
-      buttonEdit.setText("&Edit...");
+      buttonEdit.setText(i18n.tr("&Edit..."));
       buttonEdit.addSelectionListener(new SelectionAdapter() {
         @Override
         public void widgetSelected(SelectionEvent e)
@@ -145,7 +149,7 @@ public class KeyValueSetEditor extends Composite
       buttonEdit.setEnabled(false);
 
       buttonRemove = new Button(buttons, SWT.PUSH);
-      buttonRemove.setText("&Delete");
+      buttonRemove.setText(i18n.tr("&Delete"));
       buttonRemove.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/widgets/LatLonZoomEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/base/widgets/LatLonZoomEditor.java
@@ -28,7 +28,9 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Scale;
 import org.eclipse.swt.widgets.Spinner;
 import org.netxms.base.GeoLocation;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Composite editor for a (latitude, longitude, zoom level) triple used by
@@ -46,6 +48,8 @@ import org.netxms.nxmc.tools.WidgetHelper;
  */
 public class LatLonZoomEditor extends Composite
 {
+   private final I18n i18n = LocalizationHelper.getI18n(LatLonZoomEditor.class);
+
    public static final int MIN_ZOOM = 1;
    public static final int MAX_ZOOM = 18;
 
@@ -104,7 +108,7 @@ public class LatLonZoomEditor extends Composite
       zoomRow.setLayoutData(gd);
 
       zoomLabel = new Label(zoomRow, SWT.NONE);
-      zoomLabel.setText("Zoom level"); //$NON-NLS-1$
+      zoomLabel.setText(i18n.tr("Zoom level")); //$NON-NLS-1$
       gd = new GridData();
       gd.horizontalAlignment = SWT.LEFT;
       gd.horizontalSpan = 2;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/actions/dialogs/ActionSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/actions/dialogs/ActionSelectionDialog.java
@@ -38,14 +38,18 @@ import org.netxms.client.NXCSession;
 import org.netxms.client.ServerAction;
 import org.netxms.nxmc.Registry;
 import org.netxms.nxmc.base.jobs.Job;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.actions.views.helpers.DecoratingActionLabelProvider;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Action selection dialog
  */
 public class ActionSelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ActionSelectionDialog.class);
+
    private Collection<ServerAction> localCache;
    private TableViewer viewer;
    private List<ServerAction> selection;
@@ -77,7 +81,7 @@ public class ActionSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select action");
+      newShell.setText(i18n.tr("Select action"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/dialogs/AlarmCategorySelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/dialogs/AlarmCategorySelectionDialog.java
@@ -40,13 +40,17 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.events.AlarmCategory;
 import org.netxms.nxmc.PreferenceStore;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.alarms.widgets.AlarmCategoryList;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for selecting alarm category
  */
 public class AlarmCategorySelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(AlarmCategorySelectionDialog.class);
+
    private static final String TABLE_CONFIG_PREFIX = "AlarmCategorySelectionDialog";
 
    private AlarmCategoryList alarmCategoryList;
@@ -71,7 +75,7 @@ public class AlarmCategorySelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Alarm Category");
+      newShell.setText(i18n.tr("Select Alarm Category"));
       settings = PreferenceStore.getInstance();
       newShell.setSize(settings.getAsInteger(TABLE_CONFIG_PREFIX + ".cx", 600), settings.getAsInteger(TABLE_CONFIG_PREFIX + ".cy", 400));
    }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/views/AlarmDetails.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/alarms/views/AlarmDetails.java
@@ -570,7 +570,7 @@ public class AlarmDetails extends AdHocObjectView
    						else
    						{
    						   Label label = new Label(dataArea, SWT.NONE);
-   						   label.setText("No DCI associated with this alarm");
+   						   label.setText(i18n.tr("No DCI associated with this alarm"));
                         dataSection.setExpanded(false);
    						   DashboardLayoutData dd = (DashboardLayoutData)dataSection.getLayoutData();
    						   dd.fill = false;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/dialogs/SelectAssetAttributeDlg.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/dialogs/SelectAssetAttributeDlg.java
@@ -69,7 +69,7 @@ public class SelectAssetAttributeDlg extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Asset Attributes");
+      newShell.setText(i18n.tr("Select Asset Attributes"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/propertypages/AssetAttributeGeneral.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/propertypages/AssetAttributeGeneral.java
@@ -99,7 +99,7 @@ public class AssetAttributeGeneral extends PropertyPage
       textName.setEditable(createNew);
 
       textDisplayName = new LabeledText(dialogArea, SWT.NONE);
-      textDisplayName.setLabel("Display name");
+      textDisplayName.setLabel(i18n.tr("Display name"));
       gd = new GridData(SWT.FILL, SWT.CENTER, true, false);
       gd.horizontalSpan = 2;
       textDisplayName.setLayoutData(gd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/views/AssetManagementSchemaManager.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/assetmanagement/views/AssetManagementSchemaManager.java
@@ -284,7 +284,7 @@ public class AssetManagementSchemaManager extends ConfigurationView
          protected void configureShell(Shell newShell)
          {
             super.configureShell(newShell);
-            newShell.setText("Asset Attribute Properties");
+            newShell.setText(i18n.tr("Asset Attribute Properties"));
          }
       };
       dlg.setBlockOnOpen(true);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/DCIAutoBind.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/DCIAutoBind.java
@@ -89,7 +89,7 @@ public class DCIAutoBind extends ObjectPropertyPage
 
       // Enable/disable check box
       checkboxEnableBind = new Button(dialogArea, SWT.CHECK);
-      checkboxEnableBind.setText("Automatically add DCI selected by filter to this business service as check");
+      checkboxEnableBind.setText(i18n.tr("Automatically add DCI selected by filter to this business service as check"));
       checkboxEnableBind.setSelection(businessService.isDciAutoBindEnabled());
       checkboxEnableBind.addSelectionListener(new SelectionListener() {
 			@Override
@@ -118,7 +118,7 @@ public class DCIAutoBind extends ObjectPropertyPage
       });
       
       checkboxEnableUnbind = new Button(dialogArea, SWT.CHECK);
-      checkboxEnableUnbind.setText("Automatically remove DCI selected by filter from this business service");
+      checkboxEnableUnbind.setText(i18n.tr("Automatically remove DCI selected by filter from this business service"));
       checkboxEnableUnbind.setSelection(businessService.isDciAutoUnbindEnabled());
       checkboxEnableUnbind.setEnabled(businessService.isDciAutoBindEnabled());
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/ObjectAutoBind.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/ObjectAutoBind.java
@@ -91,7 +91,7 @@ public class ObjectAutoBind extends ObjectPropertyPage
 
       // Enable/disable check box
       checkboxEnableBind = new Button(dialogArea, SWT.CHECK);
-      checkboxEnableBind.setText("Automatically add objects selected by filter to this business service as check");
+      checkboxEnableBind.setText(i18n.tr("Automatically add objects selected by filter to this business service as check"));
       checkboxEnableBind.setSelection(businessService.isAutoBindEnabled());
       checkboxEnableBind.addSelectionListener(new SelectionListener() {
 			@Override
@@ -120,7 +120,7 @@ public class ObjectAutoBind extends ObjectPropertyPage
       });
       
       checkboxEnableUnbind = new Button(dialogArea, SWT.CHECK);
-      checkboxEnableUnbind.setText("Automatically remove objects selected by filter from this business service");
+      checkboxEnableUnbind.setText(i18n.tr("Automatically remove objects selected by filter from this business service"));
       checkboxEnableUnbind.setSelection(businessService.isAutoUnbindEnabled());
       checkboxEnableUnbind.setEnabled(businessService.isAutoBindEnabled());
       

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/dialogs/SortingColumnSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/dialogs/SortingColumnSelectionDialog.java
@@ -115,7 +115,7 @@ public class SortingColumnSelectionDialog extends Dialog
       columnSelector.setLayoutData(gd);
 
       checkDescending = new Button(dialogArea, SWT.CHECK);
-      checkDescending.setText("Descending order");
+      checkDescending.setText(i18n.tr("Descending order"));
       checkDescending.setSelection(descending);
 
       return dialogArea;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/dialogs/TableColumnSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/dialogs/TableColumnSelectionDialog.java
@@ -29,12 +29,16 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
+import org.netxms.nxmc.localization.LocalizationHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for selecting table column
  */
 public class TableColumnSelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(TableColumnSelectionDialog.class);
+
    private TableViewer viewer;
    private String[] columnNames;
    private String selectedName;
@@ -58,7 +62,7 @@ public class TableColumnSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Column");
+      newShell.setText(i18n.tr("Select Column"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/AbstractChart.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/AbstractChart.java
@@ -371,7 +371,7 @@ public class AbstractChart extends DashboardElementPropertyPage
       if (!(config instanceof LineChartConfig))
       {
          drillDownObject = new ObjectSelector(dialogArea, SWT.NONE, true);
-         drillDownObject.setLabel("Drill-down object");
+         drillDownObject.setLabel(i18n.tr("Drill-down object"));
          drillDownObject.setObjectClass(AbstractObject.class);
          drillDownObject.setClassFilter(ObjectSelectionDialog.createDashboardAndNetworkMapSelectionFilter());
          drillDownObject.setObjectId(config.getDrillDownObjectId());

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/AvailabilityChart.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/AvailabilityChart.java
@@ -152,7 +152,7 @@ public class AvailabilityChart extends DashboardElementPropertyPage
       legendPosition.select(positionIndexFromValue(config.getLegendPosition()));
 
       daysSelector = new LabeledSpinner(dialogArea, SWT.NONE);
-      daysSelector.setLabel("Period length (days)");
+      daysSelector.setLabel(i18n.tr("Period length (days)"));
       daysSelector.setRange(1, 1000);
       daysSelector.setSelection(config.getNumberOfDays());
       daysSelector.setVisible(periodSelector.getSelectionIndex() == AvailabilityChartConfig.CUSTOM);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/DciSummaryTable.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/DciSummaryTable.java
@@ -297,7 +297,7 @@ public class DciSummaryTable extends DashboardElementPropertyPage
       buttonAdd.setLayoutData(rd);
       
       buttonEdit = new Button(rightButtons, SWT.PUSH);
-      buttonEdit.setText("&Edit...");
+      buttonEdit.setText(i18n.tr("&Edit..."));
       buttonEdit.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/ObjectDetailsPropertyList.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/ObjectDetailsPropertyList.java
@@ -119,7 +119,7 @@ public class ObjectDetailsPropertyList extends DashboardElementPropertyPage
       dialogArea.setLayout(layout);
 
       Label label = new Label(dialogArea, SWT.NONE);
-      label.setText("Properties to display");
+      label.setText(i18n.tr("Properties to display"));
 
       final String[] names = { "Name", "Display name", "Type" };
       final int[] widths = { 150, 250, 90 };

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/ServiceComponents.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/ServiceComponents.java
@@ -228,7 +228,7 @@ public class ServiceComponents extends DashboardElementPropertyPage
       checkShowStatusBkgnd.setSelection((config.getFlags() & NetworkMap.MF_SHOW_STATUS_BKGND) != 0);
       
       checkTranslucentLabelBkgnd = new Button(objectDisplayGroup, SWT.CHECK);
-      checkTranslucentLabelBkgnd.setText("Translucent label background");
+      checkTranslucentLabelBkgnd.setText(i18n.tr("Translucent label background"));
       checkTranslucentLabelBkgnd.setSelection((config.getFlags() & NetworkMap.MF_TRANSLUCENT_LABEL_BKGND) != 0);
 
       /**** default link appearance ****/

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/StatusMap.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/StatusMap.java
@@ -153,7 +153,7 @@ public class StatusMap extends DashboardElementPropertyPage
       checkGroupObjects.setSelection(config.isGroupObjects());
 
       checkHideObjectsInMaintenance = new Button(optionsGroup, SWT.CHECK);
-      checkHideObjectsInMaintenance.setText("Hide objects in &maintenance mode");
+      checkHideObjectsInMaintenance.setText(i18n.tr("Hide objects in &maintenance mode"));
       checkHideObjectsInMaintenance.setSelection(config.isHideObjectsInMaintenance());
 
 		checkShowFilter = new Button(optionsGroup, SWT.CHECK);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/TableValue.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/TableValue.java
@@ -150,7 +150,7 @@ public class TableValue extends DashboardElementPropertyPage
       templateDciWidget.setEnabled(config.getObjectId() == AbstractObject.CONTEXT);
 
       Group goupSortingOrder = new Group(dialogArea, SWT.NONE);
-      goupSortingOrder.setText("Sorting order");
+      goupSortingOrder.setText(i18n.tr("Sorting order"));
       layout = new GridLayout();
       layout.marginTop = WidgetHelper.OUTER_SPACING;
       layout.marginBottom = WidgetHelper.OUTER_SPACING * 2;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/widgets/TitleConfigurator.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/dashboards/widgets/TitleConfigurator.java
@@ -115,7 +115,7 @@ public class TitleConfigurator extends Composite
       foregroundColor.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false, 1, 2));
 
       fontHeight = new LabeledSpinner(group, SWT.NONE);
-      fontHeight.setLabel("Font size adjustment");
+      fontHeight.setLabel(i18n.tr("Font size adjustment"));
       fontHeight.setRange(-20, 20);
       fontHeight.setSelection(config.getTitleFontSize());
       fontHeight.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/BulkUpdateDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/BulkUpdateDialog.java
@@ -84,7 +84,7 @@ public class BulkUpdateDialog extends Dialog
       }));
       
       ArrayList<String> dataUnits = new ArrayList<String>();
-      dataUnits.add("No change");
+      dataUnits.add(i18n.tr("No change"));
       Collections.addAll(dataUnits, General.DATA_UNITS);
       BulkDciUpdateElementUI unitName = new BulkDciUpdateElementUI("Unit name", NXCPCodes.VID_UNITS_NAME, dataUnits.toArray(new String[dataUnits.size()]));
       unitName.setEditableDropdown(true);
@@ -131,7 +131,7 @@ public class BulkUpdateDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Bulk DCI update");
+      newShell.setText(i18n.tr("Bulk DCI update"));
    }
    
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/CreatePolicyDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/CreatePolicyDialog.java
@@ -27,15 +27,19 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.netxms.client.AgentPolicy;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.datacollection.views.helpers.PolicyLabelProvider;
 import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Policy creation dialog
  */
 public class CreatePolicyDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(CreatePolicyDialog.class);
+
    private static final String[] POLICY_TYPE_ORDER = { AgentPolicy.AGENT_CONFIG, AgentPolicy.FILE_DELIVERY, AgentPolicy.LOG_PARSER, AgentPolicy.SUPPORT_APPLICATION };
 
 	private String policyName;
@@ -64,7 +68,7 @@ public class CreatePolicyDialog extends Dialog
 	protected void configureShell(Shell newShell)
 	{
 		super.configureShell(newShell);
-		newShell.setText("Create new policy");
+		newShell.setText(i18n.tr("Create new policy"));
 	}
 	
    /**
@@ -92,7 +96,7 @@ public class CreatePolicyDialog extends Dialog
       }
       else
       {         
-         typeSelector = WidgetHelper.createLabeledCombo(dialogArea, SWT.BORDER | SWT.READ_ONLY, "Policy type", WidgetHelper.DEFAULT_LAYOUT_DATA);
+         typeSelector = WidgetHelper.createLabeledCombo(dialogArea, SWT.BORDER | SWT.READ_ONLY, i18n.tr("Policy type"), WidgetHelper.DEFAULT_LAYOUT_DATA);
          PolicyLabelProvider labelProvider = new PolicyLabelProvider();
          for(String t : POLICY_TYPE_ORDER)
             typeSelector.add(labelProvider.getPolicyTypeDisplayName(t));

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/DisableThresholdsDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/DisableThresholdsDialog.java
@@ -65,7 +65,7 @@ public class DisableThresholdsDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Disable DCI Threshold processing");
+      newShell.setText(i18n.tr("Disable DCI Threshold processing"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditColumnDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditColumnDialog.java
@@ -127,7 +127,7 @@ public class EditColumnDialog extends Dialog
 		checkInstanceColumn.setSelection(column.isInstanceColumn());
 
       checkSnmpHexString = new Button(dialogArea, SWT.CHECK);
-      checkSnmpHexString.setText("Convert SNMP value to &hexadecimal string");
+      checkSnmpHexString.setText(i18n.tr("Convert SNMP value to &hexadecimal string"));
       checkSnmpHexString.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));
       checkSnmpHexString.setSelection(column.isConvertSnmpStringToHex());
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditDciSummaryTableColumnDlg.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditDciSummaryTableColumnDlg.java
@@ -93,7 +93,7 @@ public class EditDciSummaryTableColumnDlg extends Dialog
       dciName.setText(column.getDciName());
       
       checkDescriptionMatch = new Button(dialogArea, SWT.CHECK);
-      checkDescriptionMatch.setText("Match by description instead of name");
+      checkDescriptionMatch.setText(i18n.tr("Match by description instead of name"));
       checkDescriptionMatch.setSelection(column.isDescriptionMatch());
 
       checkRegexpMatch = new Button(dialogArea, SWT.CHECK);
@@ -101,7 +101,7 @@ public class EditDciSummaryTableColumnDlg extends Dialog
       checkRegexpMatch.setSelection(column.isRegexpMatch());
 
       checkMultivalued = new Button(dialogArea, SWT.CHECK);
-      checkMultivalued.setText("&Multivalued column");
+      checkMultivalued.setText(i18n.tr("&Multivalued column"));
       checkMultivalued.setSelection(column.isMultivalued());
       checkMultivalued.addSelectionListener(new SelectionAdapter() {
          @Override
@@ -112,7 +112,7 @@ public class EditDciSummaryTableColumnDlg extends Dialog
       });
       
       separator = new LabeledText(dialogArea, SWT.NONE);
-      separator.setLabel("&Separator for multiple values");
+      separator.setLabel(i18n.tr("&Separator for multiple values"));
       separator.getTextControl().setTextLimit(15);
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditTableThresholdDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditTableThresholdDialog.java
@@ -103,12 +103,12 @@ public class EditTableThresholdDialog extends Dialog
 		deactivationEvent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
 		sampleCount = new LabeledSpinner(dialogArea, SWT.NONE);
-		sampleCount.setLabel("Sample count");
+		sampleCount.setLabel(i18n.tr("Sample count"));
 		sampleCount.setRange(1, 100000);
 		sampleCount.setSelection(threshold.getSampleCount());
 
 		deactivationSampleCount = new LabeledSpinner(dialogArea, SWT.NONE);
-		deactivationSampleCount.setLabel("Deactivation sample count");
+		deactivationSampleCount.setLabel(i18n.tr("Deactivation sample count"));
 		deactivationSampleCount.setRange(1, 100000);
 		deactivationSampleCount.setSelection(threshold.getDeactivationSampleCount());
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/HistoricalDataSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/HistoricalDataSelectionDialog.java
@@ -101,7 +101,7 @@ public class HistoricalDataSelectionDialog extends Dialog
 		dtsFrom.setValue(timeFrom);
 		dtsFrom.setEnabled(radioTimeFrame.getSelection());
 		
-		new Label(dialogArea, SWT.NONE).setText("  -  ");
+		new Label(dialogArea, SWT.NONE).setText(i18n.tr("  -  "));
 		
 		dtsTo = new DateTimeSelector(dialogArea, SWT.NONE);
 		dtsTo.setValue(timeTo);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SavePolicyDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SavePolicyDialog.java
@@ -31,14 +31,18 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.ResourceManager;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Shows prompt for saving agent's policy
  */
 public class SavePolicyDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(SavePolicyDialog.class);
+
    public static final int SAVE_ID = 100;
    public static final int DISCARD_ID = 102;
 
@@ -57,7 +61,7 @@ public class SavePolicyDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Unsaved Changes");
+      newShell.setText(i18n.tr("Unsaved Changes"));
    }
 
    /**
@@ -98,7 +102,7 @@ public class SavePolicyDialog extends Dialog
       });
 
       final CLabel text = new CLabel(dialogArea, SWT.LEFT);
-      text.setText("Policy is not saved.\nDo you want to save it, discard changes, or return to the editor?");
+      text.setText(i18n.tr("Policy is not saved.\nDo you want to save it, discard changes, or return to the editor?"));
       GridData gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
       gd.horizontalAlignment = SWT.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SelectNetconfQueryDlg.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SelectNetconfQueryDlg.java
@@ -40,14 +40,18 @@ import org.netxms.client.datacollection.NetconfQueryDefinition;
 import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.Registry;
 import org.netxms.nxmc.base.jobs.Job;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for selecting NETCONF query definition
  */
 public class SelectNetconfQueryDlg extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(SelectNetconfQueryDlg.class);
+
    boolean multiSelection;
    private TableViewer viewer;
    private List<NetconfQueryDefinition> selection;
@@ -83,7 +87,7 @@ public class SelectNetconfQueryDlg extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("NETCONF Query Definition Selection");
+      newShell.setText(i18n.tr("NETCONF Query Definition Selection"));
       PreferenceStore settings = PreferenceStore.getInstance();
       newShell.setSize(settings.getAsPoint("SelectNetconfQueryDlg.size", 400, 250)); 
       newShell.setLocation(settings.getAsPoint("SelectNetconfQueryDlg.location", 100, 100));

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SelectWebServiceDlg.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SelectWebServiceDlg.java
@@ -41,14 +41,18 @@ import org.netxms.client.datacollection.WebServiceDefinition;
 import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.Registry;
 import org.netxms.nxmc.base.jobs.Job;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for selecting web service definition
  */
 public class SelectWebServiceDlg extends Dialog implements IParameterSelectionDialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(SelectWebServiceDlg.class);
+
    boolean multiSelection;
    private TableViewer viewer;
    private List<WebServiceDefinition> selection;
@@ -84,7 +88,7 @@ public class SelectWebServiceDlg extends Dialog implements IParameterSelectionDi
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Web Service Defenition Selection");
+      newShell.setText(i18n.tr("Web Service Defenition Selection"));
       PreferenceStore settings = PreferenceStore.getInstance();
       newShell.setSize(settings.getAsPoint("SelectWebServiceDlg.size", 400, 250)); 
       newShell.setLocation(settings.getAsPoint("SelectWebServiceDlg.location", 100, 100));

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/TestTransformationDlg.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/TestTransformationDlg.java
@@ -148,7 +148,7 @@ public class TestTransformationDlg extends Dialog
       if ((owner == null) || !(owner instanceof DataCollectionTarget))
       {
          ObjectSelectionDialog dlg = new ObjectSelectionDialog(getShell(), ObjectSelectionDialog.createDataCollectionTargetSelectionFilter());
-         dlg.setTitle("Select Execution Target");
+         dlg.setTitle(i18n.tr("Select Execution Target"));
          if (dlg.open() != Window.OK)
          {
             status.setText("Cancelled");
@@ -158,7 +158,7 @@ public class TestTransformationDlg extends Dialog
          owner = dlg.getSelectedObjects().get(0);
          if ((owner == null) || !(owner instanceof DataCollectionTarget))
          {
-            status.setText("Invalid execution target");
+            status.setText(i18n.tr("Invalid execution target"));
             status.setImage(StatusDisplayInfo.getStatusImage(Severity.CRITICAL));
             return;
          }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/ClusterOptions.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/ClusterOptions.java
@@ -142,7 +142,7 @@ public class ClusterOptions extends AbstractDCIPropertyPage
    	checkAggregate.setSelection(editor.getObject().isAggregateOnCluster());
 
       checkAggregateWithErrors = new Button(aggregationGroup, SWT.CHECK);
-      checkAggregateWithErrors.setText("Use last known value for aggregation in case of data collection error");
+      checkAggregateWithErrors.setText(i18n.tr("Use last known value for aggregation in case of data collection error"));
       checkAggregateWithErrors.setSelection(editor.getObject().isAggregateWithErrors());
          
       checkRunScript = new Button(aggregationGroup, SWT.CHECK);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java
@@ -165,7 +165,7 @@ public class General extends AbstractDCIPropertyPage
       dialogArea.setLayout(layout);
 
       Group groupMetricConfig = new Group(dialogArea, SWT.NONE);
-      groupMetricConfig.setText("Metric to collect");
+      groupMetricConfig.setText(i18n.tr("Metric to collect"));
       layout = new GridLayout();
       layout.marginHeight = WidgetHelper.OUTER_SPACING;
       layout.marginWidth = WidgetHelper.OUTER_SPACING;
@@ -205,7 +205,7 @@ public class General extends AbstractDCIPropertyPage
       });
 
       sourceNode = new ObjectSelector(groupMetricConfig, SWT.NONE, true);
-      sourceNode.setLabel("Source node override");
+      sourceNode.setLabel(i18n.tr("Source node override"));
       sourceNode.setObjectClass(Node.class);
       sourceNode.setObjectId(dco.getSourceNode());
       sourceNode.setEnabled(dco.getOrigin() != DataOrigin.PUSH && dco.getOrigin() != DataOrigin.OTLP);
@@ -226,7 +226,7 @@ public class General extends AbstractDCIPropertyPage
       metricSelector.setLayoutData(gd);
 
       description = new LabeledText(groupMetricConfig, SWT.NONE);
-      description.setLabel("Display name");
+      description.setLabel(i18n.tr("Display name"));
       description.getTextControl().setTextLimit(255);
       description.setText(dco.getDescription());
       gd = new GridData();
@@ -287,7 +287,7 @@ public class General extends AbstractDCIPropertyPage
          }
          dataUnit.select(selection);
 
-         useMultipliers = WidgetHelper.createLabeledCombo(groupProcessingAndVisualization, SWT.READ_ONLY, "Use multipliers", new GridData());
+         useMultipliers = WidgetHelper.createLabeledCombo(groupProcessingAndVisualization, SWT.READ_ONLY, i18n.tr("Use multipliers"), new GridData());
          useMultipliers.add("Default");
          useMultipliers.add("Yes");
          useMultipliers.add("No");
@@ -297,7 +297,7 @@ public class General extends AbstractDCIPropertyPage
          gd.grabExcessHorizontalSpace = true;
          gd.horizontalAlignment = SWT.FILL;
          gd.horizontalSpan = 3;
-         mappingTableSelector = WidgetHelper.createLabeledCombo(groupProcessingAndVisualization, SWT.READ_ONLY, "Display value mapping table", gd);
+         mappingTableSelector = WidgetHelper.createLabeledCombo(groupProcessingAndVisualization, SWT.READ_ONLY, i18n.tr("Display value mapping table"), gd);
          mappingTableSelector.add(i18n.tr("(none)"));
          mappingTableSelector.select(0);
          mappingTableSelector.setEnabled(false);
@@ -305,7 +305,7 @@ public class General extends AbstractDCIPropertyPage
       }
 
       Group groupPolling = new Group(dialogArea, SWT.NONE);
-      groupPolling.setText("Collection schedule");
+      groupPolling.setText(i18n.tr("Collection schedule"));
       layout = new GridLayout();
       layout.marginTop = WidgetHelper.OUTER_SPACING;
       layout.marginBottom = WidgetHelper.OUTER_SPACING * 2;
@@ -341,7 +341,7 @@ public class General extends AbstractDCIPropertyPage
       scheduleDefault.setLayoutData(gd);
 
       scheduleFixed = new Button(groupPolling, SWT.RADIO);
-      scheduleFixed.setText("Custom interval");
+      scheduleFixed.setText(i18n.tr("Custom interval"));
       scheduleFixed.setSelection(dco.getPollingScheduleType() == DataCollectionObject.POLLING_SCHEDULE_CUSTOM);
       scheduleFixed.addSelectionListener(pollingButtons);
       scheduleFixed.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
@@ -364,7 +364,7 @@ public class General extends AbstractDCIPropertyPage
       pollingIntervalComposite.setLayoutData(gd);
 
       scheduleAdvanced = new Button(groupPolling, SWT.RADIO);
-      scheduleAdvanced.setText("Advanced schedule");
+      scheduleAdvanced.setText(i18n.tr("Advanced schedule"));
       scheduleAdvanced.setSelection(dco.getPollingScheduleType() == DataCollectionObject.POLLING_SCHEDULE_ADVANCED);
       scheduleAdvanced.addSelectionListener(pollingButtons);
       scheduleAdvanced.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
@@ -387,7 +387,7 @@ public class General extends AbstractDCIPropertyPage
       scheduleLink.setVisible(scheduleAdvanced.getSelection());
 
       Group groupRetention = new Group(dialogArea, SWT.NONE);
-      groupRetention.setText("History retention period");
+      groupRetention.setText(i18n.tr("History retention period"));
       layout = new GridLayout();
       layout.marginTop = WidgetHelper.OUTER_SPACING;
       layout.marginBottom = WidgetHelper.OUTER_SPACING * 2;
@@ -448,7 +448,7 @@ public class General extends AbstractDCIPropertyPage
       retentionTimeComposite.setLayoutData(gd);
 
       storageNoStorage = new Button(groupRetention, SWT.RADIO);
-      storageNoStorage.setText("Do not save to the database");
+      storageNoStorage.setText(i18n.tr("Do not save to the database"));
       storageNoStorage.setSelection(dco.getRetentionType() == DataCollectionObject.RETENTION_NONE);
       storageNoStorage.addSelectionListener(storageButtons);
 
@@ -467,7 +467,7 @@ public class General extends AbstractDCIPropertyPage
          sampleSaveComposite.setLayout(layout);
 
          Label sampleSaveLabel = new Label(sampleSaveComposite, SWT.NONE);
-         sampleSaveLabel.setText("Save every");
+         sampleSaveLabel.setText(i18n.tr("Save every"));
 
          sampleSaveInterval = new Spinner(sampleSaveComposite, SWT.BORDER);
          sampleSaveInterval.setMinimum(1);
@@ -483,7 +483,7 @@ public class General extends AbstractDCIPropertyPage
          sampleSaveComposite.setLayoutData(gd);
 
          checkSaveOnlyChangedValues = new Button(groupRetention, SWT.CHECK);
-         checkSaveOnlyChangedValues.setText("Save only &changed values");
+         checkSaveOnlyChangedValues.setText(i18n.tr("Save only &changed values"));
          checkSaveOnlyChangedValues.setSelection(dci.isStoreChangesOnly());
          gd = new GridData();
          gd.horizontalSpan = 2;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/InstanceDiscovery.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/InstanceDiscovery.java
@@ -193,7 +193,7 @@ public class InstanceDiscovery extends AbstractDCIPropertyPage
       instanceNameFormat.setEnabled(isOtlp);
 
       groupRetention = new Group(dialogArea, SWT.NONE);
-      groupRetention.setText("Instance retention");
+      groupRetention.setText(i18n.tr("Instance retention"));
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;
       gd.verticalAlignment = SWT.FILL;
@@ -207,8 +207,8 @@ public class InstanceDiscovery extends AbstractDCIPropertyPage
       gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
       gd.horizontalAlignment = SWT.FILL;
-      instanceRetentionMode = WidgetHelper.createLabeledCombo(groupRetention, SWT.READ_ONLY, "Instance retention mode", gd);
-      instanceRetentionMode.add("Server default");
+      instanceRetentionMode = WidgetHelper.createLabeledCombo(groupRetention, SWT.READ_ONLY, i18n.tr("Instance retention mode"), gd);
+      instanceRetentionMode.add(i18n.tr("Server default"));
       instanceRetentionMode.add("Custom");
       instanceRetentionMode.select(dco.getInstanceRetentionTime() == -1 ? 0 : 1);
       instanceRetentionMode.setEnabled(dco.getInstanceDiscoveryMethod() != DataCollectionObject.IDM_NONE);
@@ -223,7 +223,7 @@ public class InstanceDiscovery extends AbstractDCIPropertyPage
       gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
       gd.horizontalAlignment = SWT.FILL;
-      instanceRetentionTime = WidgetHelper.createLabeledSpinner(groupRetention, SWT.BORDER, "Instance retention time (days)", 0, 100,  new GridData());
+      instanceRetentionTime = WidgetHelper.createLabeledSpinner(groupRetention, SWT.BORDER, i18n.tr("Instance retention time (days)"), 0, 100,  new GridData());
       instanceRetentionTime.setSelection(dco.getInstanceRetentionTime());
       instanceRetentionTime.setEnabled(instanceRetentionMode.getSelectionIndex() > 0);
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java
@@ -139,17 +139,17 @@ public class OtherOptions extends AbstractDCIPropertyPage
 
       multiplierDegree = new LabeledCombo(dialogArea, SWT.NONE);
       multiplierDegree.setLabel(i18n.tr("Multiplier degree"));
-      multiplierDegree.add("Fixed to P");
-      multiplierDegree.add("Fixed to T");
-      multiplierDegree.add("Fixed to G");
-      multiplierDegree.add("Fixed to M");
-      multiplierDegree.add("Fixed to K");
+      multiplierDegree.add(i18n.tr("Fixed to P"));
+      multiplierDegree.add(i18n.tr("Fixed to T"));
+      multiplierDegree.add(i18n.tr("Fixed to G"));
+      multiplierDegree.add(i18n.tr("Fixed to M"));
+      multiplierDegree.add(i18n.tr("Fixed to K"));
       multiplierDegree.add("Default");
-      multiplierDegree.add("Fixed to m");
-      multiplierDegree.add("Fixed to μ");
-      multiplierDegree.add("Fixed to n");
-      multiplierDegree.add("Fixed to p");
-      multiplierDegree.add("Fixed to f");
+      multiplierDegree.add(i18n.tr("Fixed to m"));
+      multiplierDegree.add(i18n.tr("Fixed to μ"));
+      multiplierDegree.add(i18n.tr("Fixed to n"));
+      multiplierDegree.add(i18n.tr("Fixed to p"));
+      multiplierDegree.add(i18n.tr("Fixed to f"));
       multiplierDegree.select(5 - dci.getMultiplier());
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;
@@ -157,7 +157,7 @@ public class OtherOptions extends AbstractDCIPropertyPage
       multiplierDegree.setLayoutData(gd);
 
       relatedObject = new ObjectSelector(dialogArea, SWT.NONE, true);
-      relatedObject.setLabel("Related object");
+      relatedObject.setLabel(i18n.tr("Related object"));
       relatedObject.setObjectClass(GenericObject.class);
       relatedObject.setObjectId(dci.getRelatedObject());
       gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptionsTable.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptionsTable.java
@@ -85,7 +85,7 @@ public class OtherOptionsTable extends AbstractDCIPropertyPage
       agentCacheMode.select(dci.getCacheMode().getValue());
 
       relatedObject = new ObjectSelector(dialogArea, SWT.NONE, true);
-      relatedObject.setLabel("Related object");
+      relatedObject.setLabel(i18n.tr("Related object"));
       relatedObject.setObjectClass(GenericObject.class);
       relatedObject.setObjectId(dci.getRelatedObject());
       GridData gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/SNMP.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/SNMP.java
@@ -171,7 +171,7 @@ public class SNMP extends AbstractDCIPropertyPage
       customSnmpPort.setLayoutData(gd);
 
       checkUseCustomSnmpVersion = new Button(pageArea, SWT.CHECK);
-      checkUseCustomSnmpVersion.setText("Use custom SNMP version:");
+      checkUseCustomSnmpVersion.setText(i18n.tr("Use custom SNMP version:"));
       checkUseCustomSnmpVersion.setSelection(dco.getSnmpVersion() != SnmpVersion.DEFAULT);
       checkUseCustomSnmpVersion.addSelectionListener(new SelectionAdapter() {
          @Override

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/SummaryTableGeneral.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/SummaryTableGeneral.java
@@ -91,7 +91,7 @@ public class SummaryTableGeneral extends PropertyPage
       if (table.isTableSoure())
       {
          dciName = new LabeledText(dialogArea, SWT.NONE);
-         dciName.setLabel("DCI name");
+         dciName.setLabel(i18n.tr("DCI name"));
          dciName.getTextControl().setTextLimit(255);
          dciName.setText(table.getTableDciName());
          dciName.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/views/SummaryDataCollectionView.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/views/SummaryDataCollectionView.java
@@ -125,7 +125,7 @@ public class SummaryDataCollectionView extends BaseDataCollectionView
       searchBar.setLayoutData(fd);
       
       queryEditor = new LabeledText(searchBar, SWT.NONE);
-      queryEditor.setLabel("Search string");
+      queryEditor.setLabel(i18n.tr("Search string"));
       queryEditor.getTextControl().addKeyListener(new KeyListener() {
          @Override
          public void keyReleased(KeyEvent e)
@@ -147,7 +147,7 @@ public class SummaryDataCollectionView extends BaseDataCollectionView
       startButton = new Button(searchBar, SWT.PUSH);
       startButton.setImage(SharedIcons.IMG_EXECUTE);
       startButton.setText("Start");
-      startButton.setToolTipText("Start search");
+      startButton.setToolTipText(i18n.tr("Start search"));
       startButton.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/views/TemplateGraphView.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/views/TemplateGraphView.java
@@ -462,7 +462,7 @@ public class TemplateGraphView extends ConfigurationView implements SessionListe
          protected void configureShell(Shell newShell)
          {
             super.configureShell(newShell);
-            newShell.setText("Properties for " + settings.getDisplayName());
+            newShell.setText(i18n.tr("Properties for ") + settings.getDisplayName());
          }
       };
       dlg.setBlockOnOpen(true);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/widgets/AgentConfigPolicyEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/widgets/AgentConfigPolicyEditor.java
@@ -29,15 +29,19 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.netxms.client.AgentPolicy;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.agentmanagement.widgets.AgentConfigEditor;
 import org.netxms.nxmc.modules.datacollection.views.PolicyEditorView;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Editor for agent configuration policy
  */
 public class AgentConfigPolicyEditor extends AbstractPolicyEditor
 {
+   private final I18n i18n = LocalizationHelper.getI18n(AgentConfigPolicyEditor.class);
+
    private AgentConfigEditor editor;
    private Button buttonExpandMacro;
    
@@ -64,7 +68,7 @@ public class AgentConfigPolicyEditor extends AbstractPolicyEditor
       mainArea.setLayout(layout);
       
       buttonExpandMacro = new Button(mainArea, SWT.CHECK);
-      buttonExpandMacro.setText("Expand macro");
+      buttonExpandMacro.setText(i18n.tr("Expand macro"));
       buttonExpandMacro.setLayoutData(new GridData());
       buttonExpandMacro.addSelectionListener(new SelectionListener() {
          

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java
@@ -58,6 +58,7 @@ import org.netxms.nxmc.base.widgets.LabeledDurationInput;
 import org.netxms.nxmc.base.widgets.LabeledText;
 import org.netxms.nxmc.base.widgets.SortableTableViewer;
 import org.netxms.nxmc.base.widgets.SortableTreeViewer;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.datacollection.dialogs.MenuItemDialog;
 import org.netxms.nxmc.modules.datacollection.views.PolicyEditorView;
 import org.netxms.nxmc.modules.datacollection.widgets.helpers.AppMenuItem;
@@ -70,12 +71,15 @@ import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Support application editor widget
  */
 public class SupportAppPolicyEditor extends AbstractPolicyEditor
 {
+   private final I18n i18n = LocalizationHelper.getI18n(SupportAppPolicyEditor.class);
+
    private static final Logger logger = LoggerFactory.getLogger(SupportAppPolicy.class);
    
    public static final int NAME = 0;
@@ -166,7 +170,7 @@ public class SupportAppPolicyEditor extends AbstractPolicyEditor
       createIconSelector(topArea);
       
       Group colorSelectors = new Group(topArea, SWT.NONE);
-      colorSelectors.setText("Color schema");
+      colorSelectors.setText(i18n.tr("Color schema"));
       layout = new GridLayout();
       layout.verticalSpacing = WidgetHelper.OUTER_SPACING;
       layout.numColumns = 3;
@@ -177,7 +181,7 @@ public class SupportAppPolicyEditor extends AbstractPolicyEditor
       GridData gd = new GridData();
       gd.horizontalSpan = layout.numColumns;
       customColorSchemaCheckbox = new Button(colorSelectors, SWT.CHECK);
-      customColorSchemaCheckbox.setText("Use custom color schema");
+      customColorSchemaCheckbox.setText(i18n.tr("Use custom color schema"));
       customColorSchemaCheckbox.setLayoutData(gd);
       customColorSchemaCheckbox.setSelection(policyData.menuBackgroundColor != null);
 
@@ -204,22 +208,22 @@ public class SupportAppPolicyEditor extends AbstractPolicyEditor
       messageArea.setLayout(layout);
 
       welcomeMessageText = new LabeledText(messageArea, SWT.NONE, SWT.MULTI | SWT.BORDER);
-      welcomeMessageText.setLabel("Welcome message");
+      welcomeMessageText.setLabel(i18n.tr("Welcome message"));
       welcomeMessageText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
       tooltipMessageText = new LabeledText(messageArea, SWT.NONE, SWT.MULTI | SWT.BORDER);
-      tooltipMessageText.setLabel("Tooltip message");
+      tooltipMessageText.setLabel(i18n.tr("Tooltip message"));
       tooltipMessageText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
       Group windowBehaviorGroup = new Group(topArea, SWT.NONE);
-      windowBehaviorGroup.setText("Window behavior");
+      windowBehaviorGroup.setText(i18n.tr("Window behavior"));
       windowBehaviorGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
       layout = new GridLayout();
       layout.numColumns = 2;
       windowBehaviorGroup.setLayout(layout);
 
       closeOnDeactivateCheckbox = new Button(windowBehaviorGroup, SWT.CHECK);
-      closeOnDeactivateCheckbox.setText("Close on &deactivate");
+      closeOnDeactivateCheckbox.setText(i18n.tr("Close on &deactivate"));
       gd = new GridData();
       gd.horizontalSpan = layout.numColumns;
       closeOnDeactivateCheckbox.setLayoutData(gd);
@@ -228,24 +232,24 @@ public class SupportAppPolicyEditor extends AbstractPolicyEditor
             new GridData(SWT.FILL, SWT.BOTTOM, true, false));
       windowPositioning.add("Undefined");
       windowPositioning.add("Automatic");
-      windowPositioning.add("Top - Left");
-      windowPositioning.add("Top - Center");
-      windowPositioning.add("Top - Right");
-      windowPositioning.add("Middle - Left");
-      windowPositioning.add("Middle - Center");
-      windowPositioning.add("Middle - Right");
-      windowPositioning.add("Bottom - Left");
-      windowPositioning.add("Bottom - Center");
-      windowPositioning.add("Bottom - Right");
+      windowPositioning.add(i18n.tr("Top - Left"));
+      windowPositioning.add(i18n.tr("Top - Center"));
+      windowPositioning.add(i18n.tr("Top - Right"));
+      windowPositioning.add(i18n.tr("Middle - Left"));
+      windowPositioning.add(i18n.tr("Middle - Center"));
+      windowPositioning.add(i18n.tr("Middle - Right"));
+      windowPositioning.add(i18n.tr("Bottom - Left"));
+      windowPositioning.add(i18n.tr("Bottom - Center"));
+      windowPositioning.add(i18n.tr("Bottom - Right"));
       windowPositioning.select(0);
 
       notificationTimeout = new LabeledDurationInput(windowBehaviorGroup, SWT.NONE);
-      notificationTimeout.setLabel("Notification timeout");
+      notificationTimeout.setLabel(i18n.tr("Notification timeout"));
       notificationTimeout.setRange(0, 3600);
       notificationTimeout.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, false));
 
       desktopWallpaperFile = new LabeledText(topArea, SWT.NONE);
-      desktopWallpaperFile.setLabel("Desktop wallpaper file name");
+      desktopWallpaperFile.setLabel(i18n.tr("Desktop wallpaper file name"));
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;
       gd.grabExcessHorizontalSpace = true;
@@ -356,7 +360,7 @@ public class SupportAppPolicyEditor extends AbstractPolicyEditor
    private void createIconSelector(Composite parent)
    {
       Group group = new Group(parent, SWT.NONE);
-      group.setText("Application Icon");
+      group.setText(i18n.tr("Application Icon"));
       GridData gd = new GridData(SWT.FILL, SWT.FILL, false, false);
       group.setLayoutData(gd);
       

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/dialogs/RuleSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/dialogs/RuleSelectionDialog.java
@@ -123,11 +123,11 @@ public class RuleSelectionDialog extends Dialog
 		viewer.getTable().setHeaderVisible(true);
 
       TableColumn column = new TableColumn(viewer.getTable(), SWT.LEFT);
-      column.setText("Rule #");
+      column.setText(i18n.tr("Rule #"));
       column.setWidth(60);
 
       column = new TableColumn(viewer.getTable(), SWT.LEFT);
-      column.setText("Rule Name");
+      column.setText(i18n.tr("Rule Name"));
       column.setWidth(250);
 	      
 		viewer.setContentProvider(new ArrayContentProvider());

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleAlarm.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleAlarm.java
@@ -236,7 +236,7 @@ public class RuleAlarm extends RuleBasePropertyPage
 		timeoutEvent.setLayoutData(gd);
 
       rcaScript = new ScriptSelector(alarmCreationGroup, SWT.NONE, false, true);
-      rcaScript.setLabel("Root cause analysis script");
+      rcaScript.setLabel(i18n.tr("Root cause analysis script"));
       rcaScript.setScriptName(rule.getRcaScriptName());
       gd = new GridData();
       gd.grabExcessHorizontalSpace = true;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleDowntimeControl.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleDowntimeControl.java
@@ -93,7 +93,7 @@ public class RuleDowntimeControl extends RuleBasePropertyPage
          selectionDoNothing.setSelection(true);
       
       tag = new LabeledText(dialogArea, SWT.NONE);
-      tag.setLabel("Downtime tag");
+      tag.setLabel(i18n.tr("Downtime tag"));
       tag.setTextLimit(15);
       tag.setText(rule.getDowntimeTag());
       tag.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RulePersistentStorage.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RulePersistentStorage.java
@@ -104,7 +104,7 @@ public class RulePersistentStorage extends RuleBasePropertyPage
       keysToSetEditor.setLayoutData(gd);
 
       label = new Label(dialogArea, SWT.NONE);
-      label.setText("Delete persistent storage entries");
+      label.setText(i18n.tr("Delete persistent storage entries"));
       gd = new GridData();
       gd.verticalIndent = vInd;
       label.setLayoutData(gd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleSourceObjects.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleSourceObjects.java
@@ -174,7 +174,7 @@ public class RuleSourceObjects extends RuleBasePropertyPage
       new Label(dialogArea, SWT.SEPARATOR | SWT.HORIZONTAL).setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
       Label label = new Label(dialogArea, SWT.NONE);
-      label.setText("Exclusions:");   
+      label.setText(i18n.tr("Exclusions:"));   
       
       excludeViewer = new TableViewer(dialogArea, SWT.BORDER | SWT.MULTI | SWT.FULL_SELECTION);
       excludeViewer.setContentProvider(new ArrayContentProvider());

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/filemanager/dialogs/FileFingerprintDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/filemanager/dialogs/FileFingerprintDialog.java
@@ -14,13 +14,17 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.AgentFileFingerprint;
 import org.netxms.nxmc.base.widgets.LabeledText;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog to show file fingerprint in file manager
  */
 public class FileFingerprintDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(FileFingerprintDialog.class);
+
    private AgentFileFingerprint fp;
 
    /**
@@ -131,7 +135,7 @@ public class FileFingerprintDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("File Fingerprint");
+      newShell.setText(i18n.tr("File Fingerprint"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/filemanager/views/ServerFileManager.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/filemanager/views/ServerFileManager.java
@@ -308,7 +308,7 @@ public class ServerFileManager extends ConfigurationView implements SessionListe
    private void uploadFile()
    {
       FileDialog fd = new FileDialog(getWindow().getShell(), SWT.OPEN | SWT.MULTI);
-      fd.setText("Select Files");
+      fd.setText(i18n.tr("Select Files"));
       if (fd.open() == null)
          return;
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/imagelibrary/dialogs/ImagePropertiesDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/imagelibrary/dialogs/ImagePropertiesDialog.java
@@ -100,7 +100,7 @@ public class ImagePropertiesDialog extends Dialog
 					public void widgetSelected(SelectionEvent e)
 					{
 						FileDialog dialog = new FileDialog(getShell(), SWT.OPEN);
-                  dialog.setText("Image Properties");
+                  dialog.setText(i18n.tr("Image Properties"));
                   WidgetHelper.setFileDialogFilterExtensions(dialog, new String[] { i18n.tr("Image files"), i18n.tr("All files") });
                   dialog.setFilterExtensions(new String[] { "*.jpg;*.jpeg;*.png;*.bmp;*.svg", "*.*" });
 						final String selectedFile = dialog.open();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/imagelibrary/widgets/ImagePreview.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/imagelibrary/widgets/ImagePreview.java
@@ -36,6 +36,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.netxms.client.LibraryImage;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.imagelibrary.ImageProvider;
 import org.netxms.nxmc.modules.imagelibrary.ImageProviderTools;
 import org.netxms.nxmc.tools.FontTools;
@@ -44,12 +45,15 @@ import org.netxms.ui.svg.SVGImage;
 import org.netxms.ui.svg.SVGParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Image preview widget for image library
  */
 public class ImagePreview extends Composite
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ImagePreview.class);
+
    private static final Logger logger = LoggerFactory.getLogger(ImagePreview.class);
 
    private static final String[] HEADER_FONTS = { "Verdana", "DejaVu Sans", "Liberation Sans", "Arial" };
@@ -79,7 +83,7 @@ public class ImagePreview extends Composite
 
       imageName = new Label(this, SWT.NONE);
       imageName.setBackground(getBackground());
-      imageName.setText("No image selected");
+      imageName.setText(i18n.tr("No image selected"));
       imageName.setFont(headerFont);
       GridData gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logviewer/dialogs/AuditLogRecordDetailsDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logviewer/dialogs/AuditLogRecordDetailsDialog.java
@@ -38,14 +38,18 @@ import org.netxms.base.DiffMatchPatch.Diff;
 import org.netxms.client.log.LogRecordDetails;
 import org.netxms.nxmc.base.widgets.DiffViewer;
 import org.netxms.nxmc.base.widgets.StyledText;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.ResourceManager;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for displaying audit log record details
  */
 public class AuditLogRecordDetailsDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(AuditLogRecordDetailsDialog.class);
+
    private LogRecordDetails data;
    private CTabFolder tabFolder;
 
@@ -68,7 +72,7 @@ public class AuditLogRecordDetailsDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Audit Log Record Details");
+      newShell.setText(i18n.tr("Audit Log Record Details"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logviewer/dialogs/EventLogRecordDetailsDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logviewer/dialogs/EventLogRecordDetailsDialog.java
@@ -27,12 +27,16 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.log.LogRecordDetails;
 import org.netxms.nxmc.base.widgets.JsonViewer;
+import org.netxms.nxmc.localization.LocalizationHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog for displaying event log record details
  */
 public class EventLogRecordDetailsDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(EventLogRecordDetailsDialog.class);
+
    private LogRecordDetails data;
    private JsonViewer text;
 
@@ -55,7 +59,7 @@ public class EventLogRecordDetailsDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Event Log Record Details");
+      newShell.setText(i18n.tr("Event Log Record Details"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/dialogs/SelectLogParserRuleDlg.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/dialogs/SelectLogParserRuleDlg.java
@@ -134,7 +134,7 @@ public class SelectLogParserRuleDlg extends Dialog
       column.setWidth(250);
 
       column = new TableColumn(viewer.getTable(), SWT.LEFT);
-      column.setText("Match Expression");
+      column.setText(i18n.tr("Match Expression"));
       column.setWidth(250);
 
       viewer.setContentProvider(new ArrayContentProvider());

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserFileEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserFileEditor.java
@@ -82,7 +82,7 @@ public class LogParserFileEditor extends DashboardComposite
 		setLayout(layout);
 		
 		labelFileName = new LabeledText(this, SWT.NONE);
-      labelFileName.setLabel("File path");
+      labelFileName.setLabel(i18n.tr("File path"));
       labelFileName.setBackground(getBackground());
       labelFileName.setText((file != null) ? file.getFile() : "");
       GridData gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserMetricEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserMetricEditor.java
@@ -73,7 +73,7 @@ public class LogParserMetricEditor extends DashboardComposite
       setLayout(layout);
 
       labelMetricName = new LabeledText(this, SWT.NONE);
-      labelMetricName.setLabel("Metric name");
+      labelMetricName.setLabel(i18n.tr("Metric name"));
       labelMetricName.setBackground(getBackground());
       labelMetricName.setText(metric.getMetric());
       GridData gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserRuleEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserRuleEditor.java
@@ -408,7 +408,7 @@ public class LogParserRuleEditor extends DashboardComposite
          timeUnits.addModifyListener(listener);
 
          checkboxReset = new Button(matcherRepeatConf, SWT.CHECK);
-         checkboxReset.setText("Reset repeat count");
+         checkboxReset.setText(i18n.tr("Reset repeat count"));
          checkboxReset.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkColor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkColor.java
@@ -171,7 +171,7 @@ public class LinkColor extends LinkPropertyPage
       remove.setEnabled(radioColorObject.getSelection());
 
       checkUseThresholds = new Button(nodeSelectionGroup, SWT.CHECK);
-      checkUseThresholds.setText("Include active &thresholds into calculation");
+      checkUseThresholds.setText(i18n.tr("Include active &thresholds into calculation"));
       checkUseThresholds.setEnabled(radioColorObject.getSelection());
       checkUseThresholds.setSelection(linkEditor.isUseActiveThresholds());
       gd = new GridData();
@@ -180,7 +180,7 @@ public class LinkColor extends LinkPropertyPage
       checkUseThresholds.setLayoutData(gd);
 
       checkUseUtilization = new Button(nodeSelectionGroup, SWT.CHECK);
-      checkUseUtilization.setText("Include interface &utilization into calculation");
+      checkUseUtilization.setText(i18n.tr("Include interface &utilization into calculation"));
       checkUseUtilization.setEnabled(radioColorObject.getSelection());
       checkUseUtilization.setSelection(linkEditor.isUseInterfaceUtilization());
       gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkGeneral.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkGeneral.java
@@ -206,7 +206,7 @@ public class LinkGeneral extends LinkPropertyPage
       optionsGroup.setLayoutData(gd);
 
       checkExcludeFromAutomaticUpdate = new Button(optionsGroup, SWT.CHECK);
-      checkExcludeFromAutomaticUpdate.setText("Exclude from automatic updates");
+      checkExcludeFromAutomaticUpdate.setText(i18n.tr("Exclude from automatic updates"));
       checkExcludeFromAutomaticUpdate.setSelection(linkEditor.isExcludeFromAutomaticUpdates());
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/TextBoxGeneral.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/TextBoxGeneral.java
@@ -110,7 +110,7 @@ public class TextBoxGeneral extends PropertyPage
       borderColor.setColorValue(ColorConverter.rgbFromInt(textBoxElement.getBorderColor()));
 
       checkShowBorder = new Button(dialogArea, SWT.CHECK);
-      checkShowBorder.setText("Show border");
+      checkShowBorder.setText(i18n.tr("Show border"));
       checkShowBorder.setSelection(textBoxElement.isBorderRequired());
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/views/AbstractNetworkMapView.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/networkmaps/views/AbstractNetworkMapView.java
@@ -676,7 +676,7 @@ public abstract class AbstractNetworkMapView extends ObjectView implements ISele
       searchBar.setLayoutData(fd);
 
       queryEditor = new LabeledText(searchBar, SWT.NONE);
-      queryEditor.setLabel("Search string");
+      queryEditor.setLabel(i18n.tr("Search string"));
       queryEditor.getTextControl().addKeyListener(new KeyListener() {
          @Override
          public void keyReleased(KeyEvent e)
@@ -703,7 +703,7 @@ public abstract class AbstractNetworkMapView extends ObjectView implements ISele
 
       previousButton = new Button(searchBar, SWT.PUSH);
       previousButton.setImage(SharedIcons.IMG_UP);
-      previousButton.setToolTipText("Find previous (Arrow Up)");
+      previousButton.setToolTipText(i18n.tr("Find previous (Arrow Up)"));
       previousButton.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)
@@ -715,7 +715,7 @@ public abstract class AbstractNetworkMapView extends ObjectView implements ISele
 
       nextButton = new Button(searchBar, SWT.PUSH);
       nextButton.setImage(SharedIcons.IMG_DOWN);
-      nextButton.setToolTipText("Find next (Arrow Down)");
+      nextButton.setToolTipText(i18n.tr("Find next (Arrow Down)"));
       nextButton.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/ObjectsPerspective.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/ObjectsPerspective.java
@@ -362,7 +362,7 @@ public abstract class ObjectsPerspective extends Perspective implements ISelecti
       objectName.setFont(JFaceResources.getBannerFont());
       Menu objectNameMenu = new Menu(objectName);
       MenuItem menuItem = new MenuItem(objectNameMenu, SWT.PUSH);
-      menuItem.setText("&Copy");
+      menuItem.setText(i18n.tr("&Copy"));
       menuItem.setImage(SharedIcons.IMG_COPY);
       menuItem.addSelectionListener(new SelectionAdapter() {
          @Override
@@ -405,7 +405,7 @@ public abstract class ObjectsPerspective extends Perspective implements ISelecti
 
       ToolItem item = new ToolItem(perspectiveToolBar, SWT.DROP_DOWN);
       item.setImage(imageManageViews);
-      item.setToolTipText("Manage views");
+      item.setToolTipText(i18n.tr("Manage views"));
       item.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)
@@ -864,7 +864,7 @@ public abstract class ObjectsPerspective extends Perspective implements ISelecti
    private void createMenuToolItem(String name, final MenuManager menuManager, final Menu menu)
    {
       ToolItem item = new ToolItem(objectMenuBar, SWT.PUSH);
-      item.setText("  " + name + " \u25BE  ");
+      item.setText("  " + name + i18n.tr(" \u25BE  "));
       item.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/dialogs/CreateNodeDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/dialogs/CreateNodeDialog.java
@@ -330,7 +330,7 @@ public class CreateNodeDialog extends Dialog
 		checkDisableSNMP.setSelection((creationFlags & NXCObjectCreationData.CF_DISABLE_SNMP) != 0);
 
       checkDisableSSH = new Button(optionsGroup, SWT.CHECK);
-      checkDisableSSH.setText("Disable usage of SSH for all polls");
+      checkDisableSSH.setText(i18n.tr("Disable usage of SSH for all polls"));
       checkDisableSSH.setSelection((creationFlags & NXCObjectCreationData.CF_DISABLE_SSH) != 0);
 
       checkDisablePing = new Button(optionsGroup, SWT.CHECK);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/dialogs/ObjectQueryEditDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/dialogs/ObjectQueryEditDialog.java
@@ -260,7 +260,7 @@ public class ObjectQueryEditDialog extends Dialog
       buttonAdd.setLayoutData(rd);
 
       buttonEdit = new Button(buttonsRight, SWT.PUSH);
-      buttonEdit.setText("&Edit...");
+      buttonEdit.setText(i18n.tr("&Edit..."));
       buttonEdit.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/dialogs/PhysicalLinkEditDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/dialogs/PhysicalLinkEditDialog.java
@@ -21,16 +21,20 @@ import org.netxms.client.objects.Interface;
 import org.netxms.client.objects.Rack;
 import org.netxms.nxmc.Registry;
 import org.netxms.nxmc.base.widgets.LabeledText;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.objects.widgets.ObjectSelector;
 import org.netxms.nxmc.modules.objects.widgets.PatchPanelSelector;
 import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Dialog to create/edit physical link object
  */
 public class PhysicalLinkEditDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(PhysicalLinkEditDialog.class);
+
    private final static String[] SIDE = { "FRONT", "BACK" };
 
    private PhysicalLink link;
@@ -110,7 +114,7 @@ public class PhysicalLinkEditDialog extends Dialog
       Set<Class<? extends AbstractObject>> filterSet = new HashSet<Class<? extends AbstractObject>>();
       objectSelectorLeft = new ObjectSelector(leftGroup, SWT.NONE, false);
       objectSelectorLeft.setObjectId(link.getLeftObjectId());
-      objectSelectorLeft.setLabel("Interface or rack");
+      objectSelectorLeft.setLabel(i18n.tr("Interface or rack"));
       objectSelectorLeft.setObjectClass(filterSet);
       gd = new GridData();
       gd.horizontalSpan = 2;
@@ -143,7 +147,7 @@ public class PhysicalLinkEditDialog extends Dialog
       AbstractObject obj = session.findObjectById(link.getLeftObjectId());
       patchPanelSelectorLeft = new PatchPanelSelector(leftGroup, SWT.NONE, obj instanceof Rack ? (Rack)obj : null);
       patchPanelSelectorLeft.setPatchPanelId(link.getLeftPatchPanelId());
-      patchPanelSelectorLeft.setLabel("Patch panel");
+      patchPanelSelectorLeft.setLabel(i18n.tr("Patch panel"));
       gd = new GridData();
       gd.horizontalSpan = 2;
       gd.grabExcessHorizontalSpace = true;
@@ -191,7 +195,7 @@ public class PhysicalLinkEditDialog extends Dialog
       filterSet.add(Rack.class);
       objectSelectorRight = new ObjectSelector(rightGroup, SWT.NONE, false);
       objectSelectorRight.setObjectId(link.getRightObjectId());
-      objectSelectorRight.setLabel("Interface or rack");
+      objectSelectorRight.setLabel(i18n.tr("Interface or rack"));
       objectSelectorRight.setObjectClass(filterSet);
       gd = new GridData();
       gd.horizontalSpan = 2;
@@ -224,7 +228,7 @@ public class PhysicalLinkEditDialog extends Dialog
 
       obj = session.findObjectById(link.getRightObjectId());
       patchPanelSelectorRight = new PatchPanelSelector(rightGroup, SWT.NONE, obj instanceof Rack ? (Rack)obj : null);
-      patchPanelSelectorRight.setLabel("Patch panel");
+      patchPanelSelectorRight.setLabel(i18n.tr("Patch panel"));
       gd = new GridData();
       gd.horizontalSpan = 2;
       gd.grabExcessHorizontalSpace = true;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/Agent.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/Agent.java
@@ -206,9 +206,9 @@ public class Agent extends ObjectPropertyPage
       certMappingMethod = WidgetHelper.createLabeledCombo(certificateMappingGroup, SWT.DROP_DOWN | SWT.READ_ONLY, i18n.tr("Method"),
             new GridData(SWT.FILL, SWT.BOTTOM, false, false));
       certMappingMethod.add("Subject");
-      certMappingMethod.add("Public key");
-      certMappingMethod.add("Common name");
-      certMappingMethod.add("Template ID");
+      certMappingMethod.add(i18n.tr("Public key"));
+      certMappingMethod.add(i18n.tr("Common name"));
+      certMappingMethod.add(i18n.tr("Template ID"));
       certMappingMethod.select(node.getAgentCertificateMappingMethod().getValue());
 
       certMappingData = new LabeledText(certificateMappingGroup, SWT.NONE);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/DashboardElements.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/DashboardElements.java
@@ -159,7 +159,7 @@ public class DashboardElements extends ObjectPropertyPage
       columnCount.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false));
 
       checkScrollable = new Button(dialogArea, SWT.CHECK);
-      checkScrollable.setText("&Scrollable content");
+      checkScrollable.setText(i18n.tr("&Scrollable content"));
       checkScrollable.setSelection(dashboard.isScrollable());
       checkScrollable.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false));
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ICMP.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ICMP.java
@@ -134,7 +134,7 @@ public class ICMP extends ObjectPropertyPage
       icmpProxy.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
       
       Group statCollectionGroup = new Group(dialogArea, SWT.NONE);
-      statCollectionGroup.setText("ICMP response statistic collection");
+      statCollectionGroup.setText(i18n.tr("ICMP response statistic collection"));
       layout = new GridLayout();
       layout.horizontalSpacing = WidgetHelper.DIALOG_SPACING;
       layout.numColumns = 3;
@@ -158,7 +158,7 @@ public class ICMP extends ObjectPropertyPage
       radioIcmpStatCollectionOff.setSelection(node.getIcmpStatCollectionMode() == IcmpStatCollectionMode.OFF);
       
       Group icmpTargetGroup = new Group(dialogArea, SWT.NONE);
-      icmpTargetGroup.setText("Additional targets for ICMP response statistic collection");
+      icmpTargetGroup.setText(i18n.tr("Additional targets for ICMP response statistic collection"));
       gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
       gd.grabExcessVerticalSpace = true;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java
@@ -139,15 +139,15 @@ public class LocationControl extends ObjectPropertyPage
       dialogArea.setLayout(layout);
 
       checkGenerateEvent = new Button(dialogArea, SWT.CHECK);
-      checkGenerateEvent.setText("&Generate event when location changes");
+      checkGenerateEvent.setText(i18n.tr("&Generate event when location changes"));
       checkGenerateEvent.setSelection(dcTarget.isLocationChageEventGenerated());
       checkGenerateEvent.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, false));
 
-      locationControlMode = WidgetHelper.createLabeledCombo(dialogArea, SWT.READ_ONLY | SWT.DROP_DOWN, "Location control mode",
+      locationControlMode = WidgetHelper.createLabeledCombo(dialogArea, SWT.READ_ONLY | SWT.DROP_DOWN, i18n.tr("Location control mode"),
             WidgetHelper.DEFAULT_LAYOUT_DATA);
-      locationControlMode.add("No control");
-      locationControlMode.add("Alert when within restricted area");
-      locationControlMode.add("Alert when outside allowed area");
+      locationControlMode.add(i18n.tr("No control"));
+      locationControlMode.add(i18n.tr("Alert when within restricted area"));
+      locationControlMode.add(i18n.tr("Alert when outside allowed area"));
       locationControlMode.select(dcTarget.getGeoLocationControlMode().getValue());
 
       Composite viewerComposite = new Composite(dialogArea, SWT.NONE);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapAppearance.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapAppearance.java
@@ -97,7 +97,7 @@ public class MapAppearance extends ObjectPropertyPage
 
       // Name on maps
       nameOnMap = new LabeledText(dialogArea, SWT.NONE);
-      nameOnMap.setLabel("Name on network maps (leave empty to use normal object name)");
+      nameOnMap.setLabel(i18n.tr("Name on network maps (leave empty to use normal object name)"));
       nameOnMap.setText(object.getConfiguredNameOnMap());
       GridData gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;
@@ -117,7 +117,7 @@ public class MapAppearance extends ObjectPropertyPage
       if (!(object instanceof NetworkMap))
       {
          drillDownObject = new ObjectSelector(dialogArea, SWT.NONE, true);
-         drillDownObject.setLabel("Drill-down object");
+         drillDownObject.setLabel(i18n.tr("Drill-down object"));
          drillDownObject.setObjectClass(AbstractObject.class);
          drillDownObject.setObjectId(object.getDrillDownObjectId());
          drillDownObject.setClassFilter(ObjectSelectionDialog.createDashboardAndNetworkMapSelectionFilter());

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapBackground.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapBackground.java
@@ -174,7 +174,7 @@ public class MapBackground extends ObjectPropertyPage
       sizeGroup.setLayout(layout);
 
       fitToScreen = new Button(sizeGroup, SWT.CHECK);
-      fitToScreen.setText("Fit to scrren");
+      fitToScreen.setText(i18n.tr("Fit to scrren"));
       fitToScreen.setSelection(map.isFitToScreen());
       gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
@@ -261,7 +261,7 @@ public class MapBackground extends ObjectPropertyPage
       image.setLayoutData(gd);
       
       comboImageFit = new LabeledCombo(graphContainer, SWT.NONE);
-      comboImageFit.setLabel("Image fit");
+      comboImageFit.setLabel(i18n.tr("Image fit"));
       comboImageFit.add("Default");
       comboImageFit.add("Center");
       comboImageFit.add("Fit");

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapOptions.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapOptions.java
@@ -296,11 +296,11 @@ public class MapOptions extends ObjectPropertyPage
       linkDisplayGroup.setLayout(layout);
 
       checkShowLinkDirection = new Button(linkDisplayGroup, SWT.CHECK);
-      checkShowLinkDirection.setText("Show link direction");
+      checkShowLinkDirection.setText(i18n.tr("Show link direction"));
       checkShowLinkDirection.setSelection((map.getFlags() & NetworkMap.MF_SHOW_LINK_DIRECTION) != 0);
 
       checkShowTraffic = new Button(linkDisplayGroup, SWT.CHECK);
-      checkShowTraffic.setText("Display traffic data");
+      checkShowTraffic.setText(i18n.tr("Display traffic data"));
       checkShowTraffic.setSelection((map.getFlags() & NetworkMap.MF_SHOW_TRAFFIC) != 0);
 
       checkDontUpdateLinkText = new Button(linkDisplayGroup, SWT.CHECK);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/NetworkServicePolling.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/NetworkServicePolling.java
@@ -136,7 +136,7 @@ public class NetworkServicePolling extends ObjectPropertyPage
 		port.setLayoutData(gd);
 		
 		ipAddress = new LabeledText(dialogArea, SWT.NONE);
-		ipAddress.setLabel("IP Address");
+		ipAddress.setLabel(i18n.tr("IP Address"));
       if (service.getIpAddress().isValidAddress())
          ipAddress.setText(service.getIpAddress().getHostAddress());
       gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/PhysicalContainerPlacement.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/PhysicalContainerPlacement.java
@@ -134,7 +134,7 @@ public class PhysicalContainerPlacement extends ObjectPropertyPage
       dialogArea.setLayout(layout);
       
       objectSelector = new ObjectSelector(dialogArea, SWT.NONE, true);
-      objectSelector.setLabel("Rack or chassis");      
+      objectSelector.setLabel(i18n.tr("Rack or chassis"));      
       objectSelector.setObjectId(hardwareEntity.getPhysicalContainerId());
 
       Set<Class<? extends AbstractObject>> filter = new HashSet<Class<? extends AbstractObject>>();
@@ -230,7 +230,7 @@ public class PhysicalContainerPlacement extends ObjectPropertyPage
       chassisElements.setLayoutData(gd);
       
       chassisImageSelector = new ImageSelector(chassisElements, SWT.NONE);
-      chassisImageSelector.setLabel("Chassis image");
+      chassisImageSelector.setLabel(i18n.tr("Chassis image"));
       chassisImageSelector.setImageGuid(placement.getImage(), true);
       gd = new GridData();
       gd.grabExcessHorizontalSpace = true;
@@ -374,7 +374,7 @@ public class PhysicalContainerPlacement extends ObjectPropertyPage
       rackElements.setLayoutData(gd);
 
 	   rackImageFrontSelector = new ImageSelector(rackElements, SWT.NONE);
-      rackImageFrontSelector.setLabel("Rack front image");
+      rackImageFrontSelector.setLabel(i18n.tr("Rack front image"));
       rackImageFrontSelector.setImageGuid(hardwareEntity.getFrontRackImage(), true);
       rackImageFrontSelector.setEnabled(hardwareEntity.getRackOrientation() == RackOrientation.FRONT || hardwareEntity.getRackOrientation() == RackOrientation.FILL);
       gd = new GridData();
@@ -384,7 +384,7 @@ public class PhysicalContainerPlacement extends ObjectPropertyPage
       rackImageFrontSelector.setLayoutData(gd);
 
       rackImageRearSelector = new ImageSelector(rackElements, SWT.NONE);
-      rackImageRearSelector.setLabel("Rack rear image");
+      rackImageRearSelector.setLabel(i18n.tr("Rack rear image"));
       rackImageRearSelector.setImageGuid(hardwareEntity.getRearRackImage(), true);
       rackImageRearSelector.setEnabled(hardwareEntity.getRackOrientation() == RackOrientation.REAR || hardwareEntity.getRackOrientation() == RackOrientation.FILL);
       gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/Polling.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/Polling.java
@@ -159,7 +159,7 @@ public class Polling extends ObjectPropertyPage
       if (object instanceof AbstractNode)
       {
          pollCount = new LabeledSpinner(dialogArea, SWT.NONE);
-         pollCount.setLabel("Required poll count for status change");
+         pollCount.setLabel(i18n.tr("Required poll count for status change"));
          pollCount.setSelection(((AbstractNode)object).getRequredPollCount());
       }
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/RackPassiveElements.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/RackPassiveElements.java
@@ -52,12 +52,15 @@ import org.netxms.nxmc.modules.objects.dialogs.RackPassiveElementEditDialog;
 import org.netxms.nxmc.modules.objects.propertypages.helpers.RackPassiveElementComparator;
 import org.netxms.nxmc.modules.objects.propertypages.helpers.RackPassiveElementLabelProvider;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * "Rack passive elements" property page for rack object
  */
 public class RackPassiveElements extends ObjectPropertyPage
 {
+   private final I18n i18n = LocalizationHelper.getI18n(RackPassiveElements.class);
+
    public static final int COLUMN_NAME = 0;
    public static final int COLUMN_TYPE = 1;
    public static final int COLUMN_POSITION = 2;
@@ -157,7 +160,7 @@ public class RackPassiveElements extends ObjectPropertyPage
       buttons.setLayoutData(gridData);
 
       addButton = new Button(buttons, SWT.PUSH);
-      addButton.setText("&Add...");
+      addButton.setText(i18n.tr("&Add..."));
       RowData rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       addButton.setLayoutData(rd);
@@ -176,7 +179,7 @@ public class RackPassiveElements extends ObjectPropertyPage
       });
 
       editButton = new Button(buttons, SWT.PUSH);
-      editButton.setText("&Edit...");
+      editButton.setText(i18n.tr("&Edit..."));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       editButton.setLayoutData(rd);
@@ -198,7 +201,7 @@ public class RackPassiveElements extends ObjectPropertyPage
       });
 
       deleteButton = new Button(buttons, SWT.PUSH);
-      deleteButton.setText("&Delete...");
+      deleteButton.setText(i18n.tr("&Delete..."));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       deleteButton.setLayoutData(rd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneAgentCredentials.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneAgentCredentials.java
@@ -140,7 +140,7 @@ public class ZoneAgentCredentials extends ObjectPropertyPage
    private void createSecretSection(Composite dialogArea)
 	{      
       Group clientArea = new Group(dialogArea, SWT.NONE);
-      clientArea.setText("Shared secrets");
+      clientArea.setText(i18n.tr("Shared secrets"));
       GridLayout layout = new GridLayout();
       layout.verticalSpacing = WidgetHelper.OUTER_SPACING;
       layout.numColumns = 2;
@@ -212,7 +212,7 @@ public class ZoneAgentCredentials extends ObjectPropertyPage
       buttonsRight.setLayoutData(gridData);
 
       secretAddButton = new Button(buttonsRight, SWT.PUSH);
-      secretAddButton.setText("&Add...");
+      secretAddButton.setText(i18n.tr("&Add..."));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       secretAddButton.setLayoutData(rd);
@@ -225,7 +225,7 @@ public class ZoneAgentCredentials extends ObjectPropertyPage
       });
       
       secretDeleteButton = new Button(buttonsRight, SWT.PUSH);
-      secretDeleteButton.setText("&Delete");
+      secretDeleteButton.setText(i18n.tr("&Delete"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       secretDeleteButton.setLayoutData(rd);
@@ -411,7 +411,7 @@ public class ZoneAgentCredentials extends ObjectPropertyPage
       buttonsRight.setLayoutData(gd);
 
       portAddButton = new Button(buttonsRight, SWT.PUSH);
-      portAddButton.setText("&Add...");
+      portAddButton.setText(i18n.tr("&Add..."));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       portAddButton.setLayoutData(rd);
@@ -424,7 +424,7 @@ public class ZoneAgentCredentials extends ObjectPropertyPage
       });
 
       portDeleteButton = new Button(buttonsRight, SWT.PUSH);
-      portDeleteButton.setText("&Delete");
+      portDeleteButton.setText(i18n.tr("&Delete"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       portDeleteButton.setLayoutData(rd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneSNMPCredentials.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneSNMPCredentials.java
@@ -154,7 +154,7 @@ public class ZoneSNMPCredentials extends ObjectPropertyPage
    private void createCommunitySection(Composite dialogArea)
    {
       Group clientArea = new Group(dialogArea, SWT.NONE);
-      clientArea.setText("Community strings");
+      clientArea.setText(i18n.tr("Community strings"));
       clientArea.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
       GridLayout layout = new GridLayout();
       layout.verticalSpacing = WidgetHelper.OUTER_SPACING;
@@ -199,7 +199,7 @@ public class ZoneSNMPCredentials extends ObjectPropertyPage
       });
 
       commMoveDownButton = new Button(buttonsLeft, SWT.PUSH);
-      commMoveDownButton.setText("&Down");
+      commMoveDownButton.setText(i18n.tr("&Down"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       commMoveDownButton.setLayoutData(rd);
@@ -394,7 +394,7 @@ public class ZoneSNMPCredentials extends ObjectPropertyPage
    private void createUSMCredentialsSection(Composite dialogArea)
    {
       Group clientArea = new Group(dialogArea, SWT.NONE);
-      clientArea.setText("USM credentials");
+      clientArea.setText(i18n.tr("USM credentials"));
       GridLayout layout = new GridLayout();
       layout.numColumns = 2;
       clientArea.setLayout(layout);
@@ -450,7 +450,7 @@ public class ZoneSNMPCredentials extends ObjectPropertyPage
       });
 
       usmMoveDownButton = new Button(buttonsLeft, SWT.PUSH);
-      usmMoveDownButton.setText("&Down");
+      usmMoveDownButton.setText(i18n.tr("&Down"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       usmMoveDownButton.setLayoutData(rd);
@@ -683,7 +683,7 @@ public class ZoneSNMPCredentials extends ObjectPropertyPage
       });
 
       portMoveDownButton = new Button(buttonsLeft, SWT.PUSH);
-      portMoveDownButton.setText("&Down");
+      portMoveDownButton.setText(i18n.tr("&Down"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       portMoveDownButton.setLayoutData(rd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneSSHCredentials.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneSSHCredentials.java
@@ -204,7 +204,7 @@ public class ZoneSSHCredentials extends ObjectPropertyPage
       });
       
       secretMoveDownButton = new Button(buttonsLeft, SWT.PUSH);
-      secretMoveDownButton.setText("&Down");
+      secretMoveDownButton.setText(i18n.tr("&Down"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       secretMoveDownButton.setLayoutData(rd);
@@ -429,7 +429,7 @@ public class ZoneSSHCredentials extends ObjectPropertyPage
       });
 
       portMoveDownButton = new Button(buttonsLeft, SWT.PUSH);
-      portMoveDownButton.setText("&Down");
+      portMoveDownButton.setText(i18n.tr("&Down"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       portMoveDownButton.setLayoutData(rd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/views/ObjectQueryResultView.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/views/ObjectQueryResultView.java
@@ -80,7 +80,7 @@ public class ObjectQueryResultView extends ConfigurationView
     */
    public ObjectQueryResultView()
    {
-      super("Object Query Results", ResourceManager.getImageDescriptor("icons/config-views/object-query-results.png"), "object-query.results.none", false);
+      super(LocalizationHelper.getI18n(ObjectQueryResultView.class).tr("Object Query Results"), ResourceManager.getImageDescriptor("icons/config-views/object-query-results.png"), "object-query.results.none", false);
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/views/WirelessStations.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/views/WirelessStations.java
@@ -73,7 +73,7 @@ public class WirelessStations extends NodeSubObjectView
     */
    public WirelessStations()
    {
-      super("Wireless Stations", ResourceManager.getImageDescriptor("icons/object-views/wireless-stations.png"), "objects.wireless-stations", true);
+      super(LocalizationHelper.getI18n(WirelessStations.class).tr("Wireless Stations"), ResourceManager.getImageDescriptor("icons/object-views/wireless-stations.png"), "objects.wireless-stations", true);
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/views/elements/InterfaceTrafficChart.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objects/views/elements/InterfaceTrafficChart.java
@@ -325,7 +325,7 @@ public class InterfaceTrafficChart extends OverviewPageElement implements Histor
    {
       if (items.getDciList()[itemBase] == 0 && items.getDciList()[itemBase + 1] == 0)
       {
-         label.setText("No data");
+         label.setText(i18n.tr("No data"));
          labelControl.moveAbove(null);
          return;
       }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/dialogs/ObjectToolSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/dialogs/ObjectToolSelectionDialog.java
@@ -34,14 +34,18 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.objecttools.ObjectTool;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.objecttools.ObjectToolsCache;
 import org.netxms.nxmc.tools.MessageDialogHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Object tool selection dialog
  */
 public class ObjectToolSelectionDialog extends Dialog
 {   
+   private final I18n i18n = LocalizationHelper.getI18n(ObjectToolSelectionDialog.class);
+
    private TableViewer viewer;
    private ObjectTool tool;
 
@@ -61,7 +65,7 @@ public class ObjectToolSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Tool");
+      newShell.setText(i18n.tr("Select Tool"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/AccessControl.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/AccessControl.java
@@ -72,7 +72,7 @@ public class AccessControl extends PropertyPage
     */
    public AccessControl(ObjectToolDetails toolDetails)
    {
-      super("Access Control");
+      super(LocalizationHelper.getI18n(AccessControl.class).tr("Access Control"));
       noDefaultAndApplyButton();
       objectTool = toolDetails;
    }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/Filter.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/Filter.java
@@ -233,7 +233,7 @@ public class Filter extends PropertyPage
 		if (action instanceof ObjectTool && action.getToolType() == ObjectTool.TYPE_LOCAL_COMMAND)
 		{
    		checkMatchWorkstationOS = new Button(dialogArea, SWT.CHECK);
-   		checkMatchWorkstationOS.setText("Workstation OS name should match the following template (comma separated regular expression list)");
+   		checkMatchWorkstationOS.setText(i18n.tr("Workstation OS name should match the following template (comma separated regular expression list)"));
    		checkMatchWorkstationOS.setSelection((filter.flags & ObjectMenuFilter.REQUIRES_WORKSTATION_OS_MATCH) != 0);
    		checkMatchWorkstationOS.addSelectionListener(new SelectionListener() {         
             @Override
@@ -290,7 +290,7 @@ public class Filter extends PropertyPage
       textTemplate.setEnabled(checkMatchTemplate.getSelection());
 		
       checkMatchCustomAttributes = new Button(dialogArea, SWT.CHECK);
-      checkMatchCustomAttributes.setText("The following custom attribute(s) should exist");
+      checkMatchCustomAttributes.setText(i18n.tr("The following custom attribute(s) should exist"));
       checkMatchCustomAttributes.setSelection((filter.flags & ObjectMenuFilter.REQUIRES_CUSTOM_ATTRIBUTE_MATCH) != 0);
       checkMatchCustomAttributes.addSelectionListener(new SelectionListener() {
          @Override

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/General.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/General.java
@@ -397,7 +397,7 @@ public class General extends PropertyPage
 		checkShowOutput.setSelection((objectTool.getFlags() & ObjectTool.GENERATES_OUTPUT) != 0);
 
       checkSuppressSuccessMessage = new Button(outputGroup, SWT.CHECK);
-      checkSuppressSuccessMessage.setText("&Suppress notification of successful execution");
+      checkSuppressSuccessMessage.setText(i18n.tr("&Suppress notification of successful execution"));
       checkSuppressSuccessMessage.setSelection((objectTool.getFlags() & ObjectTool.SUPPRESS_SUCCESS_MESSAGE) != 0);
 	}
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/reporting/propertypages/Notifications.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/reporting/propertypages/Notifications.java
@@ -38,13 +38,17 @@ import org.eclipse.swt.widgets.Label;
 import org.netxms.client.reporting.ReportRenderFormat;
 import org.netxms.client.reporting.ReportingJob;
 import org.netxms.nxmc.base.propertypages.PropertyPage;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * "Notification" property page for schedule
  */
 public class Notifications extends PropertyPage
 {
+   private final I18n i18n = LocalizationHelper.getI18n(Notifications.class);
+
 	public static final String ID = "org.netxms.ui.eclipse.reporter.propertypages.Notification"; //$NON-NLS-1$
 
    private ReportingJob job;
@@ -75,7 +79,7 @@ public class Notifications extends PropertyPage
 		
 		sendNotify = new Button(dialogArea, SWT.CHECK);
 		sendNotify.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 2, 1));
-		sendNotify.setText("Send notification on job completion");
+		sendNotify.setText(i18n.tr("Send notification on job completion"));
 		sendNotify.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)
@@ -149,7 +153,7 @@ public class Notifications extends PropertyPage
 		
 		sendReport = new Button(attachmentGroup, SWT.CHECK);
 		sendReport.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, true, false, 2, 1));
-		sendReport.setText("Attach rendered report to notification email as");
+		sendReport.setText(i18n.tr("Attach rendered report to notification email as"));
 		sendReport.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/reporting/widgets/ReportExecutionForm.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/reporting/widgets/ReportExecutionForm.java
@@ -457,7 +457,7 @@ public class ReportExecutionForm extends Composite
       if (parameters.isEmpty())
       {
          Label label = new Label(parent, SWT.NONE);
-         label.setText("This report does not have parameters");
+         label.setText(i18n.tr("This report does not have parameters"));
          return;
       }
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/EditSSHCredentialsDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/EditSSHCredentialsDialog.java
@@ -100,7 +100,7 @@ public class EditSSHCredentialsDialog extends Dialog
       gd.grabExcessHorizontalSpace = true;
       password.setLayoutData(gd);
 
-      key = WidgetHelper.createLabeledCombo(dialogArea, SWT.READ_ONLY, "SSH Key", WidgetHelper.DEFAULT_LAYOUT_DATA);
+      key = WidgetHelper.createLabeledCombo(dialogArea, SWT.READ_ONLY, i18n.tr("SSH Key"), WidgetHelper.DEFAULT_LAYOUT_DATA);
 
       key.add("");
       for(int i = 0; i < sshKeys.size(); i++)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/MappingTableSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/MappingTableSelectionDialog.java
@@ -33,13 +33,17 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.mt.MappingTableDescriptor;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Mapping table selection dialog
  */
 public class MappingTableSelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(MappingTableSelectionDialog.class);
+
    private TableViewer viewer;
    private List<MappingTableDescriptor> selection;
    private List<MappingTableDescriptor> mappingTables;
@@ -61,7 +65,7 @@ public class MappingTableSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Mapping Table");
+      newShell.setText(i18n.tr("Select Mapping Table"));
    }
 
    /**

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ObjectToolSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ObjectToolSelectionDialog.java
@@ -33,14 +33,18 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.objecttools.ObjectTool;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.objecttools.ObjectToolsCache;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Object tool selection dialog
  */
 public class ObjectToolSelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ObjectToolSelectionDialog.class);
+
    private TableViewer viewer;
    private List<ObjectTool> selection;
    
@@ -59,7 +63,7 @@ public class ObjectToolSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Object Tool");
+      newShell.setText(i18n.tr("Select Object Tool"));
    }
 
    /* (non-Javadoc)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/RepositorySelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/RepositorySelectionDialog.java
@@ -36,14 +36,18 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.market.Repository;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Repository selection dialog
  */
 public class RepositorySelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(RepositorySelectionDialog.class);
+
    private List<Repository> repositories;
    private Repository selection = null;
    private TableViewer viewer;
@@ -65,7 +69,7 @@ public class RepositorySelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Repository");
+      newShell.setText(i18n.tr("Select Repository"));
    }
 
    /* (non-Javadoc)
@@ -83,7 +87,7 @@ public class RepositorySelectionDialog extends Dialog
       dialogArea.setLayout(layout);
       
       Label label = new Label(dialogArea, SWT.LEFT);
-      label.setText("Available repositories");
+      label.setText(i18n.tr("Available repositories"));
       
       viewer = new TableViewer(dialogArea, SWT.BORDER | SWT.SINGLE | SWT.FULL_SELECTION);
       viewer.setContentProvider(new ArrayContentProvider());

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ScheduledTaskEditDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ScheduledTaskEditDialog.java
@@ -75,7 +75,7 @@ public class ScheduledTaskEditDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Edit Scheduled Task");
+      newShell.setText(i18n.tr("Edit Scheduled Task"));
    }
 
    /**
@@ -104,7 +104,7 @@ public class ScheduledTaskEditDialog extends Dialog
       taskType.setLayoutData(gd);
 
       objectSelector = new ObjectSelector(dialogArea, SWT.NONE, true);
-      objectSelector.setLabel("Select execution object");
+      objectSelector.setLabel(i18n.tr("Select execution object"));
       objectSelector.setObjectClass(AbstractObject.class);
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/SummaryTableSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/SummaryTableSelectionDialog.java
@@ -33,14 +33,18 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.netxms.client.datacollection.DciSummaryTableDescriptor;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.modules.datacollection.SummaryTablesCache;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Object tool selection dialog
  */
 public class SummaryTableSelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(SummaryTableSelectionDialog.class);
+
    private TableViewer viewer;
    private List<DciSummaryTableDescriptor> selection;
    
@@ -59,7 +63,7 @@ public class SummaryTableSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select DCI Summary Table");
+      newShell.setText(i18n.tr("Select DCI Summary Table"));
    }
 
    /* (non-Javadoc)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/VariableEditDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/VariableEditDialog.java
@@ -118,11 +118,11 @@ public class VariableEditDialog extends Dialog
       {
          case BOOLEAN:
             trueValue = new Button(dialogArea, SWT.RADIO);
-            trueValue.setText("&True");
+            trueValue.setText(i18n.tr("&True"));
             trueValue.setSelection(variable.getValueAsBoolean());
 
             falseValue = new Button(dialogArea, SWT.RADIO);
-            falseValue.setText("&False");
+            falseValue.setText(i18n.tr("&False"));
             falseValue.setSelection(!trueValue.getSelection());
 
             if (variable.getName() != null)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/views/ExportFileBuilder.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/views/ExportFileBuilder.java
@@ -531,11 +531,11 @@ public class ExportFileBuilder extends ConfigurationView
 		ruleViewer.getTable().setHeaderVisible(true);
 
       TableColumn column = new TableColumn(ruleViewer.getTable(), SWT.LEFT);
-      column.setText("Rule #");
+      column.setText(i18n.tr("Rule #"));
       column.setWidth(60);
 
       column = new TableColumn(ruleViewer.getTable(), SWT.LEFT);
-      column.setText("Rule Name");
+      column.setText(i18n.tr("Rule Name"));
       column.setWidth(250);
 
 		gd = new GridData();

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/views/NetworkCredentialsEditor.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/serverconfig/views/NetworkCredentialsEditor.java
@@ -164,7 +164,7 @@ public class NetworkCredentialsEditor extends ConfigurationView
 
          zoneSelector = new ZoneSelector(headArea, SWT.NONE, true);
          zoneSelector.setEmptySelectionText("Global");
-         zoneSelector.setLabel("Select zone");
+         zoneSelector.setLabel(i18n.tr("Select zone"));
          zoneSelector.setBackground(headArea.getBackground());
 
          zoneSelector.addModifyListener(new ModifyListener() {

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/snmp/dialogs/MibWalkDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/snmp/dialogs/MibWalkDialog.java
@@ -137,7 +137,7 @@ public class MibWalkDialog extends Dialog implements SnmpWalkListener
 		tc.setWidth(300);
 		
       tc = new TableColumn(viewer.getTable(), SWT.LEFT);
-      tc.setText("OID as text");
+      tc.setText(i18n.tr("OID as text"));
       tc.setWidth(300);
 
 		tc = new TableColumn(viewer.getTable(), SWT.LEFT);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/snmp/views/MibFileManager.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/snmp/views/MibFileManager.java
@@ -183,7 +183,7 @@ public class MibFileManager extends ConfigurationView implements SessionListener
       tabItem.setControl(outputViewer);
 
       tabItem = new CTabItem(outputTabFolder, SWT.NONE);
-      tabItem.setText("Error Log");
+      tabItem.setText(i18n.tr("Error Log"));
       tabItem.setImage(errorLogIcon);
 
       final String[] names = { i18n.tr("Severity"), i18n.tr("Location"), i18n.tr("Message") };
@@ -335,7 +335,7 @@ public class MibFileManager extends ConfigurationView implements SessionListener
    private void uploadFile()
    {
       FileDialog fd = new FileDialog(getWindow().getShell(), SWT.OPEN | SWT.MULTI);
-      fd.setText("Select Files");
+      fd.setText(i18n.tr("Select Files"));
       if (fd.open() == null)
          return;
 

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java
@@ -408,7 +408,7 @@ public class ObjectFinder extends View
       fullTextSearchGroup.setLayout(layout);
 
       text = new LabeledText(fullTextSearchGroup, SWT.NONE);
-      text.setLabel("Search string");
+      text.setLabel(i18n.tr("Search string"));
       text.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
       TraverseListener traverseListener = new TraverseListener() {
          @Override
@@ -421,19 +421,19 @@ public class ObjectFinder extends View
       text.addTraverseListener(traverseListener);
 
       Group searchModeGroup = new Group(fullTextSearchGroup, SWT.NONE);
-      searchModeGroup.setText("Search mode");
+      searchModeGroup.setText(i18n.tr("Search mode"));
       layout = new GridLayout();
       searchModeGroup.setLayout(layout);
 
       radioPlainText = new Button(searchModeGroup, SWT.RADIO);
-      radioPlainText.setText("&Normal");
+      radioPlainText.setText(i18n.tr("&Normal"));
       radioPlainText.setSelection(true);
 
       radioPattern = new Button(searchModeGroup, SWT.RADIO);
-      radioPattern.setText("&Pattern (* = any string, ? = any character)");
+      radioPattern.setText(i18n.tr("&Pattern (* = any string, ? = any character)"));
 
       radioRegularExpression = new Button(searchModeGroup, SWT.RADIO);
-      radioRegularExpression.setText("&Regular expression");
+      radioRegularExpression.setText(i18n.tr("&Regular expression"));
 
       /*** Class filter ***/
       Composite classFilterGroup = new Composite(conditionGroup, SWT.NONE);
@@ -444,7 +444,7 @@ public class ObjectFinder extends View
       classFilterGroup.setLayout(layout);
 
       Label classFilterTitle = new Label(classFilterGroup, SWT.NONE);
-      classFilterTitle.setText("Class filter");
+      classFilterTitle.setText(i18n.tr("Class filter"));
 
       classList = CheckboxTableViewer.newCheckList(classFilterGroup, SWT.BORDER | SWT.CHECK);
       classList.setContentProvider(new ArrayContentProvider());
@@ -460,7 +460,7 @@ public class ObjectFinder extends View
       classListButtons.setLayout(rlayout);
 
       Button selectAll = new Button(classListButtons, SWT.PUSH);
-      selectAll.setText("Select &all");
+      selectAll.setText(i18n.tr("Select &all"));
       RowData rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       selectAll.setLayoutData(rd);
@@ -473,7 +473,7 @@ public class ObjectFinder extends View
       });
 
       Button clearAll = new Button(classListButtons, SWT.PUSH);
-      clearAll.setText("&Clear all");
+      clearAll.setText(i18n.tr("&Clear all"));
       rd = new RowData();
       rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
       clearAll.setLayoutData(rd);
@@ -496,7 +496,7 @@ public class ObjectFinder extends View
          zoneFilterGroup.setLayout(layout);
 
          Label zoneFilterTitle = new Label(zoneFilterGroup, SWT.NONE);
-         zoneFilterTitle.setText("Zone filter");
+         zoneFilterTitle.setText(i18n.tr("Zone filter"));
 
          zoneList = CheckboxTableViewer.newCheckList(zoneFilterGroup, SWT.BORDER | SWT.CHECK);
          zoneList.setContentProvider(new ArrayContentProvider());
@@ -514,7 +514,7 @@ public class ObjectFinder extends View
          zoneListButtons.setLayout(rlayout);
 
          selectAll = new Button(zoneListButtons, SWT.PUSH);
-         selectAll.setText("Select &all");
+         selectAll.setText(i18n.tr("Select &all"));
          rd = new RowData();
          rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
          selectAll.setLayoutData(rd);
@@ -527,7 +527,7 @@ public class ObjectFinder extends View
          });
 
          clearAll = new Button(zoneListButtons, SWT.PUSH);
-         clearAll.setText("&Clear all");
+         clearAll.setText(i18n.tr("&Clear all"));
          rd = new RowData();
          rd.width = WidgetHelper.BUTTON_WIDTH_HINT;
          clearAll.setLayoutData(rd);
@@ -542,7 +542,7 @@ public class ObjectFinder extends View
 
       /*** IP filter ***/
       Group ipFilterGroup = new Group(conditionGroup, SWT.NONE);
-      ipFilterGroup.setText("IP Range");
+      ipFilterGroup.setText(i18n.tr("IP Range"));
       ipFilterGroup.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
       layout = new GridLayout();
       layout.numColumns = 3;
@@ -560,7 +560,7 @@ public class ObjectFinder extends View
 
       /*** Search button ***/
       Button searchButtonFilter = new Button(conditionGroup, SWT.PUSH);
-      searchButtonFilter.setText("&Search");
+      searchButtonFilter.setText(i18n.tr("&Search"));
       gd = new GridData(SWT.LEFT, SWT.BOTTOM, true, false);
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
       searchButtonFilter.setLayoutData(gd);
@@ -600,7 +600,7 @@ public class ObjectFinder extends View
       labelQueryEditor.setLayoutData(gd);
 
       Label labelQueryList = new Label(queryArea, SWT.LEFT);
-      labelQueryList.setText("Saved queries");
+      labelQueryList.setText(i18n.tr("Saved queries"));
       labelQueryList.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, false));
 
       queryEditor = new ScriptEditor(queryArea, SWT.BORDER, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
@@ -686,7 +686,7 @@ public class ObjectFinder extends View
       queryHeader.setLayoutData(gd);
 
       searchButtonQuery = new Button(queryHeader, SWT.PUSH);
-      searchButtonQuery.setText("&Search");
+      searchButtonQuery.setText(i18n.tr("&Search"));
       gd = new GridData(SWT.LEFT, SWT.BOTTOM, false, false);
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
       searchButtonQuery.setLayoutData(gd);

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/Authentication.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/Authentication.java
@@ -196,7 +196,7 @@ public class Authentication extends PropertyPage
 		comboMappingMethod.add(i18n.tr("Subject"));
 		comboMappingMethod.add(i18n.tr("Public key"));
       comboMappingMethod.add(i18n.tr("Common name"));
-      comboMappingMethod.add("Template ID");
+      comboMappingMethod.add(i18n.tr("Template ID"));
       comboMappingMethod.select(user.getCertMappingMethod().getValue());
 		gd = new GridData();
 		gd.horizontalAlignment = GridData.FILL;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/General.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/General.java
@@ -100,7 +100,7 @@ public class General extends PropertyPage
          textEmail = WidgetHelper.createLabeledText(dialogArea, SWT.SINGLE | SWT.BORDER, SWT.DEFAULT, "Email", initialEmail, WidgetHelper.DEFAULT_LAYOUT_DATA);
 
          initialPhoneNumber = new String(((User)object).getPhoneNumber());
-         textPhoneNumber = WidgetHelper.createLabeledText(dialogArea, SWT.SINGLE | SWT.BORDER, SWT.DEFAULT, "Phone number",
+         textPhoneNumber = WidgetHelper.createLabeledText(dialogArea, SWT.SINGLE | SWT.BORDER, SWT.DEFAULT, i18n.tr("Phone number"),
                initialPhoneNumber, WidgetHelper.DEFAULT_LAYOUT_DATA);
 
       }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/Members.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/Members.java
@@ -87,7 +87,7 @@ public class Members extends PropertyPage
          GridLayout layout = new GridLayout();
          dialogArea.setLayout(layout);
          Label label = new Label(dialogArea, SWT.CENTER | SWT.WRAP);
-         label.setText("This built-in group contains all the users in the system and\nis populated automatically. You can’t add or remove users here.");
+         label.setText(i18n.tr("This built-in group contains all the users in the system and\nis populated automatically. You can’t add or remove users here."));
          label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
          return dialogArea;
       }

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/UIAccessRules.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/users/propertypages/UIAccessRules.java
@@ -80,7 +80,7 @@ public class UIAccessRules extends PropertyPage
       rules.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
       Button addButton = new Button(dialogArea, SWT.PUSH);
-      addButton.setText("&Add element...");
+      addButton.setText(i18n.tr("&Add element..."));
       addButton.addSelectionListener(new SelectionAdapter() {
          @Override
          public void widgetSelected(SelectionEvent e)

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/worldmap/dialogs/GeoAreaEditDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/worldmap/dialogs/GeoAreaEditDialog.java
@@ -106,7 +106,7 @@ public class GeoAreaEditDialog extends Dialog
       comments.setLayoutData(gd);
 
       border = new LabeledText(dialogArea, SWT.NONE, SWT.BORDER | SWT.MULTI);
-      border.setLabel("Border points (one point per line)");
+      border.setLabel(i18n.tr("Border points (one point per line)"));
       gd = new GridData();
       gd.horizontalAlignment = SWT.FILL;
       gd.grabExcessHorizontalSpace = true;

--- a/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/worldmap/dialogs/GeoAreaSelectionDialog.java
+++ b/src/client/nxmc/java/src/main/java/org/netxms/nxmc/modules/worldmap/dialogs/GeoAreaSelectionDialog.java
@@ -39,12 +39,16 @@ import org.netxms.client.NXCSession;
 import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.Registry;
 import org.netxms.nxmc.base.jobs.Job;
+import org.netxms.nxmc.localization.LocalizationHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Geo area selection dialog
  */
 public class GeoAreaSelectionDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(GeoAreaSelectionDialog.class);
+
    private static final String TABLE_CONFIG_PREFIX = "GeoAreaSelectionDialog"; //$NON-NLS-1$
 
    private List<GeoArea> cachedAreaList;
@@ -70,7 +74,7 @@ public class GeoAreaSelectionDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Select Geo Area");
+      newShell.setText(i18n.tr("Select Geo Area"));
       PreferenceStore settings = PreferenceStore.getInstance();
       newShell.setSize(settings.getAsInteger(TABLE_CONFIG_PREFIX + ".cx", 300), settings.getAsInteger(TABLE_CONFIG_PREFIX + ".cy", 400));
    }

--- a/src/client/nxmc/java/src/main/resources/po/zh_TW.po
+++ b/src/client/nxmc/java/src/main/resources/po/zh_TW.po
@@ -24486,3 +24486,923 @@ msgstr ""
 "\n"
 "如需協助，請聯絡您的網路管理員或 NetXMS 伺服器的擁有者。\n"
 "\n"
+
+#: src/main/java/org/netxms/nxmc/base/dialogs/ThemeElementEditDialog.java:58
+msgid "Edit Theme Element"
+msgstr "編輯佈景主題元素"
+
+#: src/main/java/org/netxms/nxmc/base/login/TwoFactorResponseDialog.java:109
+msgid "Secret as text"
+msgstr "密鑰文字"
+
+#: src/main/java/org/netxms/nxmc/base/widgets/LatLonZoomEditor.java:111
+msgid "Zoom level"
+msgstr "縮放層級"
+
+#: src/main/java/org/netxms/nxmc/modules/actions/dialogs/ActionSelectionDialog.java:84
+msgid "Select action"
+msgstr "選取動作"
+
+#: src/main/java/org/netxms/nxmc/modules/alarms/dialogs/AlarmCategorySelectionDialog.java:78
+msgid "Select Alarm Category"
+msgstr "選取警報類別"
+
+#: src/main/java/org/netxms/nxmc/modules/alarms/views/AlarmDetails.java:573
+msgid "No DCI associated with this alarm"
+msgstr "此警報未關聯任何 DCI"
+
+#: src/main/java/org/netxms/nxmc/modules/assetmanagement/dialogs/SelectAssetAttributeDlg.java:72
+msgid "Select Asset Attributes"
+msgstr "選取資產屬性"
+
+#: src/main/java/org/netxms/nxmc/modules/assetmanagement/views/AssetManagementSchemaManager.java:287
+msgid "Asset Attribute Properties"
+msgstr "資產屬性內容"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/DCIAutoBind.java:92
+msgid "Automatically add DCI selected by filter to this business service as check"
+msgstr "自動將篩選所選取的 DCI 加入此業務服務作為檢查"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/DCIAutoBind.java:121
+msgid "Automatically remove DCI selected by filter from this business service"
+msgstr "當 DCI 不再通過篩選時自動將其從此業務服務移除"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/ObjectAutoBind.java:94
+msgid "Automatically add objects selected by filter to this business service as check"
+msgstr "自動將篩選所選取的物件加入此業務服務作為檢查"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/propertypages/ObjectAutoBind.java:123
+msgid "Automatically remove objects selected by filter from this business service"
+msgstr "當物件不再通過篩選時自動將其從此業務服務移除"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/views/BusinessServiceChecksView.java:351
+msgid "Add o&bject checks..."
+msgstr "新增物件檢查(&B)..."
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/views/BusinessServiceChecksView.java:359
+msgid "Add D&CI checks..."
+msgstr "新增 DCI 檢查(&C)..."
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/views/BusinessServiceChecksView.java:532
+msgid "Select Objects"
+msgstr "選取物件"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/views/BusinessServiceChecksView.java:586
+msgid "Creating business service checks"
+msgstr "正在建立業務服務檢查"
+
+#: src/main/java/org/netxms/nxmc/modules/businessservice/views/BusinessServiceChecksView.java:597
+msgid "Cannot create business service checks"
+msgstr "無法建立業務服務檢查"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/dialogs/SortingColumnSelectionDialog.java:118
+msgid "Descending order"
+msgstr "遞減排序"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/dialogs/TableColumnSelectionDialog.java:65
+msgid "Select Column"
+msgstr "選取欄位"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/AvailabilityChart.java:155
+msgid "Period length (days)"
+msgstr "期間長度（天）"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/ObjectDetailsPropertyList.java:122
+msgid "Properties to display"
+msgstr "要顯示的屬性"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/StatusMap.java:156
+msgid "Hide objects in &maintenance mode"
+msgstr "隱藏維護模式中的物件(&M)"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/propertypages/TableValue.java:153
+msgid "Sorting order"
+msgstr "排序方式"
+
+#: src/main/java/org/netxms/nxmc/modules/dashboards/widgets/TitleConfigurator.java:118
+msgid "Font size adjustment"
+msgstr "字型大小調整"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/BulkUpdateDialog.java:134
+msgid "Bulk DCI update"
+msgstr "DCI 大量更新"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/CreatePolicyDialog.java:71
+msgid "Create new policy"
+msgstr "建立新原則"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/CreatePolicyDialog.java:99
+msgid "Policy type"
+msgstr "原則類型"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/DisableThresholdsDialog.java:68
+msgid "Disable DCI Threshold processing"
+msgstr "停用 DCI 臨界值處理"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditColumnDialog.java:130
+msgid "Convert SNMP value to &hexadecimal string"
+msgstr "將 SNMP 值轉換為十六進位字串(&H)"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditDciSummaryTableColumnDlg.java:96
+msgid "Match by description instead of name"
+msgstr "以描述而非名稱進行比對"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditDciSummaryTableColumnDlg.java:104
+msgid "&Multivalued column"
+msgstr "多值欄位(&M)"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditDciSummaryTableColumnDlg.java:115
+msgid "&Separator for multiple values"
+msgstr "多個值的分隔字元(&S)"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditTableThresholdDialog.java:106
+msgid "Sample count"
+msgstr "取樣數"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/EditTableThresholdDialog.java:111
+msgid "Deactivation sample count"
+msgstr "解除取樣數"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/HistoricalDataSelectionDialog.java:104
+msgid "  -  "
+msgstr ""
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SavePolicyDialog.java:105
+msgid ""
+"Policy is not saved.\n"
+"Do you want to save it, discard changes, or return to the editor?"
+msgstr ""
+"原則尚未儲存。\n"
+"要儲存、捨棄變更，還是返回編輯器？"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SelectNetconfQueryDlg.java:90
+msgid "NETCONF Query Definition Selection"
+msgstr "選取 NETCONF 查詢定義"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/SelectWebServiceDlg.java:91
+msgid "Web Service Defenition Selection"
+msgstr "選取 Web 服務定義"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/TestTransformationDlg.java:151
+msgid "Select Execution Target"
+msgstr "選取執行目標"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/dialogs/TestTransformationDlg.java:161
+msgid "Invalid execution target"
+msgstr "執行目標無效"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/ClusterOptions.java:145
+msgid "Use last known value for aggregation in case of data collection error"
+msgstr "資料收集發生錯誤時使用最後已知的值進行彙總"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:168
+msgid "Metric to collect"
+msgstr "要收集的量測項目"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:208
+msgid "Source node override"
+msgstr "來源節點覆寫"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:300
+msgid "Display value mapping table"
+msgstr "顯示值對應表"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:308
+msgid "Collection schedule"
+msgstr "收集排程"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:344
+msgid "Custom interval"
+msgstr "自訂間隔"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:367
+msgid "Advanced schedule"
+msgstr "進階排程"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:390
+msgid "History retention period"
+msgstr "歷程保留期間"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:451
+msgid "Do not save to the database"
+msgstr "不儲存至資料庫"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:470
+msgid "Save every"
+msgstr "每隔"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/General.java:486
+msgid "Save only &changed values"
+msgstr "僅儲存變動的值(&C)"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/InstanceDiscovery.java:196
+msgid "Instance retention"
+msgstr "執行個體保留"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/InstanceDiscovery.java:210
+msgid "Instance retention mode"
+msgstr "執行個體保留模式"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/InstanceDiscovery.java:226
+msgid "Instance retention time (days)"
+msgstr "執行個體保留時間（天）"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:142
+msgid "Fixed to P"
+msgstr "固定為 P"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:143
+msgid "Fixed to T"
+msgstr "固定為 T"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:144
+msgid "Fixed to G"
+msgstr "固定為 G"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:145
+msgid "Fixed to M"
+msgstr "固定為 M"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:146
+msgid "Fixed to K"
+msgstr "固定為 K"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:148
+msgid "Fixed to m"
+msgstr "固定為 m"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:149
+msgid "Fixed to μ"
+msgstr "固定為 μ"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:150
+msgid "Fixed to n"
+msgstr "固定為 n"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:151
+msgid "Fixed to p"
+msgstr "固定為 p"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/OtherOptions.java:152
+msgid "Fixed to f"
+msgstr "固定為 f"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/SNMP.java:174
+msgid "Use custom SNMP version:"
+msgstr "使用自訂 SNMP 版本："
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/propertypages/SummaryTableAccessControl.java:99
+msgid "Users allowed to use this summary table"
+msgstr "允許使用此摘要表的使用者"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/views/TemplateGraphView.java:465
+msgid "Properties for "
+msgstr ""
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/AgentConfigPolicyEditor.java:71
+msgid "Expand macro"
+msgstr "展開巨集"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:173
+msgid "Color schema"
+msgstr "色彩配置"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:184
+msgid "Use custom color schema"
+msgstr "使用自訂色彩配置"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:211
+msgid "Welcome message"
+msgstr "歡迎訊息"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:215
+msgid "Tooltip message"
+msgstr "工具提示訊息"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:219
+msgid "Window behavior"
+msgstr "視窗行為"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:226
+msgid "Close on &deactivate"
+msgstr "失去焦點時關閉(&D)"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:235
+msgid "Top - Left"
+msgstr "上方 - 靠左"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:236
+msgid "Top - Center"
+msgstr "上方 - 置中"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:237
+msgid "Top - Right"
+msgstr "上方 - 靠右"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:238
+msgid "Middle - Left"
+msgstr "中間 - 靠左"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:239
+msgid "Middle - Center"
+msgstr "中間 - 置中"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:240
+msgid "Middle - Right"
+msgstr "中間 - 靠右"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:241
+msgid "Bottom - Left"
+msgstr "下方 - 靠左"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:242
+msgid "Bottom - Center"
+msgstr "下方 - 置中"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:243
+msgid "Bottom - Right"
+msgstr "下方 - 靠右"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:247
+msgid "Notification timeout"
+msgstr "通知逾時"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:252
+msgid "Desktop wallpaper file name"
+msgstr "桌布檔案名稱"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/SupportAppPolicyEditor.java:363
+msgid "Application Icon"
+msgstr "應用程式圖示"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/helpers/DataCollectionDisplayInfo.java:59
+msgid "<< ACCESS DENIED >>"
+msgstr "<< 拒絕存取 >>"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/helpers/DataCollectionDisplayInfo.java:61
+msgid "<< COMM ERROR >>"
+msgstr "<< 通訊錯誤 >>"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/helpers/DataCollectionDisplayInfo.java:63
+msgid "<< INVALID DATA >>"
+msgstr "<< 資料無效 >>"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/helpers/DataCollectionDisplayInfo.java:65
+msgid "<< NO SUCH INSTANCE >>"
+msgstr "<< 無此執行個體 >>"
+
+#: src/main/java/org/netxms/nxmc/modules/datacollection/widgets/helpers/DataCollectionDisplayInfo.java:67
+msgid "<< NOT SUPPORTED >>"
+msgstr "<< 不支援 >>"
+
+#: src/main/java/org/netxms/nxmc/modules/events/dialogs/RuleSelectionDialog.java:130
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/views/ExportFileBuilder.java:538
+msgid "Rule Name"
+msgstr "規則名稱"
+
+#: src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleAlarm.java:239
+msgid "Root cause analysis script"
+msgstr "根本原因分析指令碼"
+
+#: src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleAlarm.java:256
+msgid "Alarm category script"
+msgstr "警報類別指令碼"
+
+#: src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleDowntimeControl.java:96
+msgid "Downtime tag"
+msgstr "停機標記"
+
+#: src/main/java/org/netxms/nxmc/modules/events/propertypages/RulePersistentStorage.java:107
+msgid "Delete persistent storage entries"
+msgstr "刪除持續性儲存區項目"
+
+#: src/main/java/org/netxms/nxmc/modules/events/propertypages/RuleSourceObjects.java:177
+msgid "Exclusions:"
+msgstr "排除項目："
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:192
+msgid "Errors"
+msgstr "錯誤"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:385
+msgid "Rule refers to source objects that do not exist"
+msgstr "規則參照到不存在的來源物件"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:387
+msgid "Rule refers to events that do not exist"
+msgstr "規則參照到不存在的事件"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:389
+msgid "Rule refers to actions that do not exist"
+msgstr "規則參照到不存在的動作"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:391
+msgid "Rule refers to alarm categories that do not exist"
+msgstr "規則參照到不存在的警報類別"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:393
+msgid "Filtering script cannot be compiled"
+msgstr "篩選指令碼無法編譯"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:395
+msgid "Action script cannot be compiled"
+msgstr "動作指令碼無法編譯"
+
+#: src/main/java/org/netxms/nxmc/modules/events/widgets/RuleEditor.java:879
+#, java-printf-format
+msgid "with categories selected by script \"%s\""
+msgstr "使用指令碼「%s」所選取的類別"
+
+#: src/main/java/org/netxms/nxmc/modules/filemanager/dialogs/FileFingerprintDialog.java:138
+msgid "File Fingerprint"
+msgstr "檔案指紋"
+
+#: src/main/java/org/netxms/nxmc/modules/filemanager/views/ServerFileManager.java:311
+#: src/main/java/org/netxms/nxmc/modules/snmp/views/MibFileManager.java:338
+msgid "Select Files"
+msgstr "選取檔案"
+
+#: src/main/java/org/netxms/nxmc/modules/imagelibrary/widgets/ImagePreview.java:86
+msgid "No image selected"
+msgstr "未選取影像"
+
+#: src/main/java/org/netxms/nxmc/modules/incidents/widgets/IncidentList.java:255
+msgid "&All incidents"
+msgstr "所有事故(&A)"
+
+#: src/main/java/org/netxms/nxmc/modules/incidents/widgets/IncidentList.java:265
+msgid "&Open incidents only"
+msgstr "僅開啟中的事故(&O)"
+
+#: src/main/java/org/netxms/nxmc/modules/incidents/widgets/IncidentList.java:275
+msgid "&Closed incidents only"
+msgstr "僅已關閉的事故(&C)"
+
+#: src/main/java/org/netxms/nxmc/modules/logviewer/dialogs/AuditLogRecordDetailsDialog.java:75
+msgid "Audit Log Record Details"
+msgstr "稽核記錄項目詳細資料"
+
+#: src/main/java/org/netxms/nxmc/modules/logviewer/dialogs/EventLogRecordDetailsDialog.java:62
+msgid "Event Log Record Details"
+msgstr "事件記錄項目詳細資料"
+
+#: src/main/java/org/netxms/nxmc/modules/logwatch/dialogs/SelectLogParserRuleDlg.java:137
+msgid "Match Expression"
+msgstr "比對運算式"
+
+#: src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserFileEditor.java:85
+msgid "File path"
+msgstr "檔案路徑"
+
+#: src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserMetricEditor.java:76
+msgid "Metric name"
+msgstr "量測項目名稱"
+
+#: src/main/java/org/netxms/nxmc/modules/logwatch/widgets/LogParserRuleEditor.java:411
+msgid "Reset repeat count"
+msgstr "重設重複計數"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkColor.java:174
+msgid "Include active &thresholds into calculation"
+msgstr "將作用中的臨界值納入計算(&T)"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkColor.java:183
+msgid "Include interface &utilization into calculation"
+msgstr "將介面使用率納入計算(&U)"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/LinkGeneral.java:209
+msgid "Exclude from automatic updates"
+msgstr "排除於自動更新之外"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/propertypages/TextBoxGeneral.java:113
+msgid "Show border"
+msgstr "顯示邊框"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:115
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:200
+#, java-format
+msgid "Type: {0}"
+msgstr "類型：{0}"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:264
+msgid "Inbound"
+msgstr "輸入"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:265
+msgid "Outbound"
+msgstr "輸出"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:328
+msgid "VPN"
+msgstr "VPN"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:330
+msgid "Multiple links"
+msgstr "多重連線"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:332
+msgid "Agent tunnel"
+msgstr "代理程式通道"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:336
+msgid "SSH proxy"
+msgstr "SSH Proxy"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:340
+msgid "ICMP proxy"
+msgstr "ICMP Proxy"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:342
+msgid "Sensor proxy"
+msgstr "感測器 Proxy"
+
+#: src/main/java/org/netxms/nxmc/modules/networkmaps/widgets/helpers/LinkTooltip.java:346
+msgid "Wireless client"
+msgstr "無線用戶端"
+
+#: src/main/java/org/netxms/nxmc/modules/nxsl/views/ScriptExecutorView.java:789
+#, java-format
+msgid "Script on {0}"
+msgstr "{0} 上的指令碼"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/ObjectsPerspective.java:408
+msgid "Manage views"
+msgstr "管理檢視"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/ObjectsPerspective.java:867
+msgid " ▾  "
+msgstr ""
+
+#: src/main/java/org/netxms/nxmc/modules/objects/actions/EnableObjectPublicAccess.java:62
+msgid "Setting up public access"
+msgstr "正在設定公開存取"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/actions/EnableObjectPublicAccess.java:82
+#, java-printf-format
+msgid "Cannot setup public access for object \"%s\""
+msgstr "無法為物件「%s」設定公開存取"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/CreateNodeDialog.java:333
+msgid "Disable usage of SSH for all polls"
+msgstr "所有輪詢皆停用 SSH"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/CreateTrafficObserverDialog.java:127
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ObservationPointScope.java:117
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/TrafficObserverConnection.java:129
+msgid "Zone for host matching"
+msgstr "主機比對所用的區域"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/CreateTrafficObserverDialog.java:177
+msgid "Please select traffic connector"
+msgstr "請選取流量連接器"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/CreateTrafficObserverDialog.java:183
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/TrafficObserverConnection.java:181
+msgid "Credentials must be a valid JSON object"
+msgstr "認證必須是有效的 JSON 物件"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/ObjectPublicAccessDialog.java:69
+msgid "Public Access Details"
+msgstr "公開存取詳細資料"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/ObjectPublicAccessDialog.java:88
+msgid "Access token"
+msgstr "存取權杖"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/PhysicalLinkEditDialog.java:117
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/PhysicalLinkEditDialog.java:198
+msgid "Interface or rack"
+msgstr "介面或機架"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/PhysicalLinkEditDialog.java:150
+#: src/main/java/org/netxms/nxmc/modules/objects/dialogs/PhysicalLinkEditDialog.java:231
+msgid "Patch panel"
+msgstr "跳線面板"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/Agent.java:211
+#: src/main/java/org/netxms/nxmc/modules/users/propertypages/Authentication.java:199
+msgid "Template ID"
+msgstr "範本 ID"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/DashboardElements.java:162
+msgid "&Scrollable content"
+msgstr "可捲動內容(&S)"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ICMP.java:137
+msgid "ICMP response statistic collection"
+msgstr "ICMP 回應統計收集"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ICMP.java:161
+msgid "Additional targets for ICMP response statistic collection"
+msgstr "ICMP 回應統計收集的額外目標"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java:142
+msgid "&Generate event when location changes"
+msgstr "位置變更時產生事件(&G)"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java:146
+msgid "Location control mode"
+msgstr "位置控制模式"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java:148
+msgid "No control"
+msgstr "不控制"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java:149
+msgid "Alert when within restricted area"
+msgstr "進入受限區域時發出警示"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/LocationControl.java:150
+msgid "Alert when outside allowed area"
+msgstr "超出允許區域時發出警示"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapAppearance.java:100
+msgid "Name on network maps (leave empty to use normal object name)"
+msgstr "網路地圖上的名稱（留空則使用一般物件名稱）"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapBackground.java:177
+msgid "Fit to scrren"
+msgstr "符合螢幕大小"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapBackground.java:264
+msgid "Image fit"
+msgstr "影像縮放方式"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapOptions.java:299
+msgid "Show link direction"
+msgstr "顯示連線方向"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/MapOptions.java:303
+msgid "Display traffic data"
+msgstr "顯示流量資料"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ObservationPointScope.java:118
+msgid "Inherit from observer"
+msgstr "繼承自觀察者"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/PhysicalContainerPlacement.java:137
+msgid "Rack or chassis"
+msgstr "機架或機箱"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/PhysicalContainerPlacement.java:233
+msgid "Chassis image"
+msgstr "機箱影像"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/PhysicalContainerPlacement.java:377
+msgid "Rack front image"
+msgstr "機架正面影像"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/PhysicalContainerPlacement.java:387
+msgid "Rack rear image"
+msgstr "機架背面影像"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/Polling.java:162
+msgid "Required poll count for status change"
+msgstr "狀態變更所需的輪詢次數"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/Polling.java:186
+msgid "Disable &NETCONF usage for all polls"
+msgstr "所有輪詢皆停用 NETCONF(&N)"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/RackPassiveElements.java:204
+msgid "&Delete..."
+msgstr "刪除(&D)..."
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneAgentCredentials.java:143
+msgid "Shared secrets"
+msgstr "共用密鑰"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneSNMPCredentials.java:157
+msgid "Community strings"
+msgstr "Community 字串"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/propertypages/ZoneSNMPCredentials.java:397
+msgid "USM credentials"
+msgstr "USM 認證"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/views/ObjectQueryResultView.java:83
+msgid "Object Query Results"
+msgstr "物件查詢結果"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/views/WirelessStations.java:76
+msgid "Wireless Stations"
+msgstr "無線工作站"
+
+#: src/main/java/org/netxms/nxmc/modules/objects/views/elements/InterfaceTrafficChart.java:328
+msgid "No data"
+msgstr "無資料"
+
+#: src/main/java/org/netxms/nxmc/modules/objecttools/dialogs/ObjectToolSelectionDialog.java:68
+msgid "Select Tool"
+msgstr "選取工具"
+
+#: src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/Filter.java:236
+msgid "Workstation OS name should match the following template (comma separated regular expression list)"
+msgstr "工作站作業系統名稱必須符合下列樣板（以逗號分隔的正規表示式清單）"
+
+#: src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/Filter.java:293
+msgid "The following custom attribute(s) should exist"
+msgstr "必須存在下列自訂屬性"
+
+#: src/main/java/org/netxms/nxmc/modules/objecttools/propertypages/General.java:400
+msgid "&Suppress notification of successful execution"
+msgstr "不通知執行成功的結果(&S)"
+
+#: src/main/java/org/netxms/nxmc/modules/reporting/propertypages/Notifications.java:82
+msgid "Send notification on job completion"
+msgstr "工作完成時傳送通知"
+
+#: src/main/java/org/netxms/nxmc/modules/reporting/propertypages/Notifications.java:156
+msgid "Attach rendered report to notification email as"
+msgstr "將產生的報表以下列格式附加至通知郵件"
+
+#: src/main/java/org/netxms/nxmc/modules/reporting/widgets/ReportExecutionForm.java:460
+msgid "This report does not have parameters"
+msgstr "此報表沒有參數"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/EditSSHCredentialsDialog.java:103
+msgid "SSH Key"
+msgstr "SSH 金鑰"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/MappingTableSelectionDialog.java:68
+msgid "Select Mapping Table"
+msgstr "選取對應表"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ObjectToolSelectionDialog.java:66
+msgid "Select Object Tool"
+msgstr "選取物件工具"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/RepositorySelectionDialog.java:72
+msgid "Select Repository"
+msgstr "選取儲存庫"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/RepositorySelectionDialog.java:90
+msgid "Available repositories"
+msgstr "可用的儲存庫"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ScheduledTaskEditDialog.java:78
+msgid "Edit Scheduled Task"
+msgstr "編輯排程工作"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/ScheduledTaskEditDialog.java:107
+msgid "Select execution object"
+msgstr "選取執行物件"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/VariableEditDialog.java:121
+msgid "&True"
+msgstr "是(&T)"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/dialogs/VariableEditDialog.java:125
+msgid "&False"
+msgstr "否(&F)"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/views/ExportFileBuilder.java:1105
+msgid "NETCONF Query Definitions"
+msgstr "NETCONF 查詢定義"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/views/ImportConfiguration.java:144
+msgid "Replace &NETCONF query definitions"
+msgstr "取代 NETCONF 查詢定義(&N)"
+
+#: src/main/java/org/netxms/nxmc/modules/serverconfig/views/NetworkCredentialsEditor.java:167
+msgid "Select zone"
+msgstr "選取區域"
+
+#: src/main/java/org/netxms/nxmc/modules/snmp/views/MibFileManager.java:186
+msgid "Error Log"
+msgstr "錯誤記錄"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:424
+msgid "Search mode"
+msgstr "搜尋模式"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:429
+msgid "&Normal"
+msgstr "一般(&N)"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:433
+msgid "&Pattern (* = any string, ? = any character)"
+msgstr "樣式比對(&P)（* = 任意字串，? = 任意字元）"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:436
+msgid "&Regular expression"
+msgstr "正規表示式(&R)"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:447
+msgid "Class filter"
+msgstr "類別篩選"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:499
+msgid "Zone filter"
+msgstr "區域篩選"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:545
+msgid "IP Range"
+msgstr "IP 範圍"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:563
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:689
+msgid "&Search"
+msgstr "搜尋(&S)"
+
+#: src/main/java/org/netxms/nxmc/modules/tools/views/ObjectFinder.java:603
+msgid "Saved queries"
+msgstr "已儲存的查詢"
+
+#: src/main/java/org/netxms/nxmc/modules/traffic/views/ObservationPointView.java:190
+#, java-printf-format
+msgid "%.1f Gbps"
+msgstr "%.1f Gbps"
+
+#: src/main/java/org/netxms/nxmc/modules/traffic/views/ObservationPointView.java:192
+#, java-printf-format
+msgid "%.1f Mbps"
+msgstr "%.1f Mbps"
+
+#: src/main/java/org/netxms/nxmc/modules/traffic/views/ObservationPointView.java:194
+#, java-printf-format
+msgid "%.1f Kbps"
+msgstr "%.1f Kbps"
+
+#: src/main/java/org/netxms/nxmc/modules/traffic/views/ObservationPointView.java:195
+#, java-printf-format
+msgid "%.0f bps"
+msgstr "%.0f bps"
+
+#: src/main/java/org/netxms/nxmc/modules/users/propertypages/General.java:103
+msgid "Phone number"
+msgstr "電話號碼"
+
+#: src/main/java/org/netxms/nxmc/modules/users/propertypages/Members.java:90
+msgid ""
+"This built-in group contains all the users in the system and\n"
+"is populated automatically. You can’t add or remove users here."
+msgstr ""
+"此內建群組包含系統中所有使用者，並會自動維護。\n"
+"您無法在此新增或移除使用者。"
+
+#: src/main/java/org/netxms/nxmc/modules/users/propertypages/UIAccessRules.java:83
+msgid "&Add element..."
+msgstr "新增元素(&A)..."
+
+#: src/main/java/org/netxms/nxmc/modules/worldmap/dialogs/GeoAreaEditDialog.java:109
+msgid "Border points (one point per line)"
+msgstr "邊界點（每行一點）"
+
+#: src/main/java/org/netxms/nxmc/modules/worldmap/dialogs/GeoAreaSelectionDialog.java:77
+msgid "Select Geo Area"
+msgstr "選取地理區域"
+
+#: src/rwt/java/org/netxms/nxmc/Startup.java:284
+msgid "Invalid resource ID"
+msgstr "資源 ID 無效"
+
+#: src/rwt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java:88
+#: src/swt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java:94
+msgid "Edit Theme"
+msgstr "編輯佈景主題"
+
+#: src/rwt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java:113
+#: src/swt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java:120
+msgid "Theme elements"
+msgstr "佈景主題元素"
+
+#: src/rwt/java/org/netxms/nxmc/base/login/LoginDialog.java:157
+#: src/rwt/java/org/netxms/nxmc/base/login/LoginProgressDialog.java:124
+msgid "Copyright © 2013-2026 Raden Solutions"
+msgstr ""
+
+#: src/rwt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java:99
+#: src/swt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java:96
+msgid "Active theme"
+msgstr "使用中的佈景主題"
+
+#: src/rwt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java:179
+#: src/swt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java:176
+msgid "E&xport..."
+msgstr "匯出(&X)..."
+
+#: src/rwt/java/org/netxms/nxmc/base/widgets/WelcomePage.java:107
+#: src/swt/java/org/netxms/nxmc/base/widgets/WelcomePage.java:114
+msgid "Welcome to NetXMS "
+msgstr "歡迎使用 NetXMS "
+
+#: src/rwt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java:117
+#: src/swt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java:117
+msgid "Play sound on all alarms"
+msgstr "所有警報都播放音效"
+
+#: src/rwt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java:122
+#: src/swt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java:122
+msgid "Play sound as defined by active dashboard"
+msgstr "依作用中儀表板的定義播放音效"
+
+#: src/rwt/java/org/netxms/nxmc/modules/datacollection/propertypages/TemplateDataSources.java:89
+#: src/swt/java/org/netxms/nxmc/modules/datacollection/propertypages/TemplateDataSources.java:94
+msgid "Template Data Source"
+msgstr "範本資料來源"
+
+#: src/swt/java/org/netxms/nxmc/modules/dashboards/views/AbstractDashboardView.java:324
+msgid "Save dashboard as image"
+msgstr "將儀表板另存為影像"
+

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/Startup.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/Startup.java
@@ -281,7 +281,7 @@ public class Startup implements EntryPoint, StartupParameters
                   Composite content = new Composite(parent, SWT.NONE);
                   content.setLayout(new GridLayout());
                   Label label = new Label(content, SWT.NONE);
-                  label.setText("Invalid resource ID");
+                  label.setText(i18n.tr("Invalid resource ID"));
                   label.setFont(JFaceResources.getBannerFont());
                   return content;
                }

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java
@@ -44,16 +44,20 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TableColumn;
 import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.base.widgets.LabeledText;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.Theme;
 import org.netxms.nxmc.resources.ThemeElement;
 import org.netxms.nxmc.tools.ColorConverter;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Theme editing dialog
  */
 public class ThemeEditDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ThemeEditDialog.class);
+
    public static final int COLUMN_TAG = 0;
    public static final int COLUMN_FOREGROUND = 1;
    public static final int COLUMN_BACKGROUND = 2;
@@ -81,7 +85,7 @@ public class ThemeEditDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Edit Theme");
+      newShell.setText(i18n.tr("Edit Theme"));
       PreferenceStore settings = PreferenceStore.getInstance();
       newShell.setSize(settings.getAsInteger("ThemeEditDialog.cx", 670), settings.getAsInteger("ThemeEditDialog.cy", 600));
    }
@@ -106,7 +110,7 @@ public class ThemeEditDialog extends Dialog
       name.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
       Label label = new Label(dialogArea, SWT.NONE);
-      label.setText("Theme elements");
+      label.setText(i18n.tr("Theme elements"));
       GridData gd = new GridData();
       gd.verticalIndent = WidgetHelper.OUTER_SPACING - WidgetHelper.INNER_SPACING;
       label.setLayoutData(gd);

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginDialog.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginDialog.java
@@ -154,7 +154,7 @@ public class LoginDialog extends Dialog
       footer.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, false));
 
       Label copyright = new Label(footer, SWT.LEFT);
-      copyright.setText("Copyright \u00a9 2013-2026 Raden Solutions");
+      copyright.setText(i18n.tr("Copyright \u00a9 2013-2026 Raden Solutions"));
       copyright.setLayoutData(new GridData(SWT.LEFT, SWT.BOTTOM, true, false));
 
       Label version = new Label(footer, SWT.RIGHT);
@@ -216,7 +216,7 @@ public class LoginDialog extends Dialog
 
       // Login label
       Label label = new Label(formArea, SWT.CENTER);
-      label.setText("Log in");
+      label.setText(i18n.tr("Log in"));
       label.setData(RWT.CUSTOM_VARIANT, "LoginHeader");
       GridData gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginProgressDialog.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/login/LoginProgressDialog.java
@@ -121,7 +121,7 @@ public class LoginProgressDialog extends Dialog implements IRunnableContext
       footer.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, false));
 
       Label copyright = new Label(footer, SWT.LEFT);
-      copyright.setText("Copyright \u00a9 2013-2026 Raden Solutions");
+      copyright.setText(i18n.tr("Copyright \u00a9 2013-2026 Raden Solutions"));
       copyright.setLayoutData(new GridData(SWT.LEFT, SWT.BOTTOM, true, false));
 
       Label version = new Label(footer, SWT.RIGHT);

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java
@@ -40,6 +40,7 @@ import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.base.dialogs.ThemeEditDialog;
 import org.netxms.nxmc.base.jobs.Job;
 import org.netxms.nxmc.base.propertypages.PropertyPage;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.DefaultDarkTheme;
 import org.netxms.nxmc.resources.DefaultLightTheme;
 import org.netxms.nxmc.resources.Theme;
@@ -48,12 +49,15 @@ import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Theme preferences
  */
 public class ThemesPage extends PropertyPage
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ThemesPage.class);
+
    private static final Logger logger = LoggerFactory.getLogger(ThemesPage.class);
 
    private Combo themeSelector;
@@ -92,7 +96,7 @@ public class ThemesPage extends PropertyPage
       gd.horizontalAlignment = SWT.FILL;
       gd.grabExcessHorizontalSpace = true;
       gd.horizontalSpan = 4;
-      themeSelector = WidgetHelper.createLabeledCombo(dialogArea, SWT.DROP_DOWN | SWT.READ_ONLY | SWT.BORDER, "Active theme", gd);
+      themeSelector = WidgetHelper.createLabeledCombo(dialogArea, SWT.DROP_DOWN | SWT.READ_ONLY | SWT.BORDER, i18n.tr("Active theme"), gd);
       updateThemeDropDown();
 
       String currentTheme = PreferenceStore.getInstance().getAsString("CurrentTheme");
@@ -114,7 +118,7 @@ public class ThemesPage extends PropertyPage
       });
 
       editButton = new Button(dialogArea, SWT.PUSH);
-      editButton.setText("&Edit...");
+      editButton.setText(i18n.tr("&Edit..."));
       gd = new GridData();
       gd.verticalAlignment = SWT.BOTTOM;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -129,7 +133,7 @@ public class ThemesPage extends PropertyPage
       });
 
       removeButton = new Button(dialogArea, SWT.PUSH);
-      removeButton.setText("&Remove");
+      removeButton.setText(i18n.tr("&Remove"));
       gd = new GridData();
       gd.verticalAlignment = SWT.BOTTOM;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -144,7 +148,7 @@ public class ThemesPage extends PropertyPage
       });
 
       importButton = new Button(dialogArea, SWT.PUSH);
-      importButton.setText("&Import...");
+      importButton.setText(i18n.tr("&Import..."));
       gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -158,7 +162,7 @@ public class ThemesPage extends PropertyPage
       });
 
       newButton = new Button(dialogArea, SWT.PUSH);
-      newButton.setText("&New...");
+      newButton.setText(i18n.tr("&New..."));
       gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -172,7 +176,7 @@ public class ThemesPage extends PropertyPage
       });
 
       exportButton = new Button(dialogArea, SWT.PUSH);
-      exportButton.setText("E&xport...");
+      exportButton.setText(i18n.tr("E&xport..."));
       gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/widgets/WelcomePage.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/base/widgets/WelcomePage.java
@@ -104,7 +104,7 @@ public class WelcomePage extends Composite
       header.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
       Label title = new Label(header, SWT.NONE);
-      title.setText("Welcome to NetXMS " + serverVersion);
+      title.setText(i18n.tr("Welcome to NetXMS ") + serverVersion);
       title.setData(RWT.CUSTOM_VARIANT, "MainWindowHeaderBold");
       title.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java
@@ -114,12 +114,12 @@ public class AlarmSounds extends PropertyPage
       typeGroup.setLayoutData(gd);
       
       isGeneralSound = new Button(typeGroup, SWT.RADIO);
-      isGeneralSound.setText("Play sound on all alarms");
+      isGeneralSound.setText(i18n.tr("Play sound on all alarms"));
       isGeneralSound.setLayoutData(new GridData());
       isGeneralSound.setSelection(!ps.getAsBoolean("AlarmNotifier.LocalSound", false));
       
       isLocalSound = new Button(typeGroup, SWT.RADIO);
-      isLocalSound.setText("Play sound as defined by active dashboard");
+      isLocalSound.setText(i18n.tr("Play sound as defined by active dashboard"));
       isLocalSound.setLayoutData(new GridData());
       isLocalSound.setSelection(ps.getAsBoolean("AlarmNotifier.LocalSound", false));
 

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/datacollection/propertypages/DataSources.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/datacollection/propertypages/DataSources.java
@@ -83,7 +83,7 @@ public class DataSources extends PreferencePage
     */
    public DataSources(GraphDefinition settings, boolean saveToDatabase)
    {
-      super("Data Source");
+      super(LocalizationHelper.getI18n(DataSources.class).tr("Data Source"));
       config = settings;
       this.saveToDatabase = saveToDatabase;
    }

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/datacollection/propertypages/TemplateDataSources.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/datacollection/propertypages/TemplateDataSources.java
@@ -86,7 +86,7 @@ public class TemplateDataSources extends PreferencePage
     */
    public TemplateDataSources(GraphDefinition settings, boolean saveToDatabase)
    {
-      super("Template Data Source");
+      super(LocalizationHelper.getI18n(TemplateDataSources.class).tr("Template Data Source"));
       config = settings;
       this.saveToDatabase = saveToDatabase;
    }

--- a/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/nxsl/widgets/ScriptEditor.java
+++ b/src/client/nxmc/java/src/rwt/java/org/netxms/nxmc/modules/nxsl/widgets/ScriptEditor.java
@@ -189,7 +189,7 @@ public class ScriptEditor extends CompositeWithMessageArea
       {
          final Image compileImage = ResourceManager.getImage("icons/compile.png");
          compileButton = new Button(content, SWT.PUSH | SWT.FLAT);
-         compileButton.setToolTipText("Compile script");
+         compileButton.setToolTipText(i18n.tr("Compile script"));
          compileButton.setImage(compileImage);
          compileButton.addDisposeListener(new DisposeListener() {
             @Override

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/base/dialogs/ThemeEditDialog.java
@@ -49,16 +49,20 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.base.widgets.LabeledText;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.Theme;
 import org.netxms.nxmc.resources.ThemeElement;
 import org.netxms.nxmc.tools.ColorCache;
 import org.netxms.nxmc.tools.WidgetHelper;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Theme editing dialog
  */
 public class ThemeEditDialog extends Dialog
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ThemeEditDialog.class);
+
    public static final int COLUMN_TAG = 0;
    public static final int COLUMN_FOREGROUND = 1;
    public static final int COLUMN_BACKGROUND = 2;
@@ -87,7 +91,7 @@ public class ThemeEditDialog extends Dialog
    protected void configureShell(Shell newShell)
    {
       super.configureShell(newShell);
-      newShell.setText("Edit Theme");
+      newShell.setText(i18n.tr("Edit Theme"));
       PreferenceStore settings = PreferenceStore.getInstance();
       newShell.setSize(settings.getAsInteger("ThemeEditDialog.cx", 670), settings.getAsInteger("ThemeEditDialog.cy", 600));
    }
@@ -113,7 +117,7 @@ public class ThemeEditDialog extends Dialog
       name.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
       Label label = new Label(dialogArea, SWT.NONE);
-      label.setText("Theme elements");
+      label.setText(i18n.tr("Theme elements"));
       GridData gd = new GridData();
       gd.verticalIndent = WidgetHelper.OUTER_SPACING - WidgetHelper.INNER_SPACING;
       label.setLayoutData(gd);

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/base/preferencepages/ThemesPage.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.FileDialog;
 import org.netxms.nxmc.PreferenceStore;
 import org.netxms.nxmc.base.dialogs.ThemeEditDialog;
 import org.netxms.nxmc.base.propertypages.PropertyPage;
+import org.netxms.nxmc.localization.LocalizationHelper;
 import org.netxms.nxmc.resources.DefaultDarkTheme;
 import org.netxms.nxmc.resources.DefaultLightTheme;
 import org.netxms.nxmc.resources.Theme;
@@ -45,12 +46,15 @@ import org.netxms.nxmc.tools.MessageDialogHelper;
 import org.netxms.nxmc.tools.WidgetHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * Theme preferences
  */
 public class ThemesPage extends PropertyPage
 {
+   private final I18n i18n = LocalizationHelper.getI18n(ThemesPage.class);
+
    private static final Logger logger = LoggerFactory.getLogger(ThemesPage.class);
 
    private Combo themeSelector;
@@ -89,7 +93,7 @@ public class ThemesPage extends PropertyPage
       gd.horizontalAlignment = SWT.FILL;
       gd.grabExcessHorizontalSpace = true;
       gd.horizontalSpan = 4;
-      themeSelector = WidgetHelper.createLabeledCombo(dialogArea, SWT.DROP_DOWN | SWT.READ_ONLY | SWT.BORDER, "Active theme", gd);
+      themeSelector = WidgetHelper.createLabeledCombo(dialogArea, SWT.DROP_DOWN | SWT.READ_ONLY | SWT.BORDER, i18n.tr("Active theme"), gd);
       updateThemeDropDown();
 
       String currentTheme = PreferenceStore.getInstance().getAsString("CurrentTheme");
@@ -111,7 +115,7 @@ public class ThemesPage extends PropertyPage
       });
 
       editButton = new Button(dialogArea, SWT.PUSH);
-      editButton.setText("&Edit...");
+      editButton.setText(i18n.tr("&Edit..."));
       gd = new GridData();
       gd.verticalAlignment = SWT.BOTTOM;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -126,7 +130,7 @@ public class ThemesPage extends PropertyPage
       });
 
       removeButton = new Button(dialogArea, SWT.PUSH);
-      removeButton.setText("&Remove");
+      removeButton.setText(i18n.tr("&Remove"));
       gd = new GridData();
       gd.verticalAlignment = SWT.BOTTOM;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -141,7 +145,7 @@ public class ThemesPage extends PropertyPage
       });
 
       importButton = new Button(dialogArea, SWT.PUSH);
-      importButton.setText("&Import...");
+      importButton.setText(i18n.tr("&Import..."));
       gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -155,7 +159,7 @@ public class ThemesPage extends PropertyPage
       });
 
       newButton = new Button(dialogArea, SWT.PUSH);
-      newButton.setText("&New...");
+      newButton.setText(i18n.tr("&New..."));
       gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;
@@ -169,7 +173,7 @@ public class ThemesPage extends PropertyPage
       });
 
       exportButton = new Button(dialogArea, SWT.PUSH);
-      exportButton.setText("E&xport...");
+      exportButton.setText(i18n.tr("E&xport..."));
       gd = new GridData();
       gd.horizontalAlignment = SWT.CENTER;
       gd.widthHint = WidgetHelper.BUTTON_WIDTH_HINT;

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/base/widgets/WelcomePage.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/base/widgets/WelcomePage.java
@@ -111,7 +111,7 @@ public class WelcomePage extends Composite
       header.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
       Label title = new Label(header, SWT.NONE);
-      title.setText("Welcome to NetXMS " + serverVersion);
+      title.setText(i18n.tr("Welcome to NetXMS ") + serverVersion);
       title.setFont(headerFontBold);
       title.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/alarms/preferencepages/AlarmSounds.java
@@ -114,12 +114,12 @@ public class AlarmSounds extends PropertyPage
       typeGroup.setLayoutData(gd);
       
       isGeneralSound = new Button(typeGroup, SWT.RADIO);
-      isGeneralSound.setText("Play sound on all alarms");
+      isGeneralSound.setText(i18n.tr("Play sound on all alarms"));
       isGeneralSound.setLayoutData(new GridData());
       isGeneralSound.setSelection(!ps.getAsBoolean("AlarmNotifier.LocalSound", false));
       
       isLocalSound = new Button(typeGroup, SWT.RADIO);
-      isLocalSound.setText("Play sound as defined by active dashboard");
+      isLocalSound.setText(i18n.tr("Play sound as defined by active dashboard"));
       isLocalSound.setLayoutData(new GridData());
       isLocalSound.setSelection(ps.getAsBoolean("AlarmNotifier.LocalSound", false));
 

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/dashboards/views/AbstractDashboardView.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/dashboards/views/AbstractDashboardView.java
@@ -321,7 +321,7 @@ public abstract class AbstractDashboardView extends ObjectView
       gc.dispose();
 
       FileDialog fd = new FileDialog(getWindow().getShell(), SWT.SAVE);
-      fd.setText("Save dashboard as image");
+      fd.setText(i18n.tr("Save dashboard as image"));
       String[] filterExtensions = { "*.*" }; //$NON-NLS-1$
       fd.setFilterExtensions(filterExtensions);
       String[] filterNames = { ".png" };

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/datacollection/propertypages/DataSources.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/datacollection/propertypages/DataSources.java
@@ -88,7 +88,7 @@ public class DataSources extends PreferencePage
     */
    public DataSources(GraphDefinition settings, boolean saveToDatabase)
    {
-      super("Data Source");
+      super(LocalizationHelper.getI18n(DataSources.class).tr("Data Source"));
       config = settings;
       this.saveToDatabase = saveToDatabase;
    }

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/datacollection/propertypages/TemplateDataSources.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/datacollection/propertypages/TemplateDataSources.java
@@ -91,7 +91,7 @@ public class TemplateDataSources extends PreferencePage
     */
    public TemplateDataSources(GraphDefinition settings, boolean saveToDatabase)
    {
-      super("Template Data Source");
+      super(LocalizationHelper.getI18n(TemplateDataSources.class).tr("Template Data Source"));
       config = settings;
       this.saveToDatabase = saveToDatabase;
    }

--- a/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/nxsl/widgets/ScriptEditor.java
+++ b/src/client/nxmc/java/src/swt/java/org/netxms/nxmc/modules/nxsl/widgets/ScriptEditor.java
@@ -260,7 +260,7 @@ public class ScriptEditor extends CompositeWithMessageArea
       {
          final Image compileImage = ResourceManager.getImage("icons/compile.png");
          compileButton = new Button(content, SWT.PUSH | SWT.FLAT);
-         compileButton.setToolTipText("Compile script");
+         compileButton.setToolTipText(i18n.tr("Compile script"));
          compileButton.setImage(compileImage);
          compileButton.addDisposeListener(new DisposeListener() {
             @Override


### PR DESCRIPTION
Follow-up to #3592. Wraps 248 user-visible string literals that were never passed through `I18n.tr()`, so they could not be translated in any locale.

### Changes

- 248 call sites wrapped in `i18n.tr()`
- 28 classes had no I18n at all — added the two imports and the standard `private final I18n i18n = LocalizationHelper.getI18n(X.class);` field
- 7 literals sit inside `super(...)`, where the instance field does not exist yet — these use the inline form already used in `LanguagePage.java:65`

The diff is mechanical: of 359 added lines, 248 are the wrapper itself (matching 248 removed lines exactly), 55 are imports, 28 are field declarations, 28 are blank lines. No logic changes.

### Deliberately left in English

8 strings, 12 call sites:

- `[automatic]`, `Light [built-in]`, `Dark [built-in]` — compared with `equalsIgnoreCase` against `PreferenceStore` values in `ThemeEngine.java:247`
- `Session Keepalive Timer` — thread name
- `%<dciName>` / `%<dciDescription>` / `Generated when threshold value reached` / `Generated when threshold check is rearmed` — event message templates sent to the server
- `22, 80, 443` — default port list

### Catalogs

Only `zh_TW.po` is included, carrying translations for all 172 new msgids. The other seven catalogs are untouched on purpose — running the merge over them regenerates ~130k lines of source references that have drifted since the script was last run, which would bury this change. Running `generate_and_merge_translation.sh` once picks them up.

### Verified

- POT goes 5107 → 5279 msgids, none lost
- The desktop client (1569 files, `main` + `swt`) compiles clean
- `msgfmt -c` passes on all eight catalogs; `msgfmt --java2` generates `Messages_zh_TW.class`

I could not compile the `rwt` module locally (no RAP / jakarta.servlet in my environment). Those sources are edited identically but are unverified by me.
