### PR TITLE
Added physical placement property group and REST endpoint for rack and chassis placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,6 +310,7 @@ compile_commands.json
 /tests/test-libnxsnmp/test-libnxsnmp
 /tests/test-libnxsrv/test-libnxsrv
 /tests/test-ncd-webhook/test-ncd-webhook
+/tests/test-physical-placement/test-physical-placement
 /tools/inst.tar.gz
 /src/libnxjava/java/base/netxms-base/.classpath
 /src/libnxjava/java/base/netxms-base/.project

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -173,7 +173,7 @@ TESTS_DIRS = \
     tests/agent/unit/extcheck \
     tests/agent/unit/weather
 ifeq ($(BUILD_SERVER),1)
-TESTS_DIRS += tests/test-libnxsrv tests/test-ai-checks tests/test-authtokens
+TESTS_DIRS += tests/test-libnxsrv tests/test-ai-checks tests/test-authtokens tests/test-physical-placement
 endif
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -1077,7 +1077,7 @@ AC_ARG_WITH(dist,
 [AS_HELP_STRING(--with-dist,for maintainers only)],
 	DB_DRIVERS="mysql mariadb pgsql odbc mssql sqlite oracle db2 informix"
 	MODULES="jansson libargon2 java-common libnetxms libnxjava install sqlite snmp ethernetip libnxsl libnxmb libnxlp libnxnetconf db client server agent nxscript nxcproxy mobile-agent"
-	TEST_MODULES="agent ha test-ai-checks test-authtokens test-libethernetip test-libnxsl test-libnxnetconf test-libnxsnmp test-libnxsrv test-ncd-webhook"
+	TEST_MODULES="agent ha test-ai-checks test-authtokens test-libethernetip test-libnxsl test-libnxnetconf test-libnxsnmp test-libnxsrv test-ncd-webhook test-physical-placement"
 	AGENT_UNIT_TESTS="entsoe extcheck weather linux-cpu-usage-collector"
 	TOOLS="nxlptest"
 	SUBAGENT_DIRS="linux ds18x20 fbdev freebsd openbsd mqtt mysql pgsql netbsd sunos aix informix oracle prometheus lmsensors darwin rpi java jmx opcua ubntlw db2 tuxedo mongodb netconf ssh vmgr xen asterisk redis lldpd"
@@ -1326,7 +1326,7 @@ if test $? = 0; then
 
 	BUILD_SERVER="yes"
 	MODULES="$MODULES libnxsl server nxscript"
-	TEST_MODULES="$TEST_MODULES ha test-ai-checks test-authtokens test-libnxsl test-libnxsrv test-ncd-webhook"
+	TEST_MODULES="$TEST_MODULES ha test-ai-checks test-authtokens test-libnxsl test-libnxsrv test-ncd-webhook test-physical-placement"
 	TOP_LEVEL_MODULES="$TOP_LEVEL_MODULES sql images"
 	CONTRIB_MODULES="$CONTRIB_MODULES mibs backgrounds music oui templates"
 	NCDRV_MODULES="$NCDRV_MODULES nxagent"
@@ -4858,6 +4858,7 @@ AC_CONFIG_FILES([
 	tests/ha/Makefile
 	tests/test-ai-checks/Makefile
 	tests/test-authtokens/Makefile
+	tests/test-physical-placement/Makefile
 	tests/test-libethernetip/Makefile
 	tests/test-libnetxms/Makefile
 	tests/test-libnxdb/Makefile

--- a/src/server/core/Makefile.am
+++ b/src/server/core/Makefile.am
@@ -29,7 +29,7 @@ libnxcore_la_SOURCES = 2fa.cpp abind_target.cpp accesspoint.cpp acl.cpp actions.
 			netsrv.cpp network_cred.cpp node.cpp notification_channel.cpp \
 			np.cpp nxsl_classes.cpp nxslext.cpp object_categories.cpp observation_point.cpp \
 			object_queries.cpp objects.cpp objtools.cpp ospf.cpp otellog.cpp package.cpp \
-			pds.cpp physical_link.cpp poll.cpp pollable.cpp power_domain.cpp ps.cpp rack.cpp \
+			pds.cpp physical_link.cpp physical_placement.cpp poll.cpp pollable.cpp power_domain.cpp ps.cpp rack.cpp \
 			radius.cpp reporting.cpp resource.cpp rootobj.cpp sc_migration.cpp schedule.cpp script.cpp \
 			search_query.cpp sensor.cpp server_stats.cpp session.cpp skills.cpp \
 			snmp.cpp snmpd.cpp snmptrap.cpp snmptrapd.cpp ssh.cpp sshkeys.cpp stp.cpp \

--- a/src/server/core/chassis.cpp
+++ b/src/server/core/chassis.cpp
@@ -134,13 +134,22 @@ void Chassis::updateControllerBinding()
    if ((m_flags & CHF_BIND_UNDER_CONTROLLER) && !controllerFound)
    {
       shared_ptr<NetObj> controller = FindObjectById(m_controllerId, OBJECT_NODE);
-      if (controller != nullptr)
+      if (controller == nullptr)
       {
-         linkObjects(controller, self());
+         nxlog_debug_tag(DEBUG_TAG_OBJECT_RELATIONS, 4, _T("Chassis::updateControllerBinding(%s [%u]): controller node with ID %u not found"), m_name, m_id, m_controllerId);
+      }
+      else if (isChild(m_controllerId))
+      {
+         // Re-checked here because the front door check runs when the id is accepted, while this
+         // task runs later on the main pool: a placement request accepted in between can make this
+         // chassis a parent of the controller, and linking it now would close a cycle that
+         // clearInheritedAccessCache walks until the stack is gone. ChangeObjectBinding guards the
+         // generic bind path the same way.
+         nxlog_debug_tag(DEBUG_TAG_OBJECT_RELATIONS, 5, _T("Chassis::updateControllerBinding(%s [%u]): controller node %s [%u] is a descendant, binding skipped"), m_name, m_id, controller->getName(), m_controllerId);
       }
       else
       {
-         nxlog_debug_tag(DEBUG_TAG_OBJECT_RELATIONS, 4, _T("Chassis::updateControllerBinding(%s [%u]): controller node with ID %u not found"), m_name, m_id, m_controllerId);
+         linkObjects(controller, self());
       }
    }
 
@@ -193,6 +202,93 @@ uint32_t Chassis::modifyFromMessageInternal(const NXCPMessage& msg, ClientSessio
       m_rackOrientation = static_cast<RackOrientation>(msg.getFieldAsInt16(VID_RACK_ORIENTATION));
 
    return super::modifyFromMessageInternal(msg, session);
+}
+
+/**
+ * Modify chassis from JSON document (WebAPI path). Handles the controlling node and the
+ * "physicalPlacement" property group; all other fields are delegated to the base class
+ * implementation. Runs under the property lock (see NetObj::modifyFromJSON), released around
+ * the two child list walks below.
+ *
+ * Both the rack binding and the controller binding are rescheduled at the point their id is
+ * committed, exactly as modifyFromMessageInternal and updateFlags do. The caller marks the
+ * object as modified regardless of the result code, so a committed id reaches the database
+ * even when a later property of the same document is rejected; a rebind deferred until after
+ * that result code would then be skipped, leaving the chassis naming a parent it is not a
+ * child of.
+ */
+uint32_t Chassis::modifyFromJSONInternal(json_t *json, GenericClientSession *session)
+{
+   // Stage into a local so a subsequent rejection of the placement group leaves m_controllerId untouched
+   uint32_t controllerId = m_controllerId;
+   if (!json_object_update_integer(json, "controllerId", &controllerId))
+      return RCC_INVALID_ARGUMENT;
+   // Validate only when the document actually carries the key: json_object_update_integer leaves
+   // controllerId at the stored value when the property is absent, and a stored value can legitimately
+   // fail both checks below. A chassis can hold a controller id pointing at a node that is placed in
+   // it (consistent while CHF_BIND_UNDER_CONTROLLER is clear, since no link is made), or an id left
+   // by CMD_CREATE_OBJECT / modifyFromMessageInternal / a deleted controller row that resolves to
+   // nothing. Such an object must stay patchable, the same rule the placement code states.
+   if ((json_object_get(json, "controllerId") != nullptr) && (controllerId != 0))
+   {
+      // A controller id that does not resolve to a node would be committed and then dropped by
+      // updateControllerBinding, which unbinds the current controller and logs the miss at debug
+      // level only. The chassis would be left with no controller parent and an id pointing at
+      // nothing, silently stopping data collection that resolves through getEffectiveSourceNode.
+      if (FindObjectById(controllerId, OBJECT_NODE) == nullptr)
+         return RCC_INVALID_OBJECT_ID;
+
+      // Binding the chassis under one of its own descendants would close a cycle in the object
+      // tree, the same crash the placement path rejects with RCC_OBJECT_LOOP. Checked regardless
+      // of CHF_BIND_UNDER_CONTROLLER: no link is made while the flag is clear, but setting it later
+      // over NXCP makes one through updateFlags, and this is the only place that can report 409.
+      // isChild read locks the child list of this object and of every descendant, so the property
+      // lock must be dropped around it - see the note on the placement call below.
+      unlockProperties();
+      bool loop = isChild(controllerId);
+      lockProperties();
+      if (loop)
+         return RCC_OBJECT_LOOP;
+   }
+
+   json_t *physicalPlacement = json_object_get(json, "physicalPlacement");
+   if (physicalPlacement != nullptr)
+   {
+      // ModifyPhysicalPlacementFromJson calls NetObj::isChild, which read locks the child list of
+      // this object and of every descendant. Holding the property lock across that call would
+      // establish properties -> child list, the reverse of the order the configuration poll uses,
+      // and a thread waiting for the child list write lock would deadlock the two. Stage every
+      // field into a local and drop the property lock for the duration of the call; the group
+      // still commits all or nothing because nothing is written until it succeeds.
+      uint32_t rackId = m_rackId;
+      int16_t position = m_rackPosition;
+      int16_t height = m_rackHeight;
+      RackOrientation orientation = m_rackOrientation;
+      uuid imageFront = m_rackImageFront;
+      uuid imageRear = m_rackImageRear;
+      PhysicalPlacementRef placementRef = { &rackId, &position, &height, &orientation, &imageFront, &imageRear };
+      unlockProperties(); // removing possible deadlock
+      // A chassis can only be placed in a rack, never inside another chassis
+      uint32_t rcc = ModifyPhysicalPlacementFromJson(physicalPlacement, this, placementRef, false);
+      lockProperties();
+      if (rcc != RCC_SUCCESS)
+         return rcc;
+      m_rackId = rackId;
+      m_rackPosition = position;
+      m_rackHeight = height;
+      m_rackOrientation = orientation;
+      m_rackImageFront = imageFront;
+      m_rackImageRear = imageRear;
+
+      if (json_object_get(physicalPlacement, "containerId") != nullptr)
+         ThreadPoolExecute(g_mainThreadPool, this, &Chassis::updateRackBinding);
+   }
+
+   m_controllerId = controllerId;
+   if (json_object_get(json, "controllerId") != nullptr)
+      ThreadPoolExecute(g_mainThreadPool, this, &Chassis::updateControllerBinding);
+
+   return super::modifyFromJSONInternal(json, session);
 }
 
 /**
@@ -432,6 +528,11 @@ json_t *Chassis::toJson(bool includeSensitiveData)
    json_object_set_new(root, "rackId", json_integer(m_rackId));
    json_object_set_new(root, "rackImageFront", m_rackImageFront.toJson());
    json_object_set_new(root, "rackImageRear", m_rackImageRear.toJson());
+
+   // Physical placement property group. Same shape as the group accepted on the write path,
+   // and always emitted so a client never has to tell "absent" from "unplaced".
+   PhysicalPlacementRef placementRef = { &m_rackId, &m_rackPosition, &m_rackHeight, &m_rackOrientation, &m_rackImageFront, &m_rackImageRear };
+   json_object_set_new(root, "physicalPlacement", PhysicalPlacementToJson(placementRef));
    unlockProperties();
 
    return root;

--- a/src/server/core/node.cpp
+++ b/src/server/core/node.cpp
@@ -11730,6 +11730,90 @@ uint32_t Node::modifyFromJSONInternal(json_t *json, GenericClientSession *sessio
          return rcc;
    }
 
+   json_t *physicalPlacement = json_object_get(json, "physicalPlacement");
+   if (physicalPlacement != nullptr)
+   {
+      if (!json_is_object(physicalPlacement))
+         return RCC_INVALID_ARGUMENT;
+
+      // Validate the nested chassis geometry - both its own type and every key inside it -
+      // before anything is committed
+      json_t *chassisPlacement = json_object_get(physicalPlacement, "chassisPlacement");
+      if (chassisPlacement != nullptr)
+      {
+         if (!json_is_null(chassisPlacement) && !json_is_object(chassisPlacement))
+            return RCC_INVALID_ARGUMENT;
+         if (!json_is_null(chassisPlacement))
+         {
+            uint32_t rcc = ValidateChassisPlacementJson(chassisPlacement);
+            if (rcc != RCC_SUCCESS)
+               return rcc;
+         }
+      }
+
+      // ModifyPhysicalPlacementFromJson calls NetObj::isChild, which read locks the child list of
+      // this object and of every descendant. Holding the property lock across that call would
+      // establish properties -> child list, the reverse of the order the configuration poll uses
+      // when it scans interface addresses for EtherNet/IP, and a thread waiting for the child list
+      // write lock would deadlock the two. Stage every field into a local and drop the property
+      // lock for the duration of the call, the same way the primary host name check above does;
+      // the group still commits all or nothing because nothing is written until it succeeds.
+      uint32_t containerId = m_physicalContainer;
+      int16_t position = m_rackPosition;
+      int16_t height = m_rackHeight;
+      RackOrientation orientation = m_rackOrientation;
+      uuid imageFront = m_rackImageFront;
+      uuid imageRear = m_rackImageRear;
+      PhysicalPlacementRef placementRef = { &containerId, &position, &height, &orientation, &imageFront, &imageRear };
+      unlockProperties(); // removing possible deadlock
+      uint32_t rcc = ModifyPhysicalPlacementFromJson(physicalPlacement, this, placementRef, true);
+      lockProperties();
+      if (rcc != RCC_SUCCESS)
+         return rcc;
+      m_physicalContainer = containerId;
+      m_rackPosition = position;
+      m_rackHeight = height;
+      m_rackOrientation = orientation;
+      m_rackImageFront = imageFront;
+      m_rackImageRear = imageRear;
+
+      // Relink at the point the container id is committed, exactly as modifyFromMessageInternal
+      // does. The caller marks the object as modified regardless of the result code, so the new
+      // container id reaches the database even when a later property of the same document is
+      // rejected; a rebind deferred until after that result code would then be skipped, leaving
+      // the node naming a container it is not a child of.
+      if (json_object_get(physicalPlacement, "containerId") != nullptr)
+         ThreadPoolExecute(g_mainThreadPool, this, &Node::updatePhysicalContainerBinding, m_physicalContainer);
+
+      if (chassisPlacement != nullptr)
+      {
+         if (json_is_null(chassisPlacement))
+         {
+            MemFree(m_chassisPlacementConf);
+            m_chassisPlacementConf = nullptr;
+         }
+         else
+         {
+            // Merge onto the current geometry so a partial update does not zero the rest. A node
+            // with no stored geometry has no orientation to merge onto, and an orientation of 0
+            // matches neither the front nor the rear chassis view, so the node would be linked
+            // under the chassis but drawn in neither. Seed the base with the front view, the
+            // same default the Java ChassisPlacement class uses.
+            json_t *merged = chassisPlacementToJsonLocked();
+            if (merged == nullptr)
+            {
+               merged = json_object();
+               json_object_set_new(merged, "orientation", json_integer(FRONT));
+            }
+            json_object_update(merged, chassisPlacement);
+            char *xml = ChassisPlacementToXml(merged);
+            json_decref(merged);
+            MemFree(m_chassisPlacementConf);
+            m_chassisPlacementConf = xml;
+         }
+      }
+   }
+
    return super::modifyFromJSONInternal(json, session);
 }
 
@@ -16000,6 +16084,16 @@ void Node::updatePhysicalContainerBinding(uint32_t containerId)
          nxlog_debug(5, _T("Node::updatePhysicalContainerBinding(%s [%d]): incorrect object %s [%d] class"),
                      m_name, m_id, container->getName(), containerId);
       }
+      else if (isChild(containerId))
+      {
+         // Re-checked here because the front door check runs when the container id is accepted,
+         // while this task runs later on the main pool: a controller binding request accepted in
+         // between can make this node a parent of the container, and linking it now would close a
+         // cycle that clearInheritedAccessCache walks until the stack is gone. ChangeObjectBinding
+         // guards the generic bind path the same way.
+         nxlog_debug(5, _T("Node::updatePhysicalContainerBinding(%s [%d]): container %s [%d] is a descendant, binding skipped"),
+                     m_name, m_id, container->getName(), containerId);
+      }
       else
       {
          nxlog_debug(5, _T("Node::updatePhysicalContainerBinding(%s [%d]): add binding %s [%d]"), m_name, m_id, container->getName(), container->getId());
@@ -16668,6 +16762,14 @@ json_t *Node::toJson(bool includeSensitiveData)
    json_object_set_new(root, "physicalContainerId", json_integer(m_physicalContainer));
    json_object_set_new(root, "rackImageFront", m_rackImageFront.toJson());
    json_object_set_new(root, "rackImageRear", m_rackImageRear.toJson());
+
+   // Physical placement property group. Same shape as the group accepted on the write path,
+   // and always emitted so a client never has to tell "absent" from "unplaced".
+   PhysicalPlacementRef placementRef = { &m_physicalContainer, &m_rackPosition, &m_rackHeight, &m_rackOrientation, &m_rackImageFront, &m_rackImageRear };
+   json_t *physicalPlacement = PhysicalPlacementToJson(placementRef);
+   json_t *chassisPlacement = chassisPlacementToJsonLocked();
+   json_object_set_new(physicalPlacement, "chassisPlacement", (chassisPlacement != nullptr) ? json_incref(chassisPlacement) : json_null());
+   json_object_set_new(root, "physicalPlacement", physicalPlacement);
    json_object_set_new(root, "syslogMessageCount", json_integer(m_syslogMessageCount));
    json_object_set_new(root, "snmpTrapCount", json_integer(m_snmpTrapCount));
    if (includeSensitiveData)
@@ -16705,9 +16807,10 @@ json_t *Node::toJson(bool includeSensitiveData)
    json_object_set_new(root, "snmp", snmpConfigToJson(includeSensitiveData));
    json_object_set_new(root, "agent", agentConfigToJson(includeSensitiveData));
 
-   json_t *decodedChassisPlacement = getChassisPlacement();
-   if (decodedChassisPlacement != nullptr)
-      json_object_set_new(root, "chassisPlacementConfig", decodedChassisPlacement);
+   // chassisPlacement was decoded once above; hand that same reference to the legacy
+   // top-level key rather than parsing the XML a second time
+   if (chassisPlacement != nullptr)
+      json_object_set_new(root, "chassisPlacementConfig", chassisPlacement);
 
    m_topologyMutex.lock();
    shared_ptr<VlanList> vlans = m_vlans;
@@ -16746,22 +16849,17 @@ int Node::getRackPlacement(json_t *element) const
 }
 
 /**
- * Parse chassis placement configuration into JSON object.
- * Returns nullptr if this node is not placed in a chassis (no placement configuration).
+ * Parse chassis placement configuration into JSON object. Must be called with object
+ * properties locked. Returns nullptr if this node is not placed in a chassis (no placement
+ * configuration).
  */
-json_t *Node::getChassisPlacement() const
+json_t *Node::chassisPlacementToJsonLocked() const
 {
-   lockProperties();
    if ((m_chassisPlacementConf == nullptr) || (*m_chassisPlacementConf == 0))
-   {
-      unlockProperties();
       return nullptr;
-   }
 
    Config config;
-   bool parsed = config.loadXmlConfigFromMemory(m_chassisPlacementConf, strlen(m_chassisPlacementConf), nullptr, "placement", false);
-   unlockProperties();
-   if (!parsed)
+   if (!config.loadXmlConfigFromMemory(m_chassisPlacementConf, strlen(m_chassisPlacementConf), nullptr, "placement", false))
       return nullptr;
 
    json_t *placement = json_object();
@@ -16775,6 +16873,18 @@ json_t *Node::getChassisPlacement() const
    json_object_set_new(placement, "positionWidth", json_integer(config.getValueAsInt(L"/positionWidth", 0)));
    json_object_set_new(placement, "positionWidthUnits", json_integer(config.getValueAsInt(L"/positionWidthUnits", 0)));
    json_object_set_new(placement, "orientation", json_integer(config.getValueAsInt(L"/oritentaiton", 0)));
+   return placement;
+}
+
+/**
+ * Parse chassis placement configuration into JSON object.
+ * Returns nullptr if this node is not placed in a chassis (no placement configuration).
+ */
+json_t *Node::getChassisPlacement() const
+{
+   lockProperties();
+   json_t *placement = chassisPlacementToJsonLocked();
+   unlockProperties();
    return placement;
 }
 

--- a/src/server/core/physical_placement.cpp
+++ b/src/server/core/physical_placement.cpp
@@ -1,0 +1,262 @@
+/*
+** NetXMS - Network Management System
+** Copyright (C) 2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+** File: physical_placement.cpp
+**
+** Shared read and write implementation of the "physicalPlacement" property group used by
+** Node and Chassis on the WebAPI JSON path. Both directions live here so the serialized
+** key set and the accepted key set cannot drift apart.
+**
+**/
+
+#include "nxcore.h"
+
+/**
+ * Serialize physical placement property group.
+ */
+json_t *PhysicalPlacementToJson(const PhysicalPlacementRef& placement)
+{
+   json_t *group = json_object();
+   json_object_set_new(group, "containerId", json_integer(*placement.containerId));
+   json_object_set_new(group, "position", json_integer(*placement.position));
+   json_object_set_new(group, "height", json_integer(*placement.height));
+   json_object_set_new(group, "orientation", json_integer(*placement.orientation));
+   json_object_set_new(group, "imageFront", placement.imageFront->toJson());
+   json_object_set_new(group, "imageRear", placement.imageRear->toJson());
+   return group;
+}
+
+/**
+ * Check that a device of given height placed at given rack unit fits inside the rack.
+ * Rack position is the unit occupied by the device's top edge when the rack is numbered
+ * top to bottom, and by its bottom edge otherwise. Mirrors the client side check in
+ * RackWidget, which silently skips an entity that fails it, so a layout accepted here is
+ * one the rack view will actually draw.
+ */
+bool IsValidRackExtent(int position, int height, int rackHeight, bool topBottomNumbering)
+{
+   if ((position < 1) || (position > rackHeight))
+      return false;
+   if (topBottomNumbering)
+      return position + height <= rackHeight + 1;
+   return position - height >= 0;
+}
+
+/**
+ * Apply physical placement property group as JSON merge-patch. Every field is staged and
+ * validated before anything is written, so a rejected document leaves the object's
+ * placement untouched - unlike the individual scalar properties handled by
+ * NetObj::modifyFromJSONInternal, placement fields are only meaningful together.
+ * The object being placed is needed to reject a container that is one of its own
+ * descendants; it is only dereferenced once a container id actually resolves.
+ */
+uint32_t ModifyPhysicalPlacementFromJson(json_t *group, const NetObj *object, const PhysicalPlacementRef& placement, bool allowChassisContainer)
+{
+   if (!json_is_object(group))
+      return RCC_INVALID_ARGUMENT;
+
+   uint32_t containerId = *placement.containerId;
+   int16_t position = *placement.position;
+   int16_t height = *placement.height;
+   RackOrientation orientation = *placement.orientation;
+   uuid imageFront = *placement.imageFront;
+   uuid imageRear = *placement.imageRear;
+
+   if (!json_object_update_integer(group, "containerId", &containerId))
+      return RCC_INVALID_ARGUMENT;
+
+   // json_object_update_integer accepts null as 0, which is a valid clearing value for
+   // containerId but not for position - 0 is "never placed", not a rack unit. Height and
+   // orientation reject null on their own (height through the < 1 check below, orientation
+   // through its explicit type check), so only position needs to be rejected here.
+   if (json_is_null(json_object_get(group, "position")))
+      return RCC_INVALID_ARGUMENT;
+   if (!json_object_update_integer(group, "position", &position))
+      return RCC_INVALID_ARGUMENT;
+   if (!json_object_update_integer(group, "height", &height))
+      return RCC_INVALID_ARGUMENT;
+
+   json_t *value = json_object_get(group, "orientation");
+   if (value != nullptr)
+   {
+      if (!json_is_integer(value))
+         return RCC_INVALID_ARGUMENT;
+      int64_t v = json_integer_value(value);
+      if ((v < FILL) || (v > REAR))
+         return RCC_INVALID_ARGUMENT;
+      orientation = static_cast<RackOrientation>(v);
+   }
+
+   const struct { const char *key; uuid *target; } imageFields[] = {
+      { "imageFront", &imageFront },
+      { "imageRear",  &imageRear  }
+   };
+   for(const auto& field : imageFields)
+   {
+      value = json_object_get(group, field.key);
+      if (value == nullptr)
+         continue;
+      if (json_is_null(value))
+      {
+         *field.target = uuid::NULL_UUID;
+      }
+      else if (json_is_string(value))
+      {
+         uuid_t parsed;
+         if (_uuid_parseA(json_string_value(value), parsed) != 0)
+            return RCC_INVALID_ARGUMENT;
+         *field.target = uuid(parsed);
+      }
+      else
+      {
+         return RCC_INVALID_ARGUMENT;
+      }
+   }
+
+   // Geometry is validated only when the document actually touches it. An object can hold a
+   // position that this check would reject - the NXCP path validates nothing and the console
+   // spinner offers a fixed 1..50 range regardless of rack height - and such an object must
+   // still be patchable, e.g. to set an image alone. The flip side is that placing an object
+   // into a rack requires a position that fits, either sent in the same document or already
+   // stored; a never placed object has position 0 and must supply one.
+   if ((json_object_get(group, "containerId") != nullptr) || (json_object_get(group, "position") != nullptr) ||
+       (json_object_get(group, "height") != nullptr))
+   {
+      if (height < 1)
+         return RCC_INVALID_ARGUMENT;
+
+      if (containerId != 0)
+      {
+         shared_ptr<NetObj> container = FindObjectById(containerId);
+         if (container == nullptr)
+            return RCC_INVALID_OBJECT_ID;
+         if (container->getObjectClass() == OBJECT_RACK)
+         {
+            const Rack *rack = static_cast<const Rack*>(container.get());
+            if (!IsValidRackExtent(position, height, rack->getHeight(), rack->isTopBottomNumbering()))
+               return RCC_INVALID_ARGUMENT;
+         }
+         else if (!allowChassisContainer || (container->getObjectClass() != OBJECT_CHASSIS))
+         {
+            return RCC_INVALID_OBJECT_ID;
+         }
+
+         // Placing an object inside one of its own descendants would close a cycle in the
+         // object tree. The binding that follows calls NetObj::clearInheritedAccessCache,
+         // which walks the child list with no cycle detection and would recurse until the
+         // server dies; ChangeObjectBinding guards the generic bind path the same way.
+         if (object->isChild(containerId))
+            return RCC_OBJECT_LOOP;
+      }
+   }
+
+   *placement.containerId = containerId;
+   *placement.position = position;
+   *placement.height = height;
+   *placement.orientation = orientation;
+   *placement.imageFront = imageFront;
+   *placement.imageRear = imageRear;
+   return RCC_SUCCESS;
+}
+
+/**
+ * Serialize chassis placement geometry into the <placement> XML document stored in
+ * Node::m_chassisPlacementConf. The orientation tag is deliberately spelled
+ * "oritentaiton": that is the name the reader (Node::getChassisPlacement) and every
+ * client expect, including the Java ChassisPlacement class, and correcting it here would
+ * silently drop orientation for all of them. Every member is emitted, so the resulting
+ * document always parses into a complete geometry. All values are integers or a UUID in
+ * canonical form, so no XML escaping is needed.
+ * Returns a MemAlloc'ed UTF-8 string; caller takes ownership.
+ */
+char NXCORE_EXPORTABLE *ChassisPlacementToXml(json_t *placement)
+{
+   char image[64];
+   json_object_get_uuid(placement, "image").toStringA(image);
+
+   char buffer[1024];
+   snprintf(buffer, sizeof(buffer),
+      "<placement>\n"
+      "   <image>%s</image>\n"
+      "   <height>%d</height>\n"
+      "   <heightUnits>%d</heightUnits>\n"
+      "   <width>%d</width>\n"
+      "   <widthUnits>%d</widthUnits>\n"
+      "   <positionHeight>%d</positionHeight>\n"
+      "   <positionHeightUnits>%d</positionHeightUnits>\n"
+      "   <positionWidth>%d</positionWidth>\n"
+      "   <positionWidthUnits>%d</positionWidthUnits>\n"
+      "   <oritentaiton>%d</oritentaiton>\n"
+      "</placement>\n",
+      image,
+      json_object_get_int32(placement, "height"),
+      json_object_get_int32(placement, "heightUnits"),
+      json_object_get_int32(placement, "width"),
+      json_object_get_int32(placement, "widthUnits"),
+      json_object_get_int32(placement, "positionHeight"),
+      json_object_get_int32(placement, "positionHeightUnits"),
+      json_object_get_int32(placement, "positionWidth"),
+      json_object_get_int32(placement, "positionWidthUnits"),
+      json_object_get_int32(placement, "orientation"));
+   return MemCopyStringA(buffer);
+}
+
+/**
+ * Validate the type of every key in a chassis placement geometry document without mutating
+ * anything. ChassisPlacementToXml reads the nine geometry keys with json_object_get_int32,
+ * which silently coerces a non-integer value to 0 - without this check a malformed value
+ * would not fail, it would just zero the corresponding stored dimension. Unknown keys are
+ * ignored, not rejected, matching the group's merge-patch semantics; an absent key is fine
+ * for the same reason. The image is checked for a parseable UUID as well, because
+ * json_object_get_uuid coerces a malformed string to the null UUID, which would silently
+ * clear the stored image. Range checks (e.g. height >= 1) are intentionally out of scope.
+ */
+uint32_t ValidateChassisPlacementJson(json_t *placement)
+{
+   if (!json_is_object(placement))
+      return RCC_INVALID_ARGUMENT;
+
+   static const char *integerKeys[] = {
+      "height", "heightUnits", "width", "widthUnits",
+      "positionHeight", "positionHeightUnits", "positionWidth", "positionWidthUnits",
+      "orientation"
+   };
+   for(const char *key : integerKeys)
+   {
+      json_t *value = json_object_get(placement, key);
+      if ((value != nullptr) && !json_is_integer(value))
+         return RCC_INVALID_ARGUMENT;
+   }
+
+   json_t *image = json_object_get(placement, "image");
+   if (image != nullptr)
+   {
+      if (json_is_string(image))
+      {
+         uuid_t parsed;
+         if (_uuid_parseA(json_string_value(image), parsed) != 0)
+            return RCC_INVALID_ARGUMENT;
+      }
+      else if (!json_is_null(image))
+      {
+         return RCC_INVALID_ARGUMENT;
+      }
+   }
+
+   return RCC_SUCCESS;
+}

--- a/src/server/include/nms_objects.h
+++ b/src/server/include/nms_objects.h
@@ -3376,6 +3376,52 @@ enum RackOrientation
 };
 
 /**
+ * References to an object's physical placement properties. Node and Chassis own the same
+ * property set under different member names and share no common base class that holds it,
+ * so the shared read and write code addresses the owner's members through this structure.
+ */
+struct PhysicalPlacementRef
+{
+   uint32_t *containerId;
+   int16_t *position;
+   int16_t *height;
+   RackOrientation *orientation;
+   uuid *imageFront;
+   uuid *imageRear;
+};
+
+/**
+ * Serialize physical placement property group.
+ */
+json_t NXCORE_EXPORTABLE *PhysicalPlacementToJson(const PhysicalPlacementRef& placement);
+
+/**
+ * Apply physical placement property group as JSON merge-patch. Keys present in the document
+ * are applied, omitted keys are left untouched, and null clears. Nothing is written to the
+ * target unless every field validates. Set allowChassisContainer for objects that can be
+ * placed inside a chassis as well as a rack. The object being placed is used to reject a
+ * container that is one of its own descendants with RCC_OBJECT_LOOP.
+ */
+uint32_t NXCORE_EXPORTABLE ModifyPhysicalPlacementFromJson(json_t *group, const NetObj *object, const PhysicalPlacementRef& placement, bool allowChassisContainer);
+
+/**
+ * Check that a device of given height placed at given rack unit fits inside the rack.
+ */
+bool NXCORE_EXPORTABLE IsValidRackExtent(int position, int height, int rackHeight, bool topBottomNumbering);
+
+/**
+ * Serialize chassis placement geometry into the <placement> XML document format.
+ * Returns a MemAlloc'ed UTF-8 string; caller takes ownership.
+ */
+char NXCORE_EXPORTABLE *ChassisPlacementToXml(json_t *placement);
+
+/**
+ * Validate the type of every key in a chassis placement geometry document without
+ * mutating anything. Returns RCC_SUCCESS or RCC_INVALID_ARGUMENT.
+ */
+uint32_t NXCORE_EXPORTABLE ValidateChassisPlacementJson(json_t *placement);
+
+/**
  * Chassis (represents physical chassis)
  */
 class NXCORE_EXPORTABLE Chassis : public DataCollectionTarget
@@ -3394,6 +3440,7 @@ protected:
 
    virtual void fillMessageLocked(NXCPMessage *msg, uint32_t userId) override;
    virtual uint32_t modifyFromMessageInternal(const NXCPMessage& msg, ClientSession *session) override;
+   virtual uint32_t modifyFromJSONInternal(json_t *json, GenericClientSession *session) override;
    virtual void updateFlags(uint32_t flags, uint32_t mask) override;
 
    virtual void onObjectDelete(const NetObj& object) override;
@@ -4403,7 +4450,7 @@ protected:
    IcmpStatCollectionMode m_icmpStatCollectionMode;
    StringObjectMap<IcmpStatCollector> *m_icmpStatCollectors;
    InetAddressList m_icmpTargets;
-   char *m_chassisPlacementConf;   // Chassis placement configuration (opaque UTF-8 XML, stored and forwarded without processing)
+   char *m_chassisPlacementConf;   // Chassis placement configuration (UTF-8 XML, parsed/merged/re-serialized on the JSON write path)
    uint16_t m_eipPort;  // EtherNet/IP port
    InetAddress m_eipAddress;  // EtherNet/IP address (if different from primary)
    uint16_t m_cipDeviceType;
@@ -4431,6 +4478,7 @@ protected:
    virtual uint32_t modifyFromJSONInternal(json_t *json, GenericClientSession *session) override;
    uint32_t modifyJsonSnmpConfig(json_t *snmp);
    uint32_t modifyJsonAgentConfig(json_t *agent);
+   json_t *chassisPlacementToJsonLocked() const;
    virtual void updateFlags(uint32_t flags, uint32_t mask) override;
 
    virtual void onDataCollectionChange() override;

--- a/src/server/webapi/main.cpp
+++ b/src/server/webapi/main.cpp
@@ -187,6 +187,7 @@ int H_ObjectDetails(Context *context);
 int H_ObjectFacilityGet(Context *context);
 int H_ObjectFacilityUpdate(Context *context);
 int H_ObjectLocationUpdate(Context *context);
+int H_ObjectPhysicalPlacementUpdate(Context *context);
 int H_ObjectPollingGet(Context *context);
 int H_ObjectPowerDomainGet(Context *context);
 int H_ObjectPowerDomainUpdate(Context *context);
@@ -741,6 +742,9 @@ static bool InitModule(Config *config)
       .build();
    RouteBuilder("v1/objects/:object-id/location")
       .PATCH(H_ObjectLocationUpdate)
+      .build();
+   RouteBuilder("v1/objects/:object-id/physical-placement")
+      .PATCH(H_ObjectPhysicalPlacementUpdate)
       .build();
    RouteBuilder("v1/objects/:object-id/status-calculation")
       .PATCH(H_ObjectStatusCalculationUpdate)

--- a/src/server/webapi/object_helpers.cpp
+++ b/src/server/webapi/object_helpers.cpp
@@ -102,6 +102,12 @@ int ApplyJsonPatch(Context *context, NetObj *object, const char *groupKey, const
          case RCC_SUBNET_OVERLAP:
             context->setErrorResponse("Subnet overlaps with existing one");
             return 409;
+         case RCC_INVALID_OBJECT_ID:
+            context->setErrorResponse("Request references an object that does not exist or is not of the required class");
+            return 400;
+         case RCC_OBJECT_LOOP:
+            context->setErrorResponse("Requested change would create a loop in the object tree");
+            return 409;
          default:
             context->setErrorResponse("Invalid property values in request");
             return 400;

--- a/src/server/webapi/object_properties.cpp
+++ b/src/server/webapi/object_properties.cpp
@@ -79,6 +79,29 @@ int H_ObjectLocationUpdate(Context *context)
 }
 
 /**
+ * Handler for PATCH /v1/objects/:object-id/physical-placement - rack or chassis placement.
+ * Requires modify access on the placed object only, matching the NXCP path (placing a device
+ * into a rack does not require modify access on the rack).
+ */
+int H_ObjectPhysicalPlacementUpdate(Context *context)
+{
+   int httpCode = 0;
+   shared_ptr<NetObj> object = LoadObjectForModify(context, OBJECT_ACCESS_MODIFY, &httpCode);
+   if (object == nullptr)
+      return httpCode;
+
+   if ((object->getObjectClass() != OBJECT_NODE) && (object->getObjectClass() != OBJECT_CHASSIS))
+   {
+      wchar_t message[256];
+      nx_swprintf(message, 256, L"Property group physicalPlacement does not apply to object class %s", object->getObjectClassName());
+      context->setErrorResponse(message);
+      return 400;
+   }
+
+   return ApplyJsonPatch(context, object.get(), "physicalPlacement", L"Modified physical placement of object %s [%u]");
+}
+
+/**
  * Handler for PATCH /v1/objects/:object-id/status-calculation -
  * status calculation/propagation algorithms and thresholds.
  */

--- a/src/server/webapi/openapi.yaml
+++ b/src/server/webapi/openapi.yaml
@@ -3831,6 +3831,24 @@ paths:
                     the node's interfaces, that address must not already be used by another
                     node or subnet (this check is skipped for an external gateway). A name that
                     does not resolve is accepted.
+                physicalPlacement:
+                  allOf:
+                    - $ref: '#/components/schemas/PhysicalPlacement'
+                  description: >-
+                    Node and Chassis only. Placement in a rack or chassis. Prefer
+                    `PATCH /v1/objects/{object-id}/physical-placement`, which lets a client
+                    detect whether the server supports this at all.
+                controllerId:
+                  type: integer
+                  nullable: true
+                  description: >-
+                    Chassis only. ID of the node that manages the chassis. This is
+                    separate from `physicalPlacement`: it says which node controls the
+                    chassis, not where the chassis is placed. `null` or `0` clears the
+                    controller and unbinds the chassis from it. A non-zero value is
+                    rejected with `400` if it does not resolve to an existing node, and
+                    with `409` if that node is a descendant of the chassis, which would
+                    create a loop.
       responses:
         '200':
           description: Object updated; full updated object returned.
@@ -3852,7 +3870,8 @@ paths:
         '409':
           description: >-
             IP address resolved from the new primary host name is already used by another
-            node or subnet.
+            node or subnet, or the requested `physicalPlacement.containerId` or
+            `controllerId` would create a loop in the object tree.
       security:
         - BearerAuth: []
       tags:
@@ -3988,6 +4007,75 @@ paths:
           description: User does not have modify access to the object
         '404':
           description: Object with given ID does not exist
+      security:
+        - BearerAuth: []
+      tags:
+        - Objects
+  /v1/objects/{object-id}/physical-placement:
+    patch:
+      operationId: updateObjectPhysicalPlacement
+      summary: Update object placement in a rack or chassis
+      description: |
+        Place a node or chassis into a rack, place a node into a chassis, move one that is
+        already placed, or remove it from its container. Body uses JSON merge-patch
+        semantics: properties present are applied and properties omitted are left untouched.
+        `null` clears the value only for `containerId`, `imageFront`, `imageRear` and
+        `chassisPlacement`; sending `null` for `position`, `height` or `orientation` is
+        rejected with `400`. Setting `containerId` to `null` or `0` removes the object from
+        its container.
+
+        A node may be placed in a rack or in a chassis; a chassis may only be placed in a
+        rack. When the container is a rack, `position` and `height` must leave the object
+        entirely within the rack's unit range. That range is checked only when the document
+        supplies `containerId`, `position` or `height`, so an object already stored at an
+        out-of-range position stays patchable in other respects. Placing an object into a
+        rack therefore requires a valid `position`, either sent in the same document or
+        already stored: an object that has never been placed has `position` 0 and must be
+        given one, otherwise the request is rejected with `400`. Overlapping placements are
+        **not** rejected: the model has always allowed them and some installations rely on it.
+
+        Requires modify access on the object being placed. Modify access on the target
+        container is not required, matching the behaviour of the native client protocol.
+
+        The same property group is also accepted as the `physicalPlacement` property of
+        `PATCH /v1/objects/{object-id}`. Clients should prefer this sub-resource: a server
+        that predates it answers `404`, which is a usable feature check, whereas the
+        top-level patch silently ignores property groups it does not recognise.
+      parameters:
+        - name: object-id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhysicalPlacement'
+      responses:
+        '200':
+          description: Placement updated; full updated object returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectDetails'
+        '400':
+          description: >-
+            Malformed request body, invalid value (height below 1, orientation outside
+            0-2, position leaving the object outside the rack), a malformed image GUID,
+            a `containerId` that does not exist or is not a rack or chassis, or property
+            group not applicable to object class.
+        '401':
+          description: Unauthorized
+        '403':
+          description: User does not have modify access to the object
+        '404':
+          description: Object with given ID does not exist
+        '409':
+          description: >-
+            The requested `containerId` is a descendant of the object being placed, so
+            the placement would create a loop in the object tree.
       security:
         - BearerAuth: []
       tags:
@@ -11557,7 +11645,10 @@ components:
         image:
           type: string
           format: uuid
-          description: GUID of the image representing the component
+          nullable: true
+          description: >-
+            GUID of the image representing the component. `null` clears it. A string that is
+            not a well formed GUID is rejected with `400`.
         height:
           type: integer
           description: Component height
@@ -11585,6 +11676,58 @@ components:
         orientation:
           type: integer
           description: Orientation (1=front, 2=rear)
+    PhysicalPlacement:
+      type: object
+      description: >-
+        Placement of an object inside a rack or a chassis. Returned on nodes and chassis, and
+        accepted as a merge-patch on the same objects: properties present are applied and
+        properties omitted are left untouched. `null` clears the value only for the nullable
+        properties `containerId`, `imageFront`, `imageRear` and `chassisPlacement`; sending
+        `null` for `position`, `height` or `orientation` is rejected with `400`. Always
+        present on read, with `containerId` 0 for an object that is not placed anywhere.
+      properties:
+        containerId:
+          type: integer
+          nullable: true
+          description: >-
+            ID of the rack or chassis holding the object. `null` or `0` removes it from its
+            current container. A node may be placed in a rack or a chassis; a chassis may
+            only be placed in a rack. A container that is a descendant of the object being
+            placed is rejected with `409`, since it would create a loop in the object tree.
+        position:
+          type: integer
+          description: >-
+            Rack unit occupied by the object, counted from 1. Meaningful only when the
+            container is a rack. With top-to-bottom rack numbering this is the object's
+            topmost unit, otherwise its bottommost unit. Must leave the object entirely
+            within the rack.
+        height:
+          type: integer
+          minimum: 1
+          description: Object height in rack units.
+        orientation:
+          type: integer
+          enum: [0, 1, 2]
+          description: Mounting orientation (0 = fill, 1 = front, 2 = rear).
+        imageFront:
+          type: string
+          format: uuid
+          nullable: true
+          description: Image library GUID used to draw the object's front face. `null` clears it.
+        imageRear:
+          type: string
+          format: uuid
+          nullable: true
+          description: Image library GUID used to draw the object's rear face. `null` clears it.
+        chassisPlacement:
+          allOf:
+            - $ref: '#/components/schemas/ChassisPlacement'
+          type: object
+          nullable: true
+          description: >-
+            Node only. Geometry of the node within its parent chassis. Merge-patched against
+            the current geometry, so a partial document leaves the remaining members alone;
+            `null` removes the geometry entirely.
     InetAddress:
       type: object
       properties:
@@ -15179,6 +15322,12 @@ components:
         name:
           type: string
           description: Object name
+        physicalPlacement:
+          allOf:
+            - $ref: '#/components/schemas/PhysicalPlacement'
+          description: >-
+            Placement in a rack or chassis. Present on nodes and chassis; `containerId` is 0
+            when the object is not placed anywhere.
         responsibleUsers:
           type: array
           description: Users or groups responsible for the object (the object's own list; entries inherited from parent objects are not included).

--- a/tests/suite/netxms-test-suite.cmd
+++ b/tests/suite/netxms-test-suite.cmd
@@ -37,6 +37,7 @@ echo *** Running NetXMS test suite from %BinDir% ***
 call :RunTest test-libnetxms || goto failure
 call :RunTest test-ai-checks || goto failure
 call :RunTest test-authtokens || goto failure
+call :RunTest test-physical-placement || goto failure
 call :RunTest test-libethernetip || goto failure
 call :RunTest test-libnxnetconf || goto failure
 call :RunTest test-libnxsnmp || goto failure

--- a/tests/suite/netxms-test-suite.in
+++ b/tests/suite/netxms-test-suite.in
@@ -32,6 +32,12 @@ if [ -x $BINDIR/test-authtokens ]; then
 	$BINDIR/test-authtokens || exit 1
 fi
 
+if [ -x $BINDIR/test-physical-placement ]; then
+	echo ""
+	echo "********** test-physical-placement **********"
+	$BINDIR/test-physical-placement || exit 1
+fi
+
 if [ -x $BINDIR/test-libethernetip ]; then
 	echo ""
 	echo "********** test-libethernetip **********"

--- a/tests/test-physical-placement/Makefile.am
+++ b/tests/test-physical-placement/Makefile.am
@@ -1,0 +1,30 @@
+# Copyright (C) 2004 NetXMS Team <bugs@netxms.org>
+#
+# This file is free software; as a special exception the author gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+bin_PROGRAMS = test-physical-placement
+test_physical_placement_SOURCES = test-physical-placement.cpp ../../src/server/core/physical_placement.cpp
+test_physical_placement_CPPFLAGS = -I@top_srcdir@/include -I@top_srcdir@/src/server/include -I../include -I@top_srcdir@/build -DNXCORE_EXPORTS @MICROHTTPD_CPPFLAGS@
+test_physical_placement_LDFLAGS = @EXEC_LDFLAGS@
+test_physical_placement_LDADD = \
+	@top_srcdir@/src/server/libnxsrv/libnxsrv.la \
+	@top_srcdir@/src/snmp/libnxsnmp/libnxsnmp.la \
+	@top_srcdir@/src/libnxsl/libnxsl.la \
+	@top_srcdir@/src/db/libnxdb/libnxdb.la \
+	@top_srcdir@/src/agent/libnxagent/libnxagent.la \
+	@top_srcdir@/src/libnetxms/libnetxms.la \
+	@EXEC_LIBS@
+
+if USE_INTERNAL_JANSSON
+test_physical_placement_LDADD += @top_srcdir@/src/jansson/libnxjansson.la
+else
+test_physical_placement_LDADD += -ljansson
+endif
+
+EXTRA_DIST = Makefile.w32

--- a/tests/test-physical-placement/Makefile.w32
+++ b/tests/test-physical-placement/Makefile.w32
@@ -1,0 +1,14 @@
+#
+# Makefile.w32 - test-physical-placement (physical placement property group unit tests)
+# Part of NetXMS project
+#
+
+TOOL = test-physical-placement
+SOURCES = test-physical-placement.cpp physical_placement.cpp
+# physical_placement.cpp includes nxcore.h, which pulls in <microhttpd.h>
+TOOL_CPPFLAGS = -I$(TOPDIR)/src/server/include -I$(TOPDIR)/tests/include -I$(MICROHTTPD_ROOT)/include -DNXCORE_EXPORTS
+TOOL_LIBS = -lnxsrv -lnxsnmp -lnxsl -lnxdb -lnxagent -lnetxms -lnxjansson
+
+vpath %.cpp $(TOPDIR)/src/server/core
+
+include $(TOPDIR)/build/tool-common.mk

--- a/tests/test-physical-placement/test-physical-placement.cpp
+++ b/tests/test-physical-placement/test-physical-placement.cpp
@@ -1,0 +1,444 @@
+/*
+** NetXMS - Network Management System
+** Copyright (C) 2026 Raden Solutions
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+**
+** File: test-physical-placement.cpp
+**
+** Unit tests for the "physicalPlacement" property group: serialization, merge-patch
+** parsing with strict type validation, rack extent geometry, and chassis placement XML
+** serialization. Compiles the real src/server/core/physical_placement.cpp.
+**
+**/
+
+#include <nms_common.h>
+#include <nms_util.h>
+#include <nxcpapi.h>
+#include <nms_core.h>
+#include <testtools.h>
+
+/**
+ * Stub for the server object index. Constructing a real Rack or Chassis would pull in the
+ * whole server, so container lookup always misses here: the tests cover every path except
+ * the three that need a live container object (rack extent, chassis class acceptance and
+ * the descendant loop check), and IsValidRackExtent is tested directly instead.
+ */
+shared_ptr<NetObj> NXCORE_EXPORTABLE FindObjectById(uint32_t id, int objectClassHint)
+{
+   return shared_ptr<NetObj>();
+}
+
+/**
+ * Placement state under test, together with the reference structure addressing it
+ */
+struct TestPlacement
+{
+   uint32_t containerId;
+   int16_t position;
+   int16_t height;
+   RackOrientation orientation;
+   uuid imageFront;
+   uuid imageRear;
+   PhysicalPlacementRef ref;
+
+   TestPlacement()
+   {
+      containerId = 0;
+      position = 0;
+      height = 1;
+      orientation = FILL;
+      imageFront = uuid::NULL_UUID;
+      imageRear = uuid::NULL_UUID;
+      ref.containerId = &containerId;
+      ref.position = &position;
+      ref.height = &height;
+      ref.orientation = &orientation;
+      ref.imageFront = &imageFront;
+      ref.imageRear = &imageRear;
+   }
+};
+
+/**
+ * Serialization must emit every key of the group
+ */
+static void TestPlacementToJson()
+{
+   StartTest(_T("Physical placement serialization"));
+
+   TestPlacement p;
+   p.containerId = 326;
+   p.position = 36;
+   p.height = 2;
+   p.orientation = REAR;
+   p.imageFront = uuid::parseA("fd21a79f-e8d4-4c28-bf07-81b5fce4a26a");
+
+   json_t *group = PhysicalPlacementToJson(p.ref);
+   AssertNotNull(group);
+   AssertEquals(json_object_get_uint32(group, "containerId"), static_cast<uint32_t>(326));
+   AssertEquals(json_object_get_int32(group, "position"), 36);
+   AssertEquals(json_object_get_int32(group, "height"), 2);
+   AssertEquals(json_object_get_int32(group, "orientation"), 2);
+   AssertEquals(json_object_get_string_utf8(group, "imageFront", ""), "fd21a79f-e8d4-4c28-bf07-81b5fce4a26a");
+   AssertEquals(json_object_get_string_utf8(group, "imageRear", ""), "00000000-0000-0000-0000-000000000000");
+   json_decref(group);
+
+   EndTest();
+}
+
+/**
+ * Rack extent geometry, both numbering directions
+ */
+static void TestRackExtent()
+{
+   StartTest(_T("Rack extent validation"));
+
+   // Top-bottom numbering: position is the device's topmost unit
+   AssertTrue(IsValidRackExtent(1, 1, 42, true));
+   AssertTrue(IsValidRackExtent(42, 1, 42, true));
+   AssertTrue(IsValidRackExtent(41, 2, 42, true));
+   AssertFalse(IsValidRackExtent(42, 2, 42, true));
+   AssertFalse(IsValidRackExtent(43, 1, 42, true));
+   AssertFalse(IsValidRackExtent(0, 1, 42, true));
+
+   // Bottom-top numbering: position is the device's bottommost unit
+   AssertTrue(IsValidRackExtent(1, 1, 42, false));
+   AssertTrue(IsValidRackExtent(42, 1, 42, false));
+   AssertTrue(IsValidRackExtent(2, 2, 42, false));
+   AssertFalse(IsValidRackExtent(1, 2, 42, false));
+   AssertFalse(IsValidRackExtent(43, 1, 42, false));
+   AssertFalse(IsValidRackExtent(0, 1, 42, false));
+
+   EndTest();
+}
+
+/**
+ * Parse a JSON document from a literal, asserting that it is well formed
+ */
+static json_t *ParseJson(const char *text)
+{
+   json_error_t error;
+   json_t *json = json_loads(text, 0, &error);
+   AssertNotNull(json);
+   return json;
+}
+
+/**
+ * Apply a patch document to given placement and return the result code
+ */
+static uint32_t ApplyPatch(TestPlacement *p, const char *text, bool allowChassisContainer = true)
+{
+   json_t *group = ParseJson(text);
+   // The placed object is only dereferenced after a container id resolves, which never happens
+   // with the FindObjectById stub above, so nullptr is safe here
+   uint32_t rcc = ModifyPhysicalPlacementFromJson(group, nullptr, p->ref, allowChassisContainer);
+   json_decref(group);
+   return rcc;
+}
+
+/**
+ * Keys present are applied, keys omitted are left untouched
+ */
+static void TestModifyMergeSemantics()
+{
+   StartTest(_T("Physical placement merge-patch semantics"));
+
+   TestPlacement p;
+   p.position = 12;
+   p.height = 3;
+   p.orientation = FRONT;
+
+   // Omitted keys must survive
+   AssertEquals(ApplyPatch(&p, "{\"position\":20}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertEquals(static_cast<int32_t>(p.position), 20);
+   AssertEquals(static_cast<int32_t>(p.height), 3);
+   AssertTrue(p.orientation == FRONT);
+
+   // Empty document is a no-op
+   AssertEquals(ApplyPatch(&p, "{}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertEquals(static_cast<int32_t>(p.position), 20);
+
+   // null containerId unracks
+   p.containerId = 326;
+   AssertEquals(ApplyPatch(&p, "{\"containerId\":null}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertEquals(p.containerId, static_cast<uint32_t>(0));
+
+   // Explicit zero unracks too
+   p.containerId = 326;
+   AssertEquals(ApplyPatch(&p, "{\"containerId\":0}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertEquals(p.containerId, static_cast<uint32_t>(0));
+
+   EndTest();
+}
+
+/**
+ * Wrong JSON types and out of range values are rejected
+ */
+static void TestModifyValidation()
+{
+   StartTest(_T("Physical placement validation"));
+
+   TestPlacement p;
+
+   AssertEquals(ApplyPatch(&p, "[]"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"position\":\"36\"}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"height\":true}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"containerId\":\"326\"}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"orientation\":\"front\"}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+
+   // Orientation range is exactly {0, 1, 2}
+   AssertEquals(ApplyPatch(&p, "{\"orientation\":3}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"orientation\":-1}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"orientation\":2}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertTrue(p.orientation == REAR);
+
+   // Height must be at least one rack unit
+   AssertEquals(ApplyPatch(&p, "{\"height\":0}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"height\":-2}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+
+   // null clears containerId and the images, but is not a value for the geometry scalars.
+   // Height and orientation reject it through their range and type checks; position needs an
+   // explicit one, since 0 means "never placed" rather than a rack unit.
+   p.position = 12;
+   AssertEquals(ApplyPatch(&p, "{\"position\":null}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(static_cast<int32_t>(p.position), 12);
+   AssertEquals(ApplyPatch(&p, "{\"height\":null}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(ApplyPatch(&p, "{\"orientation\":null}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+
+   EndTest();
+}
+
+/**
+ * Geometry is only validated when the document touches it, so an object whose stored
+ * position or height would fail the check stays patchable in other respects
+ */
+static void TestModifyGeometryScope()
+{
+   StartTest(_T("Physical placement geometry validation scope"));
+
+   TestPlacement p;
+   p.containerId = 326;
+   p.position = 0;
+   p.height = 0;
+
+   // Neither containerId, position nor height is present: the stored geometry is not looked at,
+   // and the unresolvable container id is not looked up either
+   AssertEquals(ApplyPatch(&p, "{\"imageFront\":\"fd21a79f-e8d4-4c28-bf07-81b5fce4a26a\"}"), static_cast<uint32_t>(RCC_SUCCESS));
+   char buffer[64];
+   AssertEquals(p.imageFront.toStringA(buffer), "fd21a79f-e8d4-4c28-bf07-81b5fce4a26a");
+   AssertEquals(static_cast<int32_t>(p.position), 0);
+   AssertEquals(static_cast<int32_t>(p.height), 0);
+
+   AssertEquals(ApplyPatch(&p, "{\"orientation\":1}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertTrue(p.orientation == FRONT);
+
+   AssertEquals(ApplyPatch(&p, "{}"), static_cast<uint32_t>(RCC_SUCCESS));
+
+   // As soon as the document touches geometry the stored height is validated again
+   AssertEquals(ApplyPatch(&p, "{\"position\":4}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertEquals(static_cast<int32_t>(p.position), 0);
+
+   EndTest();
+}
+
+/**
+ * A container id that does not resolve is rejected, and nothing is written
+ */
+static void TestModifyUnknownContainer()
+{
+   StartTest(_T("Physical placement with unresolvable container"));
+
+   TestPlacement p;
+   p.position = 12;
+   p.height = 3;
+
+   AssertEquals(ApplyPatch(&p, "{\"containerId\":9999,\"position\":36}"), static_cast<uint32_t>(RCC_INVALID_OBJECT_ID));
+
+   // Rejected patch must leave the placement exactly as it was
+   AssertEquals(p.containerId, static_cast<uint32_t>(0));
+   AssertEquals(static_cast<int32_t>(p.position), 12);
+   AssertEquals(static_cast<int32_t>(p.height), 3);
+
+   EndTest();
+}
+
+/**
+ * Image GUIDs: valid strings applied, null clears, malformed rejected
+ */
+static void TestModifyImages()
+{
+   StartTest(_T("Physical placement image GUIDs"));
+
+   TestPlacement p;
+
+   AssertEquals(ApplyPatch(&p, "{\"imageFront\":\"fd21a79f-e8d4-4c28-bf07-81b5fce4a26a\"}"), static_cast<uint32_t>(RCC_SUCCESS));
+   char buffer[64];
+   AssertEquals(p.imageFront.toStringA(buffer), "fd21a79f-e8d4-4c28-bf07-81b5fce4a26a");
+
+   AssertEquals(ApplyPatch(&p, "{\"imageFront\":null}"), static_cast<uint32_t>(RCC_SUCCESS));
+   AssertTrue(p.imageFront.isNull());
+
+   AssertEquals(ApplyPatch(&p, "{\"imageRear\":\"not-a-guid\"}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   AssertTrue(p.imageRear.isNull());
+
+   AssertEquals(ApplyPatch(&p, "{\"imageRear\":42}"), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+
+   EndTest();
+}
+
+/**
+ * Chassis placement XML must round-trip through the same parser Node::getChassisPlacement
+ * uses, and must keep the historical "oritentaiton" tag spelling that every client reads.
+ */
+static void TestChassisPlacementToXml()
+{
+   StartTest(_T("Chassis placement XML serialization"));
+
+   json_t *placement = ParseJson(
+      "{\"image\":\"00000000-0000-0000-0000-000000000001\","
+      "\"height\":1,\"heightUnits\":0,\"width\":10,\"widthUnits\":0,"
+      "\"positionHeight\":1,\"positionHeightUnits\":0,"
+      "\"positionWidth\":2,\"positionWidthUnits\":0,\"orientation\":1}");
+
+   char *xml = ChassisPlacementToXml(placement);
+   json_decref(placement);
+   AssertNotNull(xml);
+
+   // The misspelling is the contract, and the correct spelling must not appear
+   AssertNotNull(strstr(xml, "<oritentaiton>1</oritentaiton>"));
+   AssertNull(strstr(xml, "<orientation>"));
+
+   Config config;
+   AssertTrue(config.loadXmlConfigFromMemory(xml, strlen(xml), nullptr, "placement", false));
+   AssertEquals(config.getValueAsInt(L"/height", -1), 1);
+   AssertEquals(config.getValueAsInt(L"/width", -1), 10);
+   AssertEquals(config.getValueAsInt(L"/positionWidth", -1), 2);
+   AssertEquals(config.getValueAsInt(L"/positionHeight", -1), 1);
+   AssertEquals(config.getValueAsInt(L"/oritentaiton", -1), 1);
+   char buffer[64];
+   AssertEquals(config.getValueAsUUID(L"/image").toStringA(buffer), "00000000-0000-0000-0000-000000000001");
+
+   MemFree(xml);
+
+   // Missing members serialize as zero rather than being omitted, so the document always
+   // parses into a complete geometry
+   json_t *partial = ParseJson("{\"width\":4}");
+   xml = ChassisPlacementToXml(partial);
+   json_decref(partial);
+   AssertNotNull(xml);
+   Config defaults;
+   AssertTrue(defaults.loadXmlConfigFromMemory(xml, strlen(xml), nullptr, "placement", false));
+   AssertEquals(defaults.getValueAsInt(L"/width", -1), 4);
+   AssertEquals(defaults.getValueAsInt(L"/height", -1), 0);
+   AssertEquals(defaults.getValueAsInt(L"/oritentaiton", -1), 0);
+   MemFree(xml);
+
+   EndTest();
+}
+
+/**
+ * ValidateChassisPlacementJson must reject a non-integer geometry key or a non-string,
+ * non-null image before anything is written - ChassisPlacementToXml itself would silently
+ * coerce a bad value to zero instead of failing.
+ */
+static void TestValidateChassisPlacement()
+{
+   StartTest(_T("Chassis placement JSON validation"));
+
+   json_t *json = ParseJson(
+      "{\"image\":\"00000000-0000-0000-0000-000000000001\","
+      "\"height\":1,\"heightUnits\":0,\"width\":10,\"widthUnits\":0,"
+      "\"positionHeight\":1,\"positionHeightUnits\":0,"
+      "\"positionWidth\":2,\"positionWidthUnits\":0,\"orientation\":1}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_SUCCESS));
+   json_decref(json);
+
+   // Empty object: every key is a merge-patch omission, so nothing to reject
+   json = ParseJson("{}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_SUCCESS));
+   json_decref(json);
+
+   // A geometry key as a string coerces to 0 in json_object_get_int32 instead of failing -
+   // this is exactly the silent corruption the validator exists to catch
+   json = ParseJson("{\"height\":\"abc\"}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   json = ParseJson("{\"width\":true}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   json = ParseJson("{\"positionHeight\":1.5}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   json = ParseJson("{\"positionWidth\":[1,2]}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   json = ParseJson("{\"orientation\":{}}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   json = ParseJson("{\"heightUnits\":null}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   // image accepts a string or null, nothing else
+   json = ParseJson("{\"image\":\"00000000-0000-0000-0000-000000000001\"}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_SUCCESS));
+   json_decref(json);
+
+   json = ParseJson("{\"image\":null}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_SUCCESS));
+   json_decref(json);
+
+   json = ParseJson("{\"image\":42}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   // A string that is not a UUID would be coerced to the null UUID by json_object_get_uuid,
+   // silently wiping the stored image, so it has to be rejected here
+   json = ParseJson("{\"image\":\"not-a-guid\"}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_INVALID_ARGUMENT));
+   json_decref(json);
+
+   // Unknown keys are ignored, not rejected - matches the group's merge-patch semantics
+   json = ParseJson("{\"bogus\":\"whatever\",\"height\":5}");
+   AssertEquals(ValidateChassisPlacementJson(json), static_cast<uint32_t>(RCC_SUCCESS));
+   json_decref(json);
+
+   EndTest();
+}
+
+/**
+ * Entry point
+ */
+int main(int argc, char *argv[])
+{
+   InitNetXMSProcess(true);
+
+   TestPlacementToJson();
+   TestRackExtent();
+   TestModifyMergeSemantics();
+   TestModifyValidation();
+   TestModifyGeometryScope();
+   TestModifyUnknownContainer();
+   TestModifyImages();
+   TestChassisPlacementToXml();
+   TestValidateChassisPlacement();
+
+   return 0;
+}


### PR DESCRIPTION
Node and Chassis now expose a "physicalPlacement" group from toJson and accept it as a JSON merge-patch: properties present are applied, properties omitted are left untouched, and null clears. Setting containerId to null or 0 removes the object from its container. A node can be placed in a rack or in a chassis, a chassis only in a rack. The group is always emitted, with containerId 0 for an object that is not placed anywhere, so a client never has to tell "absent" from "unplaced". All existing flat keys (rackPosition, rackHeight, rackOrientation, physicalContainerId, rackId, rackImageFront, rackImageRear, chassisPlacementConfig) are unchanged.

The group is served by new PATCH /v1/objects/{object-id}/physical-placement, which requires modify access on the placed object only, matching the NXCP path, and is rejected with 400 for a wrong JSON value type, height below 1, orientation outside 0-2, an extent falling outside the rack, a containerId that does not resolve or is of the wrong class, and a target object that is neither node nor chassis. The same group is also accepted as a property of PATCH /v1/objects/{object-id}. Validation is all-or-nothing within the group: a rejected document leaves placement untouched. Stricter validation applies to the JSON path only - the NXCP path keeps its current leniency, where an unresolvable container id is logged and dropped. Overlapping placements remain allowed.

The shared read and write halves live in new src/server/core/physical_placement.cpp and are described by pointers to the owner's members, since Node and Chassis hold the same six properties under different member names with no common base holding them. Chassis geometry for a node is merge-patched against the current geometry and re-serialized into the <placement> document, preserving the historical "oritentaiton" tag spelling that both Node::getChassisPlacement and ChassisPlacement.java parse.

Covered by new unit test tests/test-physical-placement. OpenAPI spec gains the PhysicalPlacement schema, the new path, and the group on both ObjectDetails and the object patch request schema.